### PR TITLE
test(primitives): fix deposit Compact roundtrip proptest

### DIFF
--- a/op-reth/crates/primitives/src/transaction/signed.rs
+++ b/op-reth/crates/primitives/src/transaction/signed.rs
@@ -581,13 +581,6 @@ mod tests {
         }
     }
 
-    fn clear_mantle_deposit_fields(tx: &mut OpTransactionSigned) {
-        if let OpTypedTransaction::Deposit(deposit) = &mut tx.transaction {
-            deposit.eth_value = 0;
-            deposit.eth_tx_value = None;
-        }
-    }
-
     proptest! {
         #[test]
         fn test_roundtrip_compact_encode_envelope(reth_tx in arb::<OpTransactionSigned>()) {
@@ -610,8 +603,6 @@ mod tests {
             let len = reth_tx.to_compact(&mut buf);
 
             let (actual_tx, _) = OpTxEnvelope::from_compact(&buf, len);
-            // Compact codec drops eth_value/eth_tx_value for deposit txs (reth_codecs_derive limitation)
-            clear_mantle_deposit_fields(&mut reth_tx);
             let expected_tx = OpTxEnvelope::from(reth_tx);
 
             assert_eq!(actual_tx, expected_tx);
@@ -633,13 +624,11 @@ mod tests {
         }
 
         #[test]
-        fn test_roundtrip_compact_decode_envelope(mut reth_tx in arb::<OpTransactionSigned>()) {
+        fn test_roundtrip_compact_decode_envelope(reth_tx in arb::<OpTransactionSigned>()) {
             let mut buf = Vec::<u8>::new();
             let len = reth_tx.to_compact(&mut buf);
 
             let (actual_tx, _) = OpTxEnvelope::from_compact(&buf, len);
-            // Compact codec drops eth_value/eth_tx_value for deposit txs (reth_codecs_derive limitation)
-            clear_mantle_deposit_fields(&mut reth_tx);
             let expected_tx = OpTxEnvelope::from(reth_tx);
 
             assert_eq!(actual_tx, expected_tx);


### PR DESCRIPTION
## Problem

`test_roundtrip_compact_decode_envelope` and `_zstd` in `reth-optimism-primitives` fail deterministically on `mantle-elysium` (any proptest-generated deposit with `eth_value != 0`):

```
left  (decoded): eth_value: 283184…, eth_tx_value: Some(256417…)
right (expected): eth_value: 0,       eth_tx_value: None
```

This is currently silent because CI runs lint only (no test job).

## Root cause

`signed.rs` is the legacy reth `OpTransactionSigned`, kept only to test Compact consistency with op-alloy's `OpTxEnvelope`. The op-alloy `mantle-elysium` branch now **persists** `eth_value`/`eth_tx_value` in the `TxDeposit` Compact codec (`crates/consensus/src/reth_codec.rs`), so `to_compact` → `from_compact` round-trips them faithfully.

But the decode proptests still call `clear_mantle_deposit_fields()` — with the now-false comment *"Compact codec drops eth_value/eth_tx_value (reth_codecs_derive limitation)"* — which zeroes the **expected** side. The faithfully-decoded `actual` keeps the fields → mismatch.

Evidence it's a stale test, not a codec bug: the **encode** proptests (no clearing) already pass, comparing `reth.to_compact` bytes to `OpTxEnvelope::from(reth).to_compact` bytes — both encode the fields identically.

## Fix

Remove the stale `clear_mantle_deposit_fields()` calls + comment (and the now-unused helper); the decode tests now assert true roundtrip fidelity.

## Test plan

- `cargo test -p reth-optimism-primitives --lib` → **26 passed; 0 failed** (both decode tests green)
- `RUSTFLAGS="-D warnings" cargo clippy -p reth-optimism-primitives --tests` → clean

## Note

Persistence behavior changed vs the old `reth_codecs_derive` era: `eth_value`/`eth_tx_value` now **do** persist to MDBX/static files (they used to be dropped). Worth keeping in mind for storage/migration reasoning.