### PR TITLE
fix(rpc)+feat(mantle): admin RPC id format fixes & Arsia mainnet timestamp

### DIFF
--- a/crates/mantle-hardforks/src/lib.rs
+++ b/crates/mantle-hardforks/src/lib.rs
@@ -65,6 +65,9 @@ pub const MANTLE_MAINNET_SKADI_TIMESTAMP: u64 = 1_756_278_000; // Wed Aug 27 202
 /// Limb upgrade timestamp for Mantle mainnet
 pub const MANTLE_MAINNET_LIMB_TIMESTAMP: u64 = 1_768_374_000; // Wed Jan 14 2026 15:00:00 GMT+0800
 
+/// Arsia upgrade timestamp for Mantle mainnet
+pub const MANTLE_MAINNET_ARSIA_TIMESTAMP: u64 = 1_776_841_200; // Wed Apr 22 2026 15:00:00 GMT+0800
+
 /// Skadi upgrade timestamp for Mantle Sepolia testnet
 pub const MANTLE_SEPOLIA_SKADI_TIMESTAMP: u64 = 1_752_649_200; // Wed Jul 16 2025 15:00:00 GMT+0800
 
@@ -117,7 +120,10 @@ impl MantleHardfork {
                 if timestamp < MANTLE_MAINNET_LIMB_TIMESTAMP {
                     return Some(Self::Skadi);
                 }
-                Some(Self::Limb)
+                if timestamp < MANTLE_MAINNET_ARSIA_TIMESTAMP {
+                    return Some(Self::Limb);
+                }
+                Some(Self::Arsia)
             }
             NamedChain::MantleSepolia => {
                 if timestamp < MANTLE_SEPOLIA_SKADI_TIMESTAMP {
@@ -140,6 +146,7 @@ impl MantleHardfork {
         vec![
             (Self::Skadi, ForkCondition::Timestamp(MANTLE_MAINNET_SKADI_TIMESTAMP)),
             (Self::Limb, ForkCondition::Timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP)),
+            (Self::Arsia, ForkCondition::Timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP)),
         ]
     }
 
@@ -363,6 +370,10 @@ mod tests {
             mantle_mainnet_forks[Limb],
             ForkCondition::Timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP)
         );
+        assert_eq!(
+            mantle_mainnet_forks[Arsia],
+            ForkCondition::Timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP)
+        );
     }
 
     #[test]
@@ -461,6 +472,29 @@ mod tests {
                 MANTLE_MAINNET_LIMB_TIMESTAMP - 1
             ),
             Some(MantleHardfork::Skadi)
+        );
+    }
+
+    #[test]
+    fn test_reverse_lookup_mainnet_arsia_hardfork() {
+        let mantle_mainnet_chain = Chain::from_id(MANTLE_MAINNET_CHAIN_ID);
+
+        // Arsia should be active at its timestamp
+        assert_eq!(
+            MantleHardfork::from_chain_and_timestamp(
+                mantle_mainnet_chain,
+                MANTLE_MAINNET_ARSIA_TIMESTAMP
+            ),
+            Some(MantleHardfork::Arsia)
+        );
+
+        // One second before Arsia: still Limb
+        assert_eq!(
+            MantleHardfork::from_chain_and_timestamp(
+                mantle_mainnet_chain,
+                MANTLE_MAINNET_ARSIA_TIMESTAMP - 1
+            ),
+            Some(MantleHardfork::Limb)
         );
     }
 

--- a/crates/optimism/chainspec/src/mantle_mainnet.rs
+++ b/crates/optimism/chainspec/src/mantle_mainnet.rs
@@ -219,12 +219,17 @@ mod tests {
         // Verify that Osaka is mapped to Limb timestamp
         assert!(spec.is_osaka_active_at_timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP));
 
-        // Verify OP-layer forks are all aligned to Arsia timestamp
+        // Verify all 7 OP-layer forks are aligned to Arsia timestamp
         assert!(spec.is_canyon_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
         assert!(spec.is_ecotone_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+        assert!(spec.is_fjord_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+        assert!(spec.is_granite_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
         assert!(spec.is_holocene_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+        assert!(spec.is_isthmus_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
         assert!(spec.is_jovian_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
         assert!(!spec.is_canyon_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP - 1));
+        assert!(!spec.is_holocene_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP - 1));
+        assert!(!spec.is_jovian_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP - 1));
     }
 
     #[test]

--- a/crates/optimism/chainspec/src/mantle_mainnet.rs
+++ b/crates/optimism/chainspec/src/mantle_mainnet.rs
@@ -5,7 +5,9 @@ use crate::{
     LazyLock, OpChainSpec,
 };
 use alloc::sync::Arc;
-use reth_mantle_forks::{MANTLE_MAINNET_LIMB_TIMESTAMP, MANTLE_MAINNET_SKADI_TIMESTAMP};
+use reth_mantle_forks::{
+    MANTLE_MAINNET_ARSIA_TIMESTAMP, MANTLE_MAINNET_LIMB_TIMESTAMP, MANTLE_MAINNET_SKADI_TIMESTAMP,
+};
 use reth_primitives_traits::SealedHeader;
 
 /// Mantle Mainnet genesis hash
@@ -151,7 +153,7 @@ fn create_mantle_mainnet_genesis() -> alloy_genesis::Genesis {
         MantleGenesisInfo {
             mantle_skadi_time: Some(MANTLE_MAINNET_SKADI_TIMESTAMP),
             mantle_limb_time: Some(MANTLE_MAINNET_LIMB_TIMESTAMP),
-            mantle_arsia_time: None,
+            mantle_arsia_time: Some(MANTLE_MAINNET_ARSIA_TIMESTAMP),
         },
     );
 
@@ -165,6 +167,7 @@ mod tests {
     use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, EthereumHardforks};
     use reth_ethereum_forks::EthereumHardfork;
     use reth_mantle_forks::{MantleHardfork, MantleHardforks};
+    use reth_optimism_forks::{OpHardfork, OpHardforks};
 
     #[test]
     fn verify_mantle_mainnet_chain_id() {
@@ -194,6 +197,17 @@ mod tests {
     }
 
     #[test]
+    fn verify_arsia_is_configured() {
+        let spec = MANTLE_MAINNET.clone();
+
+        // Arsia should be active at the hardcoded timestamp
+        assert!(spec.is_arsia_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+
+        // Arsia should not be active before the timestamp
+        assert!(!spec.is_arsia_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP - 1));
+    }
+
+    #[test]
     fn verify_hardfork_timestamps() {
         let spec = MANTLE_MAINNET.clone();
 
@@ -204,6 +218,13 @@ mod tests {
 
         // Verify that Osaka is mapped to Limb timestamp
         assert!(spec.is_osaka_active_at_timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP));
+
+        // Verify OP-layer forks are all aligned to Arsia timestamp
+        assert!(spec.is_canyon_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+        assert!(spec.is_ecotone_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+        assert!(spec.is_holocene_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+        assert!(spec.is_jovian_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP));
+        assert!(!spec.is_canyon_active_at_timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP - 1));
     }
 
     #[test]
@@ -230,5 +251,7 @@ mod tests {
         assert_eq!(builtin.fork(MantleHardfork::Skadi), expected.fork(MantleHardfork::Skadi));
         assert_eq!(builtin.fork(MantleHardfork::Limb), expected.fork(MantleHardfork::Limb));
         assert_eq!(builtin.fork(MantleHardfork::Arsia), expected.fork(MantleHardfork::Arsia));
+        assert_eq!(builtin.fork(OpHardfork::Holocene), expected.fork(OpHardfork::Holocene));
+        assert_eq!(builtin.fork(OpHardfork::Jovian), expected.fork(OpHardfork::Jovian));
     }
 }

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition};
 use reth_network_api::{NetworkInfo, Peers};
-use reth_network_peers::{id2pk, AnyNode, NodeRecord};
+use reth_network_peers::{AnyNode, NodeRecord};
 use reth_network_types::PeerKind;
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_server_types::ToRpcResult;
@@ -155,9 +155,7 @@ where
         ]);
 
         Ok(NodeInfo {
-            id: id2pk(enode.id)
-                .map(|pk| pk.to_string())
-                .unwrap_or_else(|_| alloy_primitives::hex::encode(enode.id.as_slice())),
+            id: alloy_primitives::hex::encode(keccak256(enode.id.as_slice())),
             name: status.client_version,
             enode: enode.to_string(),
             enr: self.network.local_enr().to_string(),

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -76,7 +76,7 @@ where
 
         for peer in peers {
             infos.push(PeerInfo {
-                id: keccak256(peer.remote_id.as_slice()).to_string(),
+                id: alloy_primitives::hex::encode(keccak256(peer.remote_id.as_slice())),
                 name: peer.client_version.to_string(),
                 enode: peer.enode,
                 enr: peer.enr,


### PR DESCRIPTION
## Summary

This PR contains two independent fixes:

### 1. Admin RPC `id` field format fixes (ported from upstream)

#### fix(rpc): Remove `0x` prefix from `admin_peers[].id` (ports paradigmxyz/reth#23318)

- **Root cause**: `keccak256(...).to_string()` calls `B256::Display`, which always prepends `0x` via `alloy-primitives` `fmt_hex`, producing a 66-char prefixed string
- **Fix**: Replace with `alloy_primitives::hex::encode(keccak256(...))` to produce a bare 64-char hex string matching go-ethereum's output

#### fix(rpc): `admin_nodeInfo.id` returns correct keccak256 node ID (ports paradigmxyz/reth#23319)

- **Root cause**: `id2pk(enode.id).map(|pk| pk.to_string())` returns a secp256k1 **compressed public key** (33 bytes, `02`/`03` prefix) — entirely the wrong format
- **Fix**: `enode.id` is `PeerId` (`B512`, 64 raw bytes of X∥Y), so `keccak256(enode.id.as_slice())` directly produces the go-ethereum-compatible node ID. Also removes the now-unused `id2pk` import.

### 2. Mantle mainnet Arsia hardfork timestamp

- **Root cause**: `mantle_arsia_time` was `None`, leaving Canyon/Ecotone and 5 other OP-layer forks unactivated on mainnet
- **Fix**: Add `MANTLE_MAINNET_ARSIA_TIMESTAMP = 1_776_841_200`, matching op-geth `params/mantle.go` (`MantleArsiaTime: u64Ptr(1_776_841_200)`). Per the Mantle alignment logic, this simultaneously activates Canyon/Ecotone/Fjord/Granite/Holocene/Isthmus/Jovian at the Arsia timestamp.

## Files Changed

| File | Change |
|---|---|
| `crates/rpc/rpc/src/admin.rs` | Two `id` format fixes; remove unused `id2pk` import |
| `crates/mantle-hardforks/src/lib.rs` | Add `MANTLE_MAINNET_ARSIA_TIMESTAMP` constant, fork list entry, reverse-lookup logic, and tests |
| `crates/optimism/chainspec/src/mantle_mainnet.rs` | Enable Arsia timestamp; add `verify_arsia_is_configured` test and OP-fork alignment assertions |

## Test Plan

- [x] `cargo check -p reth-rpc --all-features` — no errors
- [x] `cargo nextest run -p reth-mantle-forks -p reth-optimism-chainspec` — 49/49 PASS
- [x] New tests: `verify_arsia_is_configured`, `test_reverse_lookup_mainnet_arsia_hardfork`, OP fork alignment assertions in `verify_hardfork_timestamps`, `OpHardfork::Holocene/Jovian` consistency assertions in `verify_builtin_matches_genesis_conversion_semantics`
- [x] Reviewer: confirm `admin_peers[].id` and `admin_nodeInfo.id` format matches go-ethereum
- [x] Reviewer: confirm timestamp `1_776_841_200` matches mainnet op-geth configuration