### PR TITLE
test: re-enable token_ratio_midblock regression tests

### DIFF
--- a/mantle-reth/crates/integration-tests/tests/token_ratio_midblock.rs
+++ b/mantle-reth/crates/integration-tests/tests/token_ratio_midblock.rs
@@ -167,7 +167,6 @@ fn block_env() -> BlockEnv {
 }
 
 #[test]
-#[ignore = "requires op-revm fix (remove stale try_fetch guard in validate_against_state_and_deduct_caller)"]
 fn token_ratio_midblock_l1_fee_vault_no_overcredit() {
     let caller: Address = "0x1111111111111111111111111111111111111111".parse().unwrap();
     let eoa: Address = "0x2222222222222222222222222222222222222222".parse().unwrap();
@@ -236,7 +235,6 @@ fn token_ratio_midblock_l1_fee_vault_no_overcredit() {
 /// ratio (the deduct-caller refetch guard undoes `reset_l2_block` before the
 /// oracle's own SSTORE), so this fails at tx3 by +384.
 #[test]
-#[ignore = "requires op-revm fix (remove stale try_fetch guard in validate_against_state_and_deduct_caller)"]
 fn token_ratio_multi_oracle_per_tx_l1_fee_correct() {
     let caller: Address = "0x1111111111111111111111111111111111111111".parse().unwrap();
     let eoa: Address = "0x2222222222222222222222222222222222222222".parse().unwrap();


### PR DESCRIPTION
## What

Removes the two `#[ignore]` attributes on the `token_ratio_midblock` regression tests:
- `token_ratio_midblock_l1_fee_vault_no_overcredit`
- `token_ratio_multi_oracle_per_tx_l1_fee_correct`

## Why

These tests were ignored pending an op-revm fix for the **mid-block `token_ratio` over-credit** bug (a stale `try_fetch` guard in `validate_against_state_and_deduct_caller` re-pinned `l2_block` with the pre-update ratio, so the next user tx after a gas-oracle SSTORE was L1-fee'd at the stale ratio — over-crediting the L1FeeVault by +384 per ratio unit).

The fix has landed in the pinned op-revm (`b4f61822`): the L1BlockInfo refresh now lives in `validate_initial_tx_gas` (`try_fetch` on stale `l2_block`, `reset_l2_block` when the tx targets `GAS_ORACLE_CONTRACT`), and the redundant re-fetch guard in `validate_against_state_and_deduct_caller` is gone.

## Test plan

`cargo test -p mantle-reth-integration-tests --test token_ratio_midblock -- --nocapture`

Verified locally — **2 passed**:
- `L1FeeVault total = 572544` (canonical), not the buggy `572928`
- multi-oracle sequence charges each tx at the correct ratio: `2984 / 2980 / 2976`

## Note

The module-level doc comment in `token_ratio_midblock.rs` still describes the test as "fails by +384 on current elysium op-revm". That narration is now stale (fix is in) but left as historical context; can update in a follow-up if preferred.