### PR TITLE
fix(arsia): BVM_ETH cold reset for deposit mint (pin to arsia.1 tags)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.25.2"
-source = "git+https://github.com/mantle-xyz/evm?branch=fix%2Fop-revm-bvm-eth-cold-reset#996e6625a62b5004dfe9cfb156b621a4a96ae8bd"
+source = "git+https://github.com/mantle-xyz/evm?tag=v0.25.2-mantle-arsia.1#93126ead860af9d73ba032fef11fa88845f8623d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.25.2"
-source = "git+https://github.com/mantle-xyz/evm?branch=fix%2Fop-revm-bvm-eth-cold-reset#996e6625a62b5004dfe9cfb156b621a4a96ae8bd"
+source = "git+https://github.com/mantle-xyz/evm?tag=v0.25.2-mantle-arsia.1#93126ead860af9d73ba032fef11fa88845f8623d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "31.0.2"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "7.1.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "bitvec",
  "phf",
@@ -11067,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "11.0.2"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11083,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "12.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "9.0.5"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11111,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "8.0.5"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "auto_impl",
  "either",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "auto_impl",
  "either",
@@ -11158,7 +11158,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.32.0"
-source = "git+https://github.com/mantle-xyz/revm-inspectors?branch=fix%2Fop-revm-bvm-eth-cold-reset#06564ed9afed72bf8087e3aab0e5eeae30cf1167"
+source = "git+https://github.com/mantle-xyz/revm-inspectors?tag=v0.32.0-mantle-arsia.1#19313af33f9d424dc0a6cad6b809713128a817a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11175,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "29.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "29.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "21.0.2"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11222,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "8.1.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.25.2"
-source = "git+https://github.com/mantle-xyz/evm?tag=v2.2.1#ea9e2a8670749fb8d21131c630381cb0b9354d1d"
+source = "git+https://github.com/mantle-xyz/evm?branch=fix%2Fop-revm-bvm-eth-cold-reset#996e6625a62b5004dfe9cfb156b621a4a96ae8bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.25.2"
-source = "git+https://github.com/mantle-xyz/evm?tag=v2.2.1#ea9e2a8670749fb8d21131c630381cb0b9354d1d"
+source = "git+https://github.com/mantle-xyz/evm?branch=fix%2Fop-revm-bvm-eth-cold-reset#996e6625a62b5004dfe9cfb156b621a4a96ae8bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3059,7 +3059,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3389,7 +3389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4723,7 +4723,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -4741,7 +4741,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5075,7 +5075,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5984,7 +5984,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",
@@ -6970,7 +6970,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -7007,9 +7007,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "31.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "7.1.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "bitvec",
  "phf",
@@ -11067,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "11.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11083,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "12.0.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "9.0.5"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11111,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "8.0.5"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "auto_impl",
  "either",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "auto_impl",
  "either",
@@ -11158,7 +11158,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.32.0"
-source = "git+https://github.com/mantle-xyz/revm-inspectors?tag=v2.2.1#c8f693bc1e8857f6b73c9d77e18329815d4fc174"
+source = "git+https://github.com/mantle-xyz/revm-inspectors?branch=fix%2Fop-revm-bvm-eth-cold-reset#06564ed9afed72bf8087e3aab0e5eeae30cf1167"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11175,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "29.0.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "29.0.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "21.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11222,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "8.1.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v2.2.2#56aee9a66dd9a9c1efde58f3d411bc133a0771a0"
+source = "git+https://github.com/mantle-xyz/revm?branch=fix%2Fop-revm-bvm-eth-deposit-cold-reset#4c215fbc11b2be0114997486e852fa5769a52284"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -11470,7 +11470,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11483,7 +11483,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11541,7 +11541,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12374,7 +12374,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,25 +481,25 @@ reth-ress-provider = { path = "crates/ress/provider" }
 # revm-database-interface = { version = "8.0.5", default-features = false }
 # op-revm = { version = "12.0.2", default-features = false }
 # revm-inspectors = "0.32.0"
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-state = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-context = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-database = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v2.2.2", default-features = false }
-revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", tag = "v2.2.1", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-state = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-context = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-database = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
+revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "fix/op-revm-bvm-eth-cold-reset", default-features = false }
 
 # eth
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 # alloy-evm = { version = "0.23.0", default-features = false }
-alloy-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v2.2.1", default-features = false }
+alloy-evm = { git = "https://github.com/mantle-xyz/evm", branch = "fix/op-revm-bvm-eth-cold-reset", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-macro = "1.4.1"
@@ -537,7 +537,7 @@ alloy-transport-ipc = { version = "1.4.3", default-features = false }
 alloy-transport-ws = { version = "1.4.3", default-features = false }
 
 # op
-alloy-op-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v2.2.1", default-features = false }
+alloy-op-evm = { git = "https://github.com/mantle-xyz/evm", branch = "fix/op-revm-bvm-eth-cold-reset", default-features = false }
 alloy-op-hardforks = "0.4.4"
 op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", default-features = false }
 op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,25 +481,25 @@ reth-ress-provider = { path = "crates/ress/provider" }
 # revm-database-interface = { version = "8.0.5", default-features = false }
 # op-revm = { version = "12.0.2", default-features = false }
 # revm-inspectors = "0.32.0"
-revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-state = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-context = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-database = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "fix/op-revm-bvm-eth-deposit-cold-reset", default-features = false }
-revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "fix/op-revm-bvm-eth-cold-reset", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-state = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-context = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-database = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
+revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", tag = "v0.32.0-mantle-arsia.1", default-features = false }
 
 # eth
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 # alloy-evm = { version = "0.23.0", default-features = false }
-alloy-evm = { git = "https://github.com/mantle-xyz/evm", branch = "fix/op-revm-bvm-eth-cold-reset", default-features = false }
+alloy-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v0.25.2-mantle-arsia.1", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-macro = "1.4.1"
@@ -537,7 +537,7 @@ alloy-transport-ipc = { version = "1.4.3", default-features = false }
 alloy-transport-ws = { version = "1.4.3", default-features = false }
 
 # op
-alloy-op-evm = { git = "https://github.com/mantle-xyz/evm", branch = "fix/op-revm-bvm-eth-cold-reset", default-features = false }
+alloy-op-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v0.25.2-mantle-arsia.1", default-features = false }
 alloy-op-hardforks = "0.4.4"
 op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", default-features = false }
 op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", default-features = false }


### PR DESCRIPTION
## What

Fixes the hoodi-qa2 block 59294 geth/reth consensus fork by resetting BVM_ETH (account + touched storage slots) back to EIP-2929 cold after deposit mint/transfer, matching op-geth. Removes the static `BVM_ETH_MINT_GAS_COMPENSATION` (4500) hack.

## Dependency pins (Arsia release tags)

| fork | tag |
|---|---|
| mantle-xyz/revm (+op-revm) | `v98-mantle-arsia.1` |
| mantle-xyz/revm-inspectors | `v0.32.0-mantle-arsia.1` |
| mantle-xyz/evm (alloy-evm/op-evm) | `v0.25.2-mantle-arsia.1` |

revm change: PR mantle-xyz/revm#27 (121 op-revm tests green, deposit gas tests run under ARSIA spec).

## Validation
- `cargo check -p op-reth`: green
- Cargo.lock pins all three forks at the immutable tags

After merge → tag `v1.9.3-mantle-arsia.2` → ECR image build → deploy to hoodi-qa2 + chain consistency regression.