### PR TITLE
build: include branch name in version string for non-tag builds

### DIFF
--- a/mantle-reth/crates/cli/build.rs
+++ b/mantle-reth/crates/cli/build.rs
@@ -5,6 +5,7 @@ use std::{env, path::MAIN_SEPARATOR, process::Command};
 fn main() {
     println!("cargo:rerun-if-changed=../../.git/HEAD");
     println!("cargo:rerun-if-changed=../../.git/refs/tags/");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads/");
 
     let sha_short = run_git(&["rev-parse", "--short=8", "HEAD"]).unwrap_or_default();
     println!("cargo:rustc-env=MANTLE_GIT_SHA_SHORT={sha_short}");
@@ -16,6 +17,8 @@ fn main() {
     let describe =
         run_git(&["describe", "--always", "--tags", "--match", "op-reth-v*"]).unwrap_or_default();
 
+    let branch = run_git(&["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_default();
+
     let is_dirty = Command::new("git")
         .args(["diff-index", "--quiet", "HEAD"])
         .status()
@@ -24,24 +27,33 @@ fn main() {
 
     // If describe contains "-g" followed by a hex suffix, we're not exactly on a tag.
     let not_on_tag = describe.contains("-g") && describe.len() > sha_short.len();
-    let suffix = if not_on_tag || is_dirty { "-dev" } else { "" };
+    // No tag at all: describe == sha_short (just a bare commit hash)
+    let no_tag = !not_on_tag && describe == sha_short;
 
-    // Extract the base tag (strip trailing "-N-gSHA" if present)
-    let base_tag = if not_on_tag {
-        // "op-reth-v2.2.1-mantle-arsia.1-5-gd158cf04" → "op-reth-v2.2.1-mantle-arsia.1"
-        // Find the last "-g" followed by hex digits
-        describe
-            .rfind("-g")
-            .and_then(|g_pos| {
-                // Also strip the commit count before "-g": find the dash before the count
-                describe[..g_pos].rfind('-').map(|dash_pos| &describe[..dash_pos])
-            })
-            .unwrap_or(&describe)
+    let version = if !not_on_tag && !no_tag && !is_dirty {
+        // Exactly on a clean tag: "op-reth-v2.2.1-mantle-arsia.1"
+        describe.clone()
     } else {
-        &describe
+        // Extract the base tag (strip trailing "-N-gSHA" if present)
+        let base = if not_on_tag {
+            describe
+                .rfind("-g")
+                .and_then(|g_pos| describe[..g_pos].rfind('-').map(|dash_pos| &describe[..dash_pos]))
+                .unwrap_or(&describe)
+        } else {
+            &describe
+        };
+
+        // Include branch name when not on a tag
+        let branch_part = if !branch.is_empty() && branch != "HEAD" {
+            format!(" ({branch})")
+        } else {
+            String::new()
+        };
+
+        format!("{base}{branch_part}-dev")
     };
 
-    let version = format!("{base_tag}{suffix}");
     println!("cargo:rustc-env=MANTLE_VERSION={version}");
 
     // Build profile from OUT_DIR (same trick as reth-node-core)


### PR DESCRIPTION
## Summary
- When built on a tag: shows tag name only (e.g. `op-reth-v2.2.1-mantle-arsia.1`)
- When built off a tag on a branch: includes branch name (e.g. `op-reth-v2.2.1-mantle-arsia.1 (mantle-elysium)-dev`)
- When no tag exists: shows commit + branch (e.g. `38a251e32a (mantle-elysium)-dev`)
- Detached HEAD (CI): shows commit only (e.g. `38a251e32a-dev`)

## Test plan
- [x] `just pr` passed locally
- [x] Verified on-tag output: `op-reth-v0.0.1-test`
- [x] Verified off-tag output: `38a251e32a (mantle-elysium)-dev`