### PR TITLE
chore(deps): bump op-alloy to mantle-elysium HEAD (TxDeposit Compact eth_value fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.5.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -3551,8 +3551,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4062,7 +4062,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5764,7 +5764,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "op-alloy"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5806,7 +5806,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5819,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5833,7 +5833,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5863,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#c06cb7238182f556f517b6762c6723b64594501f"
+source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",


### PR DESCRIPTION
## Summary

Lockfile-only bump to pull **mantle-v2#362** (preserve `eth_value`/`eth_tx_value` in the `TxDeposit` Compact codec) into op-reth.

`op-alloy*` / `alloy-op-*` git deps move `c06cb723` → `9eecb9e9` (current `mantle-elysium` HEAD). `Cargo.toml` is **unchanged** — those deps already track the `mantle-elysium` branch; only `Cargo.lock` is updated.

## Why

Before #362, `CompactTxDeposit` dropped the Mantle BVM_ETH fields on Compact encode/decode. An elysium op-reth reading a deposit written by another version (e.g. `v1.9.3-mantle-arsia`) would:
- return `ethValue=0x0` / `ethTxValue=null` (and a wrong tx hash) from `eth_getTransactionByHash` — silent data corruption;
- **fail to re-execute the historical block** with `receipt root mismatch` (node halts).

## Verification

Built this branch and ran against an `arsia.6`-written DB snapshot:
- `stage run execution` over the BVM_ETH deposit block: **`Finished stage Execution`, no `receipt root mismatch`** (pre-fix this failed: got `0x40ff553e…` / expected `0x17c1cc9b…`).
- `eth_getTransactionByHash(<deposit>)`: returns the correct `ethValue=0x1b69a93f1640000` / `ethTxValue` (matches op-geth oracle).

Refs: mantle-v2#362, op-reth integration plan §11.4.