### PR TITLE
fix(txpool): add accept arm for known tx types in match guard

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -15,3 +15,9 @@ doc-valid-idents = [
     "MessagePack",
 ]
 allow-dbg-in-tests = true
+# SAFETY: Do NOT enable collapsible_match. This lint converts if-inside-match
+# into match guards, which silently changes semantics: when a guard fails, Rust
+# falls through to the next arm instead of staying in the matched arm. This
+# caused a P0 bug (PR #31) where EIP-1559 transactions were rejected because
+# the guard `!self.eip1559` failed and fell through to a catch-all reject arm.
+allow-collapsible-match = false

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -257,9 +257,6 @@ where
     ) -> Result<Tx, TransactionValidationOutcome<Tx>> {
         // Checks for tx_type
         match transaction.ty() {
-            LEGACY_TX_TYPE_ID => {
-                // Accept legacy transactions
-            }
             // Accept only legacy transactions until EIP-2718/2930 activates
             EIP2930_TX_TYPE_ID if !self.eip2718 => {
                 return Err(TransactionValidationOutcome::Invalid(
@@ -288,6 +285,9 @@ where
                     InvalidTransactionError::Eip7702Disabled.into(),
                 ))
             }
+            // Accept known transaction types when their respective fork is active
+            LEGACY_TX_TYPE_ID | EIP2930_TX_TYPE_ID | EIP1559_TX_TYPE_ID | EIP4844_TX_TYPE_ID |
+            EIP7702_TX_TYPE_ID => {}
 
             ty if !self.other_tx_types.bit(ty as usize) => {
                 return Err(TransactionValidationOutcome::Invalid(


### PR DESCRIPTION
## Summary

- **Fix EIP-1559 (type 2) transactions being incorrectly rejected as "transaction type not supported"** in the transaction pool validator.
- Clippy's `collapsible_match` refactoring (`f0b9cf0b`) converted `if`-inside-`match` to match guards, but didn't account for Rust's guard fall-through semantics. When `eip1559=true`, the guard `!self.eip1559` evaluates to `false`, causing type 2 txs to fall through to the `other_tx_types` catch-all arm and be rejected.
- Adds an explicit accept arm for all known tx types (`LEGACY | EIP2930 | EIP1559 | EIP4844 | EIP7702`) after the rejection guards, so they are accepted when their respective fork is active. This aligns with upstream paradigmxyz/reth commit `3ac5637bd1` (PR #22594).

## Changes

- `crates/transaction-pool/src/validate/eth.rs`: Removed standalone `LEGACY_TX_TYPE_ID` accept arm and added a combined accept arm for all known tx types after the fork-gated rejection guards.

## Test plan

- [x] Release binary built successfully with the fix
- [x] Verify EIP-1559 (type 2) transactions are accepted when `eip1559` fork is active
- [x] Verify legacy, EIP-2930, EIP-4844, and EIP-7702 transactions continue to work correctly
- [x] Verify transactions are still correctly rejected when their fork is not yet active
- [x] Verify unknown/custom transaction types still route through `other_tx_types` check