### PR TITLE
ci: add DockerfileOp for elysium workspace layout

### DIFF
--- a/DockerfileOp
+++ b/DockerfileOp
@@ -1,0 +1,46 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+LABEL org.opencontainers.image.source=https://github.com/mantle-xyz/reth
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+
+# Builds a cargo-chef plan
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+
+ARG BUILD_PROFILE=release
+ENV BUILD_PROFILE=$BUILD_PROFILE
+
+ARG RUSTFLAGS=""
+ENV RUSTFLAGS="$RUSTFLAGS"
+
+# Mantle op-reth is the `mantle-reth-cli` package (new elysium workspace layout).
+ARG FEATURES="jemalloc asm-keccak min-debug-logs"
+ENV FEATURES=$FEATURES
+
+RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/mantle-reth/crates/cli/Cargo.toml
+
+COPY . .
+RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/mantle-reth/crates/cli/Cargo.toml
+
+RUN ls -la /app/target/$BUILD_PROFILE/op-reth
+RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth
+
+FROM ubuntu:24.04 AS runtime
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl-dev pkg-config strace && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/op-reth /usr/local/bin/
+RUN chmod +x /usr/local/bin/op-reth
+
+EXPOSE 30303 30303/udp 9001 8545 8546 7545 8551
+ENTRYPOINT ["/usr/local/bin/op-reth"]


### PR DESCRIPTION
Unblocks the mantle-config image build (`A-Mantle App Build Only`), which fails with `grep/sed: ./DockerfileOp: No such file or directory` because the elysium restructure never added a root `DockerfileOp`.

Adapted from the v1.9.3-mantle-arsia `DockerfileOp` (same cargo-chef structure the build pipeline's sed-injection already handles), changed to build the `op-reth` binary from the `mantle-reth-cli` package (`mantle-reth/crates/cli`) instead of the old `crates/optimism/bin`. Default `FEATURES="jemalloc asm-keccak min-debug-logs"` matches `just build`.

Note: a new RC tag is needed after merge so the tagged build includes this file (the current `op-reth-v2.2.1-mantle-elysium.1-rc2` tag predates it).