### PR TITLE
chore(deps): migrate alloy-evm to upstream crates.io 0.34.0 (retire mantle-xyz/evm fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,8 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.34.0"
-source = "git+https://github.com/mantle-xyz/evm?branch=mantle-v0.34.0#b91d0077aae4181c74f98405453304c477ddaa43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -406,7 +407,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -423,7 +424,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.5.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -3550,8 +3551,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4061,7 +4062,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5762,7 +5763,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "op-alloy"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -5774,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5804,7 +5805,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5817,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5831,7 +5832,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -5840,7 +5841,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5861,7 +5862,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#465207a6831a22a291e974858eea95cd7c6aa120"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@
 #   reth crates    → paradigmxyz/reth rev 88505c7f (= v2.2.0, same as upstream op-reth pins)
 #   revm/op-revm   → mantle-xyz/revm branch mantle-elysium (Mantle fee model patches)
 #   revm-inspectors → mantle-xyz/revm-inspectors branch mantle-elysium
-#   alloy-evm      → mantle-xyz/evm branch mantle-v0.34.0 (Mantle token_ratio trait method)
+#   alloy-evm      → crates.io 0.34.0 (upstream, no Mantle patches; see mantle-v2#359)
 #   alloy-op-evm   → mantle-xyz/mantle-v2 branch mantle-elysium
 #   alloy-op-hardforks → mantle-xyz/mantle-v2 branch mantle-elysium
 #   op-alloy       → mantle-xyz/mantle-v2 branch mantle-elysium
@@ -232,8 +232,8 @@ revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = 
 # TODO: Switch to tag once mantle-elysium is tagged
 revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "mantle-elysium" }
 
-# ==================== ALLOY-EVM (Mantle fork: mantle-xyz/evm, has token_ratio trait method) ====================
-alloy-evm = { git = "https://github.com/mantle-xyz/evm", branch = "mantle-v0.34.0", default-features = false }
+# ==================== ALLOY-EVM (upstream crates.io, no Mantle patches; see mantle-v2#359) ====================
+alloy-evm = { version = "0.34.0", default-features = false }
 
 # ==================== ALLOY-OP-EVM / ALLOY-OP-HARDFORKS (Mantle: mantle-xyz/mantle-v2) ====================
 # TODO: Switch to tag once mantle-v2 Rust crates are tagged
@@ -423,8 +423,6 @@ revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = 
 revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "mantle-elysium" }
 # op-revm: mantle-xyz/revm (same as workspace dep)
 op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-# alloy-evm: mantle-xyz/evm (Mantle version with token_ratio trait method)
-alloy-evm = { git = "https://github.com/mantle-xyz/evm", branch = "mantle-v0.34.0" }
 # alloy-op-evm / alloy-op-hardforks: mantle-xyz/mantle-v2 (Mantle version)
 alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }


### PR DESCRIPTION
## Summary

Follow-up to **mantle-xyz/mantle-v2#359** ("rust: remove op-reth subtree; alloy-evm → upstream alloy-rs/evm").

That PR removed the dead `token_ratio` trait method stub from `alloy-op-evm` on the `mantle-elysium` branch. The `token_ratio` method was the **only** customization in the `mantle-xyz/evm` fork (declared as a required trait method on `alloy-evm`'s `Evm` trait, with no call sites in this workspace). With the stub gone on the op-evm side, keeping the fork would break the build, so this PR retires the fork and switches `alloy-evm` to pristine upstream.

The real token_ratio value path is **untouched**: it is read by op-revm `L1BlockInfo::try_fetch` from the gas oracle contract slot, never through the `Evm` trait method.

## Changes

- `alloy-evm`: `mantle-xyz/evm@mantle-v0.34.0` → crates.io `0.34.0`
- Drop the `alloy-evm` redirect from `[patch.crates-io]`
- Bump `alloy-op-evm` / `op-alloy*` git deps to `mantle-elysium` HEAD (includes #359): `465207a6` → `c06cb723`

Net diff: `Cargo.toml` (3 hunks) + `Cargo.lock` (re-resolution). No source code changes — there are no `Evm::token_ratio()` call sites in this tree.

## Verification

Local `just pr` (`cargo +nightly fmt --all`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo test --workspace --all-features`, doc-tests): **all green, 0 failures**.

Note: `token_ratio_midblock*` integration tests remain `#[ignore]` as they already were on `mantle-elysium` (they require a separate op-revm fix); this PR does not change their state.