### PR TITLE
fix(ci): DockerfileOp injection-safety + BuildKit cache mounts

### DIFF
--- a/DockerfileOp
+++ b/DockerfileOp
@@ -1,12 +1,13 @@
-# Single-stage cargo build (no cargo-chef): the elysium workspace uses a local
-# `[patch]` path dependency (patches/reth-trie-common), which cargo-chef's cook
-# stage cannot resolve from recipe.json alone (it only has recipe.json, not the
-# patch crate's Cargo.toml) and panics with "failed to read .../Cargo.toml".
-# A plain COPY + cargo build has the whole tree (incl. patches/) available.
+# Single-stage build of the op-reth binary.
 #
-# The mantle-config build pipeline injects a JFrog `.cargo/config.toml` RUN
-# immediately before any `cargo build` line, so COPY happens first and the
-# injected config is not overwritten.
+# The chef layer-cache tool is intentionally NOT used: the elysium workspace has
+# a local [patch] path dependency (patches/reth-trie-common) that chef's cook
+# step cannot resolve from recipe.json alone and panics on. A plain COPY of the
+# whole tree (incl. patches/) and a direct compile avoids that.
+#
+# Keep the literal build-command string out of comments: the mantle-config
+# pipeline injects a JFrog config RUN before any line matching it, so an
+# occurrence in a comment above FROM would produce "no build stage".
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS builder
 WORKDIR /app
 


### PR DESCRIPTION
Two CI/build fixes to the elysium DockerfileOp (stacked; rc2 tracks this branch for pre-merge verification):

**1. Keep the build-command string out of comments.** The pipeline injects the JFrog cargo config with `sed '/cargo build\|cargo chef/i RUN ...'`, inserting before *every* matching line — including comments. The earlier comments mentioned the build command above `FROM`, so the injected RUN landed at line 1 → `no build stage in current context`.

**2. Add BuildKit cache mounts** (cargo registry/git + target dir) so a persistent/remote builder reuses them across builds, turning the ~18m cold release compile into a fast incremental one. Kept on a single physical line so the `sed /cargo build/i` injection can't split a `\`-continued RUN; binary copied out inside the same RUN.

Validated: injection simulated (FROM stays first, lands before the build line, no split) + `docker build --check` clean. The cold CI build already succeeded on the previous commit of this branch.