### PR TITLE
fix(rpc): align estimateGas value pre-check with op-geth + add funds-check coverage

### DIFF
--- a/mantle-reth/crates/eth-api/src/lib.rs
+++ b/mantle-reth/crates/eth-api/src/lib.rs
@@ -331,4 +331,128 @@ mod tests {
         // This should now fail (insufficient funds)
         assert!(result.is_err(), "with non-zero L1 base fee, calldata should add L1 cost");
     }
+
+    #[test]
+    fn check_funds_value_equals_balance_is_ok() {
+        // The check uses a strict `total > balance` comparison (op-geth's funds
+        // preflight rejects only when the *total* exceeds balance). With zero gas
+        // fee + zero operator/L1 cost, total == value, so value == balance must pass.
+        let info = L1BlockInfo::default();
+        let value = U256::from(1_000_000u64);
+        assert!(
+            mantle_arsia_check_funds(&ArsiaFundsCheck {
+                gas_limit: 21_000,
+                // fee_cap must be non-zero or the whole check is skipped; keep L2 cost
+                // negligible by pairing a tiny fee with a value-dominated balance.
+                fee_cap: U256::from(1u64),
+                value,
+                // balance exactly covers value + the 1 wei/gas L2 cost (21000 * 1)
+                from_balance: value + U256::from(21_000u64),
+                l1_block_info: &info,
+                tx_input: &[],
+                chain_spec: MANTLE_MAINNET.as_ref(),
+                timestamp: arsia_ts(),
+            })
+            .is_ok(),
+            "total == balance must pass (strict > comparison)"
+        );
+    }
+
+    #[test]
+    fn check_funds_operator_constant_only() {
+        // scalar = 0, constant > 0 => operator_cost == constant (independent of gas_limit).
+        let constant = 1_000_000u64;
+        let info = l1_info_with_operator_fee(0, constant);
+        let fee_cap = U256::from(10_000_000_000u64);
+        let l2_cost = U256::from(21_000u64) * fee_cap;
+
+        // Balance covers L2 but is 1 wei short of the operator constant.
+        let result = mantle_arsia_check_funds(&ArsiaFundsCheck {
+            gas_limit: 21_000,
+            fee_cap,
+            value: U256::ZERO,
+            from_balance: l2_cost + U256::from(constant) - U256::from(1),
+            l1_block_info: &info,
+            tx_input: &[],
+            chain_spec: MANTLE_MAINNET.as_ref(),
+            timestamp: arsia_ts(),
+        });
+        assert!(result.is_err(), "1 wei short of L2 + operator constant must fail");
+
+        // Exactly L2 + constant passes.
+        assert!(
+            mantle_arsia_check_funds(&ArsiaFundsCheck {
+                gas_limit: 21_000,
+                fee_cap,
+                value: U256::ZERO,
+                from_balance: l2_cost + U256::from(constant),
+                l1_block_info: &info,
+                tx_input: &[],
+                chain_spec: MANTLE_MAINNET.as_ref(),
+                timestamp: arsia_ts(),
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn check_funds_all_components_combined() {
+        // Exercise every additive term at once: L2 + operator(scalar+constant) + value.
+        // L1 cost stays 0 (default l1_base_fee), so `total` is exactly computable here.
+        let info = l1_info_with_operator_fee(2, 50_000);
+        let fee_cap = U256::from(10_000_000_000u64);
+        let value = U256::from(500_000u64);
+        let l2_cost = U256::from(21_000u64) * fee_cap;
+        let operator_cost =
+            U256::from(21_000u64) * U256::from(2u64) * U256::from(100u64) + U256::from(50_000u64);
+        let total = l2_cost + operator_cost + value;
+
+        // 1 wei short of the full total must fail.
+        let result = mantle_arsia_check_funds(&ArsiaFundsCheck {
+            gas_limit: 21_000,
+            fee_cap,
+            value,
+            from_balance: total - U256::from(1),
+            l1_block_info: &info,
+            tx_input: &[],
+            chain_spec: MANTLE_MAINNET.as_ref(),
+            timestamp: arsia_ts(),
+        });
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.total, total, "reported total must equal L2 + operator + value");
+
+        // Exactly the total passes.
+        assert!(
+            mantle_arsia_check_funds(&ArsiaFundsCheck {
+                gas_limit: 21_000,
+                fee_cap,
+                value,
+                from_balance: total,
+                l1_block_info: &info,
+                tx_input: &[],
+                chain_spec: MANTLE_MAINNET.as_ref(),
+                timestamp: arsia_ts(),
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn check_funds_saturates_without_panic() {
+        // gas_limit * fee_cap and operator math use saturating ops; extreme inputs
+        // must not panic on overflow and must report insufficient funds.
+        let info = l1_info_with_operator_fee(u64::MAX, u64::MAX);
+        let result = mantle_arsia_check_funds(&ArsiaFundsCheck {
+            gas_limit: u64::MAX,
+            fee_cap: U256::MAX,
+            value: U256::MAX,
+            from_balance: U256::from(1u64),
+            l1_block_info: &info,
+            tx_input: &[0xff; 64],
+            chain_spec: MANTLE_MAINNET.as_ref(),
+            timestamp: arsia_ts(),
+        });
+        assert!(result.is_err(), "saturated total must exceed a 1 wei balance");
+    }
 }

--- a/mantle-reth/crates/integration-tests/tests/gas_estimation.rs
+++ b/mantle-reth/crates/integration-tests/tests/gas_estimation.rs
@@ -41,20 +41,23 @@ async fn estimate_gas_simple_transfer_via_rpc() {
 }
 
 /// A value transfer the caller cannot afford is rejected up front with an
-/// "insufficient funds for transfer" error — this is the `value > balance` pre-check
-/// in the Mantle `estimate_gas_at` override (op-geth `state_transition.go` clause 6),
-/// and it does not require a mined L1-info block.
+/// "insufficient funds for transfer" error — this is the `value >= balance` pre-check
+/// in the Mantle `estimate_gas_at` override (op-geth `gasestimator.go` clause 6). Like
+/// geth, the check only runs when a fee cap is set, so the request specifies
+/// `maxFeePerGas`; it does not require a mined L1-info block.
 #[tokio::test]
 async fn estimate_gas_value_exceeds_balance_rejected_via_rpc() {
     with_mantle_rpc_client(|client| async move {
-        // UNFUNDED has zero balance; any non-zero value exceeds it.
+        // UNFUNDED has zero balance; any non-zero value exceeds it. A fee cap is set so
+        // the geth-gated value pre-check (feeCap != 0) actually runs.
         let res: Result<U256, _> = client
             .request(
                 "eth_estimateGas",
                 vec![serde_json::json!({
                     "from": UNFUNDED,
                     "to": FUNDED,
-                    "value": "0xde0b6b3a7640000" // 1 ETH
+                    "value": "0xde0b6b3a7640000", // 1 ETH
+                    "maxFeePerGas": "0x3b9aca00"   // 1 gwei → fee gate is open
                 })],
             )
             .await;

--- a/mantle-reth/crates/integration-tests/tests/gas_estimation.rs
+++ b/mantle-reth/crates/integration-tests/tests/gas_estimation.rs
@@ -1,82 +1,123 @@
-//! Smoke tests for Mantle-specific RPC endpoints and gas estimation.
+//! Smoke + behavioural tests for Mantle-specific gas estimation RPCs.
 //!
-//! These tests verify the RPC methods are reachable and return structurally
-//! valid responses. Numerical accuracy is verified by `tests/rpc_compat`.
+//! These exercise the live `eth_estimateGas` / `eth_estimateTotalFee` paths through a
+//! booted `MantleNode`, covering the Arsia funds-preflight wiring added in
+//! `op-reth/crates/rpc/src/eth/call.rs` (port of op-geth `mantleArsiaCheckFunds` +
+//! the `value > balance` pre-check). Numerical accuracy is cross-checked against geth
+//! by `tests/rpc_compat`; the pure formula is unit-tested in `mantle-reth-eth-api`.
 
-use crate::helpers::{mantle_payload_attributes, mantle_test_chain_spec};
+use crate::helpers::with_mantle_rpc_client;
 use alloy_primitives::U256;
-use mantle_reth_cli::node::MantleNode;
-use reth_chainspec::EthChainSpec;
-use reth_db::test_utils::create_test_rw_db_with_path;
-use reth_e2e_test_utils::node::NodeTestContext;
-use reth_node_builder::{EngineNodeLauncher, Node, NodeBuilder, NodeConfig};
-use reth_node_core::args::{DatadirArgs, RpcServerArgs};
-use reth_provider::providers::BlockchainProvider;
-use reth_tasks::Runtime;
+use jsonrpsee::core::client::ClientT;
+
+/// Pre-funded Hardhat account from `assets/genesis.json` (holds ~1M ETH).
+const FUNDED: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+/// Second pre-funded Hardhat account.
+const FUNDED_2: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+/// An address with no genesis allocation — balance is zero.
+const UNFUNDED: &str = "0x000000000000000000000000000000000000dEaD";
 
 /// `eth_estimateGas` for a simple transfer returns >= 21000 via RPC.
 ///
 /// No block mining needed — estimateGas works against genesis state.
 #[tokio::test]
 async fn estimate_gas_simple_transfer_via_rpc() {
-    reth_tracing::init_test_tracing();
+    with_mantle_rpc_client(|client| async move {
+        let gas: U256 = client
+            .request(
+                "eth_estimateGas",
+                vec![serde_json::json!({
+                    "from": FUNDED,
+                    "to": FUNDED_2,
+                    "value": "0x1"
+                })],
+            )
+            .await
+            .expect("eth_estimateGas should succeed");
 
-    let chain_spec = mantle_test_chain_spec();
+        assert!(gas >= U256::from(21_000u64), "expected >= 21000, got {gas}");
+    })
+    .await;
+}
 
-    let mut config: NodeConfig<reth_optimism_chainspec::OpChainSpec> = NodeConfig::new(chain_spec)
-        .with_unused_ports()
-        .with_datadir_args(DatadirArgs {
-            datadir: reth_db::test_utils::tempdir_path().into(),
-            ..Default::default()
-        })
-        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
-    config.network.discovery.discv5_port = 0;
-    config.network.discovery.discv5_port_ipv6 = 0;
+/// A value transfer the caller cannot afford is rejected up front with an
+/// "insufficient funds for transfer" error — this is the `value > balance` pre-check
+/// in the Mantle `estimate_gas_at` override (op-geth `state_transition.go` clause 6),
+/// and it does not require a mined L1-info block.
+#[tokio::test]
+async fn estimate_gas_value_exceeds_balance_rejected_via_rpc() {
+    with_mantle_rpc_client(|client| async move {
+        // UNFUNDED has zero balance; any non-zero value exceeds it.
+        let res: Result<U256, _> = client
+            .request(
+                "eth_estimateGas",
+                vec![serde_json::json!({
+                    "from": UNFUNDED,
+                    "to": FUNDED,
+                    "value": "0xde0b6b3a7640000" // 1 ETH
+                })],
+            )
+            .await;
 
-    let db = create_test_rw_db_with_path(
-        config
-            .datadir
-            .datadir
-            .unwrap_or_chain_default(config.chain.chain(), config.datadir.clone())
-            .db(),
-    );
-    let runtime = Runtime::test();
-    let node_handle = NodeBuilder::new(config)
-        .with_database(db)
-        .with_types_and_provider::<MantleNode, BlockchainProvider<_>>()
-        .with_components(MantleNode::default().components())
-        .with_add_ons(MantleNode::default().add_ons())
-        .launch_with_fn(|builder| {
-            let launcher = EngineNodeLauncher::new(
-                runtime.clone(),
-                builder.config.datadir(),
-                Default::default(),
-            );
-            builder.launch_with(launcher)
-        })
-        .await
-        .expect("MantleNode failed to launch");
+        let err =
+            res.expect_err("estimateGas must reject a value transfer from a zero-balance account");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("insufficient funds for transfer"),
+            "expected 'insufficient funds for transfer', got: {msg}"
+        );
+    })
+    .await;
+}
 
-    // Don't mine — estimateGas works on genesis state directly.
-    let _node = NodeTestContext::new(node_handle.node, mantle_payload_attributes).await.unwrap();
+/// With no value and no fee specified, an unfunded account still gets an estimate:
+/// the `value > balance` pre-check is skipped (value == 0) and the Arsia funds
+/// preflight is skipped (no fee → `fee_cap == 0`, mirroring op-geth's
+/// `GasEstimationWithSkipCheckBalanceMode`). Documents the skip gates.
+#[tokio::test]
+async fn estimate_gas_zero_value_unfunded_skips_funds_check_via_rpc() {
+    with_mantle_rpc_client(|client| async move {
+        let gas: U256 = client
+            .request(
+                "eth_estimateGas",
+                vec![serde_json::json!({
+                    "from": UNFUNDED,
+                    "to": FUNDED
+                })],
+            )
+            .await
+            .expect("estimateGas with no value/fee should skip the funds check and succeed");
 
-    let client = _node.inner.rpc_server_handle().http_client().expect("HTTP RPC enabled");
+        assert!(gas >= U256::from(21_000u64), "expected >= 21000, got {gas}");
+    })
+    .await;
+}
 
-    // Pre-funded Hardhat account from genesis.json
-    let from = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+/// `eth_estimateTotalFee` is reachable on an Arsia chain and returns a structurally
+/// valid total (L2 gas + L1 data + operator fee). Shares the estimateGas path with
+/// `eth_estimateGas` (op-geth `DoEstimateGas`), so the funds-preflight wiring is
+/// exercised transitively.
+#[tokio::test]
+async fn estimate_total_fee_simple_transfer_via_rpc() {
+    with_mantle_rpc_client(|client| async move {
+        let total: U256 = client
+            .request(
+                "eth_estimateTotalFee",
+                // positional params: [request, block?] — block defaults to latest.
+                vec![serde_json::json!({
+                    "from": FUNDED,
+                    "to": FUNDED_2,
+                    "value": "0x1"
+                })],
+            )
+            .await
+            .expect("eth_estimateTotalFee should succeed on an Arsia chain");
 
-    use jsonrpsee::core::client::ClientT;
-    let gas: U256 = client
-        .request(
-            "eth_estimateGas",
-            vec![serde_json::json!({
-                "from": from,
-                "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
-                "value": "0x1"
-            })],
-        )
-        .await
-        .expect("eth_estimateGas should succeed");
-
-    assert!(gas >= U256::from(21_000u64), "expected >= 21000, got {gas}");
+        // L2 gas estimate is always >= 21000; the total fee is gas * price + L1 + operator,
+        // so it must be representable (no panic / overflow). On the zero-base-fee genesis
+        // state the numeric value may be small, so we only assert the call shape here —
+        // numerical parity with geth lives in tests/rpc_compat.
+        let _ = total;
+    })
+    .await;
 }

--- a/mantle-reth/crates/integration-tests/tests/helpers.rs
+++ b/mantle-reth/crates/integration-tests/tests/helpers.rs
@@ -3,9 +3,18 @@
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B64, B256};
 use alloy_rpc_types_engine::PayloadAttributes;
+use jsonrpsee::http_client::HttpClient;
+use mantle_reth_cli::node::MantleNode;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use reth_chainspec::EthChainSpec;
+use reth_db::test_utils::create_test_rw_db_with_path;
+use reth_e2e_test_utils::node::NodeTestContext;
+use reth_node_builder::{EngineNodeLauncher, Node, NodeBuilder, NodeConfig};
+use reth_node_core::args::{DatadirArgs, RpcServerArgs};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::payload::OpPayloadAttrs;
+use reth_provider::providers::BlockchainProvider;
+use reth_tasks::Runtime;
 use std::sync::Arc;
 
 /// Build a Mantle-flavoured `OpChainSpec` from the test genesis JSON.
@@ -41,4 +50,59 @@ pub(crate) fn mantle_payload_attributes(timestamp: u64) -> OpPayloadAttrs {
         eip_1559_params: Some(B64::ZERO),
         min_base_fee: Some(0),
     })
+}
+
+/// Boot a Mantle test node (all hardforks active at genesis) with HTTP-RPC enabled and
+/// run `test` against its RPC client.
+///
+/// The node is kept alive for the duration of the closure and torn down afterwards, so
+/// callers don't have to repeat the (verbose) node-launch boilerplate. estimateGas /
+/// estimateTotalFee work against genesis state, so no block needs to be mined.
+pub(crate) async fn with_mantle_rpc_client<F, Fut>(test: F)
+where
+    F: FnOnce(HttpClient) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = mantle_test_chain_spec();
+
+    let mut config: NodeConfig<OpChainSpec> = NodeConfig::new(chain_spec)
+        .with_unused_ports()
+        .with_datadir_args(DatadirArgs {
+            datadir: reth_db::test_utils::tempdir_path().into(),
+            ..Default::default()
+        })
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+    config.network.discovery.discv5_port = 0;
+    config.network.discovery.discv5_port_ipv6 = 0;
+
+    let db = create_test_rw_db_with_path(
+        config
+            .datadir
+            .datadir
+            .unwrap_or_chain_default(config.chain.chain(), config.datadir.clone())
+            .db(),
+    );
+    let runtime = Runtime::test();
+    let node_handle = NodeBuilder::new(config)
+        .with_database(db)
+        .with_types_and_provider::<MantleNode, BlockchainProvider<_>>()
+        .with_components(MantleNode::default().components())
+        .with_add_ons(MantleNode::default().add_ons())
+        .launch_with_fn(|builder| {
+            let launcher = EngineNodeLauncher::new(
+                runtime.clone(),
+                builder.config.datadir(),
+                Default::default(),
+            );
+            builder.launch_with(launcher)
+        })
+        .await
+        .expect("MantleNode failed to launch");
+
+    let node = NodeTestContext::new(node_handle.node, mantle_payload_attributes).await.unwrap();
+    let client = node.inner.rpc_server_handle().http_client().expect("HTTP RPC enabled");
+
+    test(client).await;
 }

--- a/op-reth/crates/rpc/src/eth/call.rs
+++ b/op-reth/crates/rpc/src/eth/call.rs
@@ -31,16 +31,29 @@ where
         state_override: Option<StateOverride>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
         async move {
-            // [MANTLE] Pre-check: value transfer (geth state_transition.go clause 6).
-            // geth uses target block state (StateAndHeaderByNumberOrHash), not parent state.
+            // [MANTLE] Pre-check: value transfer (op-geth `gasestimator.go` clause 6,
+            // lines 98-105). geth only runs this when a fee cap is set
+            // (`feeCap.BitLen() != 0`, i.e. not `GasEstimationWithSkipCheckBalanceMode`)
+            // and rejects when `value >= balance`. We mirror both the fee gate and the
+            // `>=` comparison, evaluated against the target block state (matching geth's
+            // `StateAndHeaderByNumberOrHash`). Without a fee, upstream `estimate_gas_at`
+            // skips its own `caller_gas_allowance` check too, so this stays gated to avoid
+            // diverging from geth (which returns an estimate rather than erroring).
             if let Some(from) = request.as_ref().from {
                 let value = request.as_ref().value.unwrap_or(U256::ZERO);
+                let fee_cap = U256::from(
+                    request
+                        .as_ref()
+                        .max_fee_per_gas
+                        .unwrap_or(request.as_ref().gas_price.unwrap_or(0)),
+                );
                 if !value.is_zero() &&
+                    !fee_cap.is_zero() &&
                     let Ok(Some(block)) = self.provider().block_by_id(at) &&
                     let Ok(state) = self.provider().state_by_block_id(at)
                 {
                     let balance = state.account_balance(&from).ok().flatten().unwrap_or(U256::ZERO);
-                    if value > balance {
+                    if value >= balance {
                         let hi = request.as_ref().gas.unwrap_or(block.header().gas_limit());
                         return Err(reth_rpc_eth_types::EthApiError::InvalidParams(format!(
                             "failed with {hi} gas: insufficient funds for transfer: address {from}"


### PR DESCRIPTION
## What

Aligns the Mantle `eth_estimateGas` value pre-check with op-geth, and adds unit + integration test coverage for the Arsia gas-estimation funds checks.

## Code fix — `op-reth/crates/rpc/src/eth/call.rs`

The Mantle `estimate_gas_at` override ran its `value`-vs-balance pre-check **unconditionally** (whenever `value != 0`) using a strict `>`. op-geth `gasestimator.go` clause 6 (lines 98–105) instead:
- **gates** the value check on `feeCap != 0` (skipped in `GasEstimationWithSkipCheckBalanceMode`), and
- rejects on **`value >= balance`**.

Upstream reth likewise only runs `caller_gas_allowance` when `gas_price > 0` (`estimate.rs:124`), so the ungated Mantle check diverged from geth when **no fee** was supplied (geth returns an estimate; reth errored). Fix: gate the pre-check on a non-zero fee cap and switch `>` → `>=`.

> The **post-estimate** `mantle_arsia_check_funds` (total = `gas*feeCap + L1 + operator + value`, strict `>`) already matches op-geth `gasestimator.go:267` and is unchanged — this PR adds its missing tests.

## Tests

**Unit** — `mantle-reth/crates/eth-api/src/lib.rs` (`mantle_arsia_check_funds`, +4):
- strict `total > balance` boundary (`value == balance` passes)
- operator constant-only fee (`scalar = 0`)
- all components combined (L2 + operator + value) exact ±1 wei boundary
- saturating math at `u64::MAX` / `U256::MAX` (no overflow panic)

**Integration** — `mantle-reth/crates/integration-tests/tests/gas_estimation.rs` (live RPC against a booted `MantleNode`):
- `value >= balance` **with a fee** rejected with `"insufficient funds for transfer"` (the gated pre-check)
- zero value + no fee skips the funds check (fee gate closed)
- `eth_estimateTotalFee` smoke (shares the estimate path)

Also refactors the node-launch boilerplate into a shared `with_mantle_rpc_client` helper.

## Test plan

- [x] `cargo test -p mantle-reth-eth-api --lib` → **11 passed** (7 existing + 4 new)
- [x] `cargo test -p mantle-reth-integration-tests --test it gas_estimation` → **4 passed**
- [x] `cargo +nightly fmt --check` clean on changed files