### PR TITLE
[retrospective] reth-side BVM_ETH failed-deposit fix (revm arsia.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.25.2"
-source = "git+https://github.com/mantle-xyz/evm?tag=v0.25.2-mantle-arsia.1#93126ead860af9d73ba032fef11fa88845f8623d"
+source = "git+https://github.com/mantle-xyz/evm?tag=v0.25.2-mantle-arsia.4#abb2a5b7d50ae6b4446d2849a4d45072b19c6269"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.25.2"
-source = "git+https://github.com/mantle-xyz/evm?tag=v0.25.2-mantle-arsia.1#93126ead860af9d73ba032fef11fa88845f8623d"
+source = "git+https://github.com/mantle-xyz/evm?tag=v0.25.2-mantle-arsia.4#abb2a5b7d50ae6b4446d2849a4d45072b19c6269"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4723,7 +4723,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4741,7 +4741,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",
@@ -6970,7 +6970,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -7007,7 +7007,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "31.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "7.1.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "bitvec",
  "phf",
@@ -11067,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "11.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11083,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "12.0.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "9.0.5"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11111,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "8.0.5"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "auto_impl",
  "either",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "12.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "auto_impl",
  "either",
@@ -11158,7 +11158,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.32.0"
-source = "git+https://github.com/mantle-xyz/revm-inspectors?tag=v0.32.0-mantle-arsia.1#19313af33f9d424dc0a6cad6b809713128a817a6"
+source = "git+https://github.com/mantle-xyz/revm-inspectors?tag=v0.32.0-mantle-arsia.4#49b772ec120343d7b2d03b8776c4c04979bb7945"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11175,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "29.0.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "29.0.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "21.0.2"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11222,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "8.1.1"
-source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.1#c4a5004b898b04c999c242381f05b0e32ff18648"
+source = "git+https://github.com/mantle-xyz/revm?tag=v98-mantle-arsia.4#23dc20bbec4d65b11af4bfed3d81840a681a4c9e"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,25 +481,25 @@ reth-ress-provider = { path = "crates/ress/provider" }
 # revm-database-interface = { version = "8.0.5", default-features = false }
 # op-revm = { version = "12.0.2", default-features = false }
 # revm-inspectors = "0.32.0"
-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-state = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-context = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-database = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.1", default-features = false }
-revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", tag = "v0.32.0-mantle-arsia.1", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-state = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-context = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-database = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v98-mantle-arsia.4", default-features = false }
+revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", tag = "v0.32.0-mantle-arsia.4", default-features = false }
 
 # eth
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 # alloy-evm = { version = "0.23.0", default-features = false }
-alloy-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v0.25.2-mantle-arsia.1", default-features = false }
+alloy-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v0.25.2-mantle-arsia.4", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-macro = "1.4.1"
@@ -537,7 +537,7 @@ alloy-transport-ipc = { version = "1.4.3", default-features = false }
 alloy-transport-ws = { version = "1.4.3", default-features = false }
 
 # op
-alloy-op-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v0.25.2-mantle-arsia.1", default-features = false }
+alloy-op-evm = { git = "https://github.com/mantle-xyz/evm", tag = "v0.25.2-mantle-arsia.4", default-features = false }
 alloy-op-hardforks = "0.4.4"
 op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", default-features = false }
 op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/op-alloy", tag = "v2.2.0", default-features = false }

--- a/crates/optimism/consensus/tests/mantle_mainnet_block_96442768_receipt_root.rs
+++ b/crates/optimism/consensus/tests/mantle_mainnet_block_96442768_receipt_root.rs
@@ -1,0 +1,116 @@
+//! Reproduces Mantle mainnet block 96442768 receipt-root behavior.
+//!
+//! Block 96442768 contains a FAILED deposit (tx index 1: `to` = EOA, empty
+//! calldata, `eth_value` + `eth_tx_value` set, `status = 0`). Per the OP deposit
+//! spec the BVM_ETH mint still persists on failure, and op-geth emits the ERC20
+//! `Mint` event *before* taking its revert snapshot, so the failed-deposit
+//! receipt keeps that one log.
+//!
+//! op-revm used to return `ExecutionResult::Halt` with no logs for a failed
+//! deposit, so reth built a receipt with empty logs / zero bloom and computed a
+//! receipts root that differed from op-geth -> the block was rejected
+//! (`receipt root mismatch`) and the node forked.
+//!
+//! This test pins the causality at the receipts-root layer: with the BVM_ETH
+//! `Mint` log present the root equals the canonical header root; without it the
+//! root equals the wrong root reth rejected on-chain.
+
+use alloy_consensus::Receipt;
+use alloy_primitives::{b256, hex, Bytes, Log, LogData, B256};
+use op_alloy_consensus::OpDepositReceipt;
+use reth_optimism_chainspec::MANTLE_MAINNET;
+use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;
+use reth_optimism_primitives::OpReceipt;
+
+const BLOCK_96442768_TIMESTAMP: u64 = 1_781_015_848;
+
+/// Canonical header `receiptsRoot` (built by the op-geth sequencer) for mainnet
+/// block 96442768.
+const HEADER_RECEIPTS_ROOT: B256 =
+    b256!("0x8a7630cea4e4adc07e8b680213ce46ceccc440935a138f0f34b33a19218ee666");
+
+/// The root reth computed (and rejected) before the fix — from the
+/// `receipt root mismatch` newPayload error and the forked node's own block.
+const RETH_FORK_ROOT: B256 =
+    b256!("0xc241638060c10d591d9e3beda456b402c9326ad349fa1439e20720cacc9d607b");
+
+/// The single BVM_ETH `Mint(address,uint256)` log emitted on the failed deposit
+/// (tx index 1, hash `0x6b7cbddd…7482`). minter = `0xc214…8de4`, value = 0.001 ETH.
+fn bvm_eth_mint_log() -> Log {
+    Log {
+        address: hex!("dEAddEaDdeadDEadDEADDEAddEADDEAddead1111").into(),
+        data: LogData::new_unchecked(
+            vec![
+                // keccak("Mint(address,uint256)")
+                b256!("0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885"),
+                // indexed minter address
+                b256!("0x000000000000000000000000c214b42e093c7739179833496791fbd50ec68de4"),
+            ],
+            // 0x38d7ea4c68000 = 1_000_000_000_000_000 wei (0.001 ETH)
+            Bytes::copy_from_slice(&hex!(
+                "00000000000000000000000000000000000000000000000000038d7ea4c68000"
+            )),
+        ),
+    }
+}
+
+/// The two deposit receipts of block 96442768, as reth's executor builds them.
+///
+/// `failed_deposit_keeps_mint_log` toggles the failed deposit's log set:
+/// `true` = the fixed behavior (op-geth parity), `false` = the pre-fix reth bug.
+fn block_receipts(failed_deposit_keeps_mint_log: bool) -> Vec<OpReceipt> {
+    vec![
+        // tx[0]: L1-attributes system deposit (to = 0x42..15), succeeds, no logs.
+        OpReceipt::Deposit(OpDepositReceipt {
+            inner: Receipt { status: true.into(), cumulative_gas_used: 57_499, logs: vec![] },
+            deposit_nonce: Some(0x21a_30a6),
+            deposit_receipt_version: None,
+        }),
+        // tx[1]: failed user deposit (status = 0); the BVM_ETH mint persists, and
+        // with it the `Mint` event log.
+        OpReceipt::Deposit(OpDepositReceipt {
+            inner: Receipt {
+                status: false.into(),
+                cumulative_gas_used: 157_499,
+                logs: if failed_deposit_keeps_mint_log {
+                    vec![bvm_eth_mint_log()]
+                } else {
+                    vec![]
+                },
+            },
+            deposit_nonce: Some(0),
+            deposit_receipt_version: None,
+        }),
+    ]
+}
+
+#[test]
+fn mantle_mainnet_96442768_failed_deposit_mint_log_matches_receipt_root() {
+    // With the BVM_ETH `Mint` log on the failed deposit (the fix), the receipts
+    // root matches the canonical op-geth header.
+    let root_with_log = calculate_receipt_root_no_memo_optimism(
+        &block_receipts(true),
+        MANTLE_MAINNET.as_ref(),
+        BLOCK_96442768_TIMESTAMP,
+    );
+    assert_eq!(
+        root_with_log, HEADER_RECEIPTS_ROOT,
+        "failed-deposit BVM_ETH Mint log must be in the receipt for the root to match op-geth"
+    );
+
+    // Dropping that log (the pre-fix reth behavior) reproduces the exact wrong
+    // root that caused the on-chain fork at block 96442768.
+    let root_without_log = calculate_receipt_root_no_memo_optimism(
+        &block_receipts(false),
+        MANTLE_MAINNET.as_ref(),
+        BLOCK_96442768_TIMESTAMP,
+    );
+    assert_ne!(
+        root_without_log, HEADER_RECEIPTS_ROOT,
+        "an empty failed-deposit receipt must NOT match the canonical root"
+    );
+    assert_eq!(
+        root_without_log, RETH_FORK_ROOT,
+        "dropping the Mint log reproduces the receipt root reth rejected on mainnet"
+    );
+}

--- a/crates/optimism/consensus/tests/mantle_sepolia_block_286456_failed_deposit_transfer_log.rs
+++ b/crates/optimism/consensus/tests/mantle_sepolia_block_286456_failed_deposit_transfer_log.rs
@@ -1,0 +1,159 @@
+//! Reproduces Mantle Sepolia block 286456 receipt-root behavior.
+//!
+//! Block 286456 (hash `0xa088c560…`) contains a FAILED deposit at tx index 1
+//! (`0xbcdbae6a…`, `to` = L2StandardBridge `0x42..10`, `status = 0`) that mints
+//! `eth_value` of BVM_ETH AND transfers it to the bridge. Per the OP deposit
+//! spec op-geth runs the BVM_ETH mint AND the (successful) transfer *before*
+//! taking its revert snapshot, so BOTH the `Mint` and `Transfer` event logs
+//! survive the failure and end up in the receipt (2 logs).
+//!
+//! This is the case the first fix (`v98-mantle-arsia.2`) did NOT cover: that fix
+//! re-surfaced only the `Mint` log (mint-only path), because the mainnet block it
+//! was validated against (96442768) had a transfer that did NOT succeed, so only
+//! the mint persisted. Here the transfer succeeds (transfer == mint == 0.001
+//! ETH), so the canonical receipt carries Mint + Transfer.
+//!
+//! This test pins the causality at the receipts-root layer:
+//!  - Mint + Transfer  -> root == canonical op-geth header root (the full fix)
+//!  - Mint only        -> the wrong root reth computed & rejected on-chain
+//!  - no logs          -> a different wrong root (the original pre-fix bug)
+//!
+//! Companion to the op-revm execution test
+//! `test_failed_deposit_persists_mint_and_transfer_when_transfer_succeeds`,
+//! which proves op-revm actually emits both logs once the transfer-log fix
+//! (mantle-xyz/revm `fix/failed-deposit-transfer-log`) ships.
+
+use alloy_consensus::Receipt;
+use alloy_primitives::{b256, hex, Bytes, Log, LogData, B256};
+use op_alloy_consensus::OpDepositReceipt;
+use reth_optimism_chainspec::MANTLE_SEPOLIA;
+use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;
+use reth_optimism_primitives::OpReceipt;
+
+const BLOCK_286456_TIMESTAMP: u64 = 1_781_028_032;
+
+/// Canonical header `receiptsRoot` (op-geth) for Sepolia block 286456
+/// (hash `0xa088c560…`).
+const HEADER_RECEIPTS_ROOT: B256 =
+    b256!("0x9f29d9b81a94d5ab324194493550e842b43a66fe2bf32c0bf3a29474de96d6f8");
+
+/// The root reth logged & rejected on-chain (`receipt root mismatch ... got
+/// 0xd1939af6...`). It is the **empty-logs** root — i.e. produced by a reth with
+/// NO failed-deposit log fix at all (mint log dropped): reth `v1.9.3-mantle-arsia.2`,
+/// which pins revm `v98-mantle-arsia.1` (cold-reset only, before the mint-log fix).
+const RETH_FORK_ROOT_NO_LOGS: B256 =
+    b256!("0xd1939af61deb278177b875b36eb990a7d1d1db0070044fb9adaba05f41b78b36");
+
+/// The root a mint-only fix (reth `v1.9.3-mantle-arsia.3` -> revm
+/// `v98-mantle-arsia.2`) produces: the Mint log is surfaced but the Transfer log
+/// is still missing, so it STILL differs from the canonical root and still forks.
+const MINT_ONLY_ROOT: B256 =
+    b256!("0x57a968ee59d0868151e9eaf5eade1ce60f95d90d54ce6a75230b17dd00a0965b");
+
+/// BVM_ETH `Mint(address,uint256)`: minter = 0x7466be34…, value = 0.001 ETH.
+fn mint_log() -> Log {
+    Log {
+        address: hex!("dEAddEaDdeadDEadDEADDEAddEADDEAddead1111").into(),
+        data: LogData::new_unchecked(
+            vec![
+                b256!("0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885"),
+                b256!("0x0000000000000000000000007466be349b17a0f966f97ddeefe393894b9faf06"),
+            ],
+            Bytes::copy_from_slice(&hex!(
+                "00000000000000000000000000000000000000000000000000038d7ea4c68000"
+            )),
+        ),
+    }
+}
+
+/// BVM_ETH `Transfer(address,address,uint256)`: 0x7466be34… -> L2StandardBridge
+/// (0x42..10), value = 0.001 ETH.
+fn transfer_log() -> Log {
+    Log {
+        address: hex!("dEAddEaDdeadDEadDEADDEAddEADDEAddead1111").into(),
+        data: LogData::new_unchecked(
+            vec![
+                b256!("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+                b256!("0x0000000000000000000000007466be349b17a0f966f97ddeefe393894b9faf06"),
+                b256!("0x0000000000000000000000004200000000000000000000000000000000000010"),
+            ],
+            Bytes::copy_from_slice(&hex!(
+                "00000000000000000000000000000000000000000000000000038d7ea4c68000"
+            )),
+        ),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FailedDepositLogs {
+    /// op-geth parity: mint + successful transfer both persist.
+    MintAndTransfer,
+    /// `v98-mantle-arsia.2`: only the mint log re-surfaced.
+    MintOnly,
+    /// Pre-fix reth: the halt dropped all logs.
+    None,
+}
+
+/// The two deposit receipts of block 286456, exactly as observed on-chain
+/// (`eth_getBlockReceipts`), with the failed deposit's log set toggled.
+fn block_receipts(logs: FailedDepositLogs) -> Vec<OpReceipt> {
+    let failed_logs = match logs {
+        FailedDepositLogs::MintAndTransfer => vec![mint_log(), transfer_log()],
+        FailedDepositLogs::MintOnly => vec![mint_log()],
+        FailedDepositLogs::None => vec![],
+    };
+    vec![
+        // tx[0]: L1-attributes system deposit (to = 0x42..15), succeeds, no logs.
+        OpReceipt::Deposit(OpDepositReceipt {
+            inner: Receipt { status: true.into(), cumulative_gas_used: 57_475, logs: vec![] },
+            deposit_nonce: Some(0x45ef7),
+            deposit_receipt_version: None,
+        }),
+        // tx[1]: failed user deposit to L2StandardBridge (status = 0); the BVM_ETH
+        // mint and the successful transfer both persist into the receipt.
+        OpReceipt::Deposit(OpDepositReceipt {
+            inner: Receipt { status: false.into(), cumulative_gas_used: 83_705, logs: failed_logs },
+            deposit_nonce: Some(0x8d),
+            deposit_receipt_version: None,
+        }),
+    ]
+}
+
+fn root(logs: FailedDepositLogs) -> B256 {
+    calculate_receipt_root_no_memo_optimism(
+        &block_receipts(logs),
+        MANTLE_SEPOLIA.as_ref(),
+        BLOCK_286456_TIMESTAMP,
+    )
+}
+
+#[test]
+fn mantle_sepolia_286456_failed_deposit_keeps_mint_and_transfer_log() {
+    let full = root(FailedDepositLogs::MintAndTransfer);
+    let mint_only = root(FailedDepositLogs::MintOnly);
+    let empty = root(FailedDepositLogs::None);
+    println!("mint+transfer = {full:?}");
+    println!("mint-only     = {mint_only:?}");
+    println!("no logs       = {empty:?}");
+
+    // The full fix: only with BOTH the Mint and Transfer logs does the receipts
+    // root match the canonical op-geth header.
+    assert_eq!(
+        full, HEADER_RECEIPTS_ROOT,
+        "failed deposit must keep BOTH Mint and Transfer logs for the root to match op-geth"
+    );
+
+    // Mint-only (reth v1.9.3-mantle-arsia.3 / revm v98-mantle-arsia.2): the Mint
+    // log is surfaced but the Transfer log is still dropped, so the root STILL
+    // differs from canonical -> this block still forks until the transfer-log fix.
+    assert_eq!(mint_only, MINT_ONLY_ROOT, "mint-only root is stable/known");
+    assert_ne!(mint_only, HEADER_RECEIPTS_ROOT, "mint-only is NOT sufficient for this block");
+
+    // No logs (reth v1.9.3-mantle-arsia.2 / revm v98-mantle-arsia.1): reproduces
+    // the exact wrong root reth logged & rejected on-chain (0xd1939af6...).
+    assert_eq!(
+        empty, RETH_FORK_ROOT_NO_LOGS,
+        "empty-logs root reproduces the receipt root reth rejected on-chain"
+    );
+    assert_ne!(empty, HEADER_RECEIPTS_ROOT, "empty logs must NOT match canonical");
+}

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -434,7 +434,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let access_list = inspector.into_access_list();
             tx_env.set_access_list(access_list.clone());
             match result.result {
-                ExecutionResult::Halt { reason, gas_used } => {
+                ExecutionResult::Halt { reason, gas_used, .. } => {
                     let error =
                         Some(Self::Error::from_evm_halt(reason, tx_env.gas_limit()).to_string());
                     return Ok(AccessListResult {
@@ -458,7 +458,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let gas_limit = tx_env.gas_limit();
             let result = this.transact(&mut db, evm_env, tx_env)?;
             let res = match result.result {
-                ExecutionResult::Halt { reason, gas_used } => {
+                ExecutionResult::Halt { reason, gas_used, .. } => {
                     let error = Some(Self::Error::from_evm_halt(reason, gas_limit).to_string());
                     AccessListResult { access_list, gas_used: U256::from(gas_used), error }
                 }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -1084,7 +1084,7 @@ pub fn ensure_success<Halt, Error: FromEvmHalt<Halt> + FromEthApiError>(
         ExecutionResult::Revert { output, .. } => {
             Err(Error::from_eth_err(RpcInvalidTransactionError::Revert(RevertError::new(output))))
         }
-        ExecutionResult::Halt { reason, gas_used } => Err(Error::from_evm_halt(reason, gas_used)),
+        ExecutionResult::Halt { reason, gas_used, .. } => Err(Error::from_evm_halt(reason, gas_used)),
     }
 }
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -200,7 +200,7 @@ where
     let mut log_index = 0;
     for (index, (result, tx)) in results.into_iter().zip(block.body().transactions()).enumerate() {
         let call = match result {
-            ExecutionResult::Halt { reason, gas_used } => {
+            ExecutionResult::Halt { reason, gas_used, .. } => {
                 let error = T::Error::from_evm_halt(reason, tx.gas_limit());
                 SimCallResult {
                     return_data: Bytes::new(),


### PR DESCRIPTION
## Retrospective / single consolidated view (DRAFT)

One squashed commit showing the **complete reth-side** fix for the BVM_ETH failed-deposit consensus bug, consolidated from 4 commits on `fix/block-96442768-receipt-root-test`.

**Status:** the fix is already on this branch (`legacy/reth-v1.9.3-mantle-arsia`) via PR #51 and shipped to production via tag `v1.9.3-mantle-arsia.6`. This PR re-expresses those 4 commits as a single diff for review/retrospective; it is kept as a DRAFT and should not be merged (it would add a duplicate squashed commit). Close after review.

## Incident
op-reth verifiers forked from op-geth at **mainnet block 96442768** (receipt-root mismatch); op-node marked the block INVALID and reth stalled.

## Root cause (in revm; reth only adopts the dependency)
On a **failed deposit**, op-geth keeps the BVM_ETH **Mint** log, and — when the deposit entered the EVM call — the **Transfer** log + recipient balance. revm dropped them, so reth computed a different `receiptsRoot`/`stateRoot` than canonical.

| class | op-geth keeps | example |
|---|---|---|
| pre-exec / HALT | Mint only | mainnet 96442768, sepolia 286432 |
| in-call REVERT | Mint + Transfer | sepolia 286456 |
| in-call OOG | Mint + Transfer | synthetic (revm PR #31) |

## reth-side change (this PR)
- Bump `revm/op-revm/revm-inspectors/alloy-evm/alloy-op-evm` to `v98-mantle-arsia.4` / `v0.32.0-mantle-arsia.4` / `v0.25.2-mantle-arsia.4`.
- Two real-block regression tests (`receiptsRoot == on-chain`):
  - `mantle_mainnet_block_96442768_receipt_root` (HALT / mint-only)
  - `mantle_sepolia_block_286456_failed_deposit_transfer_log` (REVERT / mint+transfer)
- Minor RPC adaptations for the new `ExecutionResult::Halt` logs field.

## Squashed from
`a067a3f` (arsia.2) -> `2e2a76c` (arsia.3) -> `ad62969` (re-lock) -> `c42edbf` (arsia.4).

## Verification
129 op-revm lib tests pass; sepolia-qa5 + v133 recovered on arsia.6 (reth == geth hashes, `eth_syncing=false`, zero INVALID; 286432/286456 receiptsRoot match canonical).

## Not included
Glamsterdam/Elysium (revm v107) port — tracked separately.