### PR TITLE
build(justfile): add backward-compatible build-op alias

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,6 +26,9 @@ default:
 build:
   cargo build -p mantle-reth-cli --bin op-reth --features "{{FEATURES}}" --profile "{{PROFILE}}"
 
+# Alias: backward-compatible with old Makefile `make build-op`
+build-op: build
+
 # Build op-reth binary (debug, with Mantle state-export feature)
 build-debug:
   cargo build -p mantle-reth-cli --bin op-reth --features "{{MANTLE_DEBUG_FEATURES}}"


### PR DESCRIPTION
## Changes

Adds a `build-op: build` alias to the `justfile`, restoring the `build-op` entry point that the old Makefile / Taskfile exposed, so `just build-op` works alongside `just build`.

One file, +3 lines, no logic change.

## Note

Unrelated to the CI GLIBC failure (that fix lives in #43). This PR is purely an entry-point compatibility shim for scripts/docs that still use `make build-op`.