### PR TITLE
perf(ci): add BuildKit cache mounts to op-reth docker build

### DIFF
--- a/DockerfileOp
+++ b/DockerfileOp
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Single-stage build of the op-reth binary.
 #
 # The chef layer-cache tool is intentionally NOT used: the elysium workspace has
@@ -8,6 +9,11 @@
 # Keep the literal build-command string out of comments: the mantle-config
 # pipeline injects a JFrog config RUN before any line matching it, so an
 # occurrence in a comment above FROM would produce "no build stage".
+#
+# BuildKit cache mounts persist the cargo registry/git and the target dir across
+# builds on a persistent/remote builder, turning a ~18m cold compile into a fast
+# incremental one. The binary is copied out inside the same RUN because cache
+# mounts are only present for the RUN that declares them.
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS builder
 WORKDIR /app
 
@@ -28,10 +34,9 @@ ENV FEATURES=$FEATURES
 
 COPY . .
 
-RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/mantle-reth/crates/cli/Cargo.toml
-
-RUN ls -la /app/target/$BUILD_PROFILE/op-reth
-RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth
+# NOTE: this must stay a SINGLE physical line — the pipeline injects a RUN before
+# the line containing the build command, which would split a `\`-continued RUN.
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/usr/local/cargo/git --mount=type=cache,target=/app/target cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/mantle-reth/crates/cli/Cargo.toml && cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth
 
 FROM ubuntu:24.04 AS runtime
 


### PR DESCRIPTION
Lands the BuildKit cache-mount change that was pushed to #60's branch *after* #60 had already merged, so it never reached mantle-elysium (mantle-elysium currently has no cache mount; rc2 and the deployed image do).

Mounts the cargo registry/git + target dir as BuildKit caches so the persistent CI builder reuses them across builds. Measured: 'Build and push' dropped from **1345s → 521s** (CI run 27589467272, success). RUN kept single-line so the pipeline's `sed '/cargo build/i ...'` injection can't split it. Validated with `docker build --check` (clean).

Build-speed only; no functional change.