### PR TITLE
ci(cross): pin glibc 2.39 image for linux-gnu release targets

### DIFF
--- a/op-reth/Cross.toml
+++ b/op-reth/Cross.toml
@@ -15,6 +15,31 @@ pre-build = [
     "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-dev clang",
 ]
 
+[target.x86_64-unknown-linux-gnu]
+# Pin a glibc 2.39 base image (Ubuntu 24.04) for the native Linux target.
+# cross's default x86_64-unknown-linux-gnu image ships an older glibc; build
+# scripts compiled against the host's glibc 2.39 then fail at runtime with
+# `version GLIBC_2.39 not found`. Ubuntu 24.04 provides glibc 2.39, matching
+# the toolchain used by the release runners. Mirrors the riscv64 entry below.
+#
+# NOTE: a target-level pre-build OVERRIDES the global [build] pre-build, so the
+# HTTPS/retry setup and rust-bindgen deps are repeated here, plus the native
+# C/C++ toolchain that the bare ubuntu image lacks.
+image = "ubuntu:24.04"
+pre-build = [
+    # Use HTTPS for package sources
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates",
+    "find /etc/apt/ -type f \\( -name '*.list' -o -name '*.sources' \\) -exec sed -i 's|http://|https://|g' {} +",
+
+    # Configure APT retries and timeouts to handle network issues
+    "echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::http::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::ftp::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+
+    # Native build toolchain (bare ubuntu image has none) + rust-bindgen deps
+    "apt-get update && apt-get install --assume-yes --no-install-recommends gcc g++ make pkg-config llvm-dev libclang-dev clang",
+]
+
 [target.x86_64-pc-windows-gnu]
 # Why do we need a custom Dockerfile on Windows:
 # 1. `reth-libmdbx` stopped working with MinGW 9.3 that cross image comes with.

--- a/op-reth/Cross.toml
+++ b/op-reth/Cross.toml
@@ -40,6 +40,37 @@ pre-build = [
     "apt-get update && apt-get install --assume-yes --no-install-recommends gcc g++ make pkg-config llvm-dev libclang-dev clang",
 ]
 
+[target.aarch64-unknown-linux-gnu]
+# Same glibc 2.39 pin as x86_64 above. aarch64 is a cross-compile: the build
+# scripts run on the x86_64 build host (inside this container), so the
+# container's glibc — not the target's — is what must satisfy the
+# `GLIBC_2.39 not found` requirement. Ubuntu 24.04 provides it.
+#
+# A target-level pre-build OVERRIDES the global [build] pre-build, so the
+# HTTPS/retry setup and rust-bindgen deps are repeated here, plus the native
+# host toolchain AND the aarch64 cross toolchain that the bare ubuntu image
+# lacks. CC/CXX/LINKER are pinned so the cc crate compiles target C deps
+# (e.g. reth-libmdbx) with the aarch64 cross compiler.
+image = "ubuntu:24.04"
+pre-build = [
+    # Use HTTPS for package sources
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates",
+    "find /etc/apt/ -type f \\( -name '*.list' -o -name '*.sources' \\) -exec sed -i 's|http://|https://|g' {} +",
+
+    # Configure APT retries and timeouts to handle network issues
+    "echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::http::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::ftp::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+
+    # Native host toolchain + rust-bindgen deps + aarch64 cross toolchain
+    "apt-get update && apt-get install --assume-yes --no-install-recommends gcc g++ make pkg-config llvm-dev libclang-dev clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu",
+]
+env.passthrough = [
+    "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc",
+    "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc",
+    "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++",
+]
+
 [target.x86_64-pc-windows-gnu]
 # Why do we need a custom Dockerfile on Windows:
 # 1. `reth-libmdbx` stopped working with MinGW 9.3 that cross image comes with.


### PR DESCRIPTION
## Background

The `mantle-release` workflow fails during the build stage (run [26872674713](https://github.com/mantle-xyz/reth/actions/runs/26872674713), tag `v1.9.3-mantle-arsia.2`). **Both the x86_64 and aarch64 targets fail** with the same error:

```
/target/maxperf/build/libc-*/build-script-build: /lib/x86_64-linux-gnu/libc.so.6:
  version `GLIBC_2.32' / `GLIBC_2.33' / `GLIBC_2.34' / `GLIBC_2.39' not found
```

Root cause: cross's default linux-gnu build images ship an older glibc, while the build-script binaries (libc / serde / serde_core, including artifacts restored by rust-cache) require glibc up to 2.39 and fail to run. This is build-infra drift, not a code bug — the same config passed on `arsia.1` (5/12) and reproduces the failure on `arsia.2` (6/3).

## Changes

`op-reth/Cross.toml` adds one section per release-matrix target, pinning both to a glibc 2.39 image, mirroring the in-repo `riscv64gc` `ubuntu:24.04` pattern:

- `[target.x86_64-unknown-linux-gnu]`: native build — `ubuntu:24.04` + native `gcc g++ make pkg-config` + rust-bindgen deps.
- `[target.aarch64-unknown-linux-gnu]`: cross build (build scripts run on the x86_64 host inside the container, so the container glibc must also be 2.39). Additionally installs `gcc-aarch64-linux-gnu g++-aarch64-linux-gnu` and pins `CC/CXX/LINKER` so the cc crate builds the aarch64 C deps (reth-libmdbx) correctly.

> In cross, a target-level `pre-build` OVERRIDES the global `[build] pre-build`, so the HTTPS source / retry / bindgen deps are repeated in both sections.

## Verification

- [x] Parses cleanly with `tomllib`; all four targets present.
- [ ] **Pending**: `mantle-release` (must be triggered against a `v*` tag containing this fix) confirming both build jobs pass — the only authoritative check.

## Non-goals

- No business logic / EVM semantics changes.
- No justfile changes (`build-op` alias is in #44).