### PR TITLE
feat(engine): add engine_getPayloadV5 for Mantle Limb fork

### DIFF
--- a/mantle-reth/crates/chainspec/src/lib.rs
+++ b/mantle-reth/crates/chainspec/src/lib.rs
@@ -84,7 +84,9 @@ static MANTLE_MAINNET_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         ),
         (OpHardfork::Isthmus.boxed(), ForkCondition::Timestamp(MANTLE_MAINNET_SKADI_TIMESTAMP)),
         (MantleHardfork::Skadi.boxed(), ForkCondition::Timestamp(MANTLE_MAINNET_SKADI_TIMESTAMP)),
+        // Limb activates Osaka (engine_getPayloadV5)
         (MantleHardfork::Limb.boxed(), ForkCondition::Timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP)),
+        (EthereumHardfork::Osaka.boxed(), ForkCondition::Timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP)),
         // Arsia activates remaining OP forks: Canyon + Fjord + Granite + Holocene + Jovian
         (OpHardfork::Canyon.boxed(), ForkCondition::Timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP)),
         (OpHardfork::Fjord.boxed(), ForkCondition::Timestamp(MANTLE_MAINNET_ARSIA_TIMESTAMP)),
@@ -226,8 +228,9 @@ pub fn from_mantle_genesis(genesis: Genesis) -> OpChainSpec {
         (OpHardfork::Ecotone.boxed(), skadi_ts),
         (OpHardfork::Isthmus.boxed(), skadi_ts),
         (MantleHardfork::Skadi.boxed(), skadi_ts),
-        // Mantle Limb
+        // Mantle Limb — activates Osaka (engine_getPayloadV5)
         (MantleHardfork::Limb.boxed(), limb_ts),
+        (EthereumHardfork::Osaka.boxed(), limb_ts),
         // Mantle Arsia
         (OpHardfork::Canyon.boxed(), arsia_ts),
         (OpHardfork::Fjord.boxed(), arsia_ts),

--- a/mantle-reth/crates/chainspec/src/mantle_mainnet.rs
+++ b/mantle-reth/crates/chainspec/src/mantle_mainnet.rs
@@ -84,6 +84,13 @@ mod tests {
     }
 
     #[test]
+    fn verify_mantle_mainnet_limb_activates_osaka() {
+        let spec = &*MANTLE_MAINNET;
+        assert!(spec.is_osaka_active_at_timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP));
+        assert!(!spec.is_osaka_active_at_timestamp(MANTLE_MAINNET_LIMB_TIMESTAMP - 1));
+    }
+
+    #[test]
     fn verify_mantle_mainnet_mantle_hardforks() {
         let spec = &*MANTLE_MAINNET;
         assert!(

--- a/mantle-reth/crates/chainspec/src/mantle_sepolia.rs
+++ b/mantle-reth/crates/chainspec/src/mantle_sepolia.rs
@@ -53,6 +53,13 @@ mod tests {
     }
 
     #[test]
+    fn verify_mantle_sepolia_limb_activates_osaka() {
+        let spec = &*MANTLE_SEPOLIA;
+        assert!(spec.is_osaka_active_at_timestamp(MANTLE_SEPOLIA_LIMB_TIMESTAMP));
+        assert!(!spec.is_osaka_active_at_timestamp(MANTLE_SEPOLIA_LIMB_TIMESTAMP - 1));
+    }
+
+    #[test]
     fn verify_mantle_sepolia_arsia_activates_op_forks() {
         let spec = &*MANTLE_SEPOLIA;
         assert!(spec.is_canyon_active_at_timestamp(MANTLE_SEPOLIA_ARSIA_TIMESTAMP));

--- a/op-reth/crates/rpc/src/engine.rs
+++ b/op-reth/crates/rpc/src/engine.rs
@@ -30,6 +30,7 @@ pub const OP_ENGINE_CAPABILITIES: &[&str] = &[
     "engine_getPayloadV2",
     "engine_getPayloadV3",
     "engine_getPayloadV4",
+    "engine_getPayloadV5",
     "engine_newPayloadV2",
     "engine_newPayloadV3",
     "engine_newPayloadV4",
@@ -178,6 +179,18 @@ pub trait OpEngineApi<Engine: EngineTypes> {
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<Engine::ExecutionPayloadEnvelopeV4>;
+
+    /// Returns the most recent version of the payload that is available in the corresponding
+    /// payload build process at the time of receiving this call.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/15399c2e2f16a5f800bf3f285640357e2c245ad9/src/engine/osaka.md#engine_getpayloadv5>
+    ///
+    /// Required for Mantle Limb fork (maps to upstream Osaka/Prague payload envelope).
+    #[method(name = "getPayloadV5")]
+    async fn get_payload_v5(
+        &self,
+        payload_id: PayloadId,
+    ) -> RpcResult<Engine::ExecutionPayloadEnvelopeV5>;
 
     /// Returns the execution payload bodies by the given hash.
     ///
@@ -341,6 +354,14 @@ where
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV4> {
         trace!(target: "rpc::engine", "Serving engine_getPayloadV4");
         Ok(self.inner.get_payload_v4_metered(payload_id).await?)
+    }
+
+    async fn get_payload_v5(
+        &self,
+        payload_id: PayloadId,
+    ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV5> {
+        trace!(target: "rpc::engine", "Serving engine_getPayloadV5");
+        Ok(self.inner.get_payload_v5_metered(payload_id).await?)
     }
 
     async fn get_payload_bodies_by_hash_v1(


### PR DESCRIPTION
## Summary
- Add `engine_getPayloadV5` to `OpEngineApi` (trait + impl + capabilities list)
- Map `EthereumHardfork::Osaka` to Mantle Limb timestamp in chainspec (mainnet + sepolia + genesis JSON)
- Add unit tests for Osaka activation at Limb timestamp

## Context
Mantle's op-node (commit `c4e0852ed`) calls `engine_getPayloadV5` after the Limb fork, but op-reth only supported up to V4. This caused:
- `"Method not found"` → sequencer cannot seal blocks → acceptance tests timeout

The mapping chain: Limb → `OpSpecId::OSAKA` (in `alloy-op-evm`) → `SpecId::OSAKA` (in `op-revm`) → `is_osaka_active_at_timestamp` check in reth core's `validate_payload_timestamp`.

## Test plan
- [x] `cargo test -p mantle-reth-chainspec` — 13/13 passed (including 2 new Osaka tests)
- [x] `cargo check --workspace` — zero errors
- [ ] `just pr` passed locally
- [ ] op-acceptance-tests with reth (pending rebuild + rerun)