### PR TITLE
fix(txpool): reserve L1-info deposit gas in Mantle gas-limit check

### DIFF
--- a/mantle-reth/crates/integration-tests/tests/gas_limit.rs
+++ b/mantle-reth/crates/integration-tests/tests/gas_limit.rs
@@ -1,0 +1,117 @@
+//! TxPool gas-limit reservation: a non-deposit transaction may use at most
+//! `block_gas_limit - MANTLE_L1_INFO_GAS_OVERHEAD` gas, matching op-geth's `EffectiveGasLimit`.
+//!
+//! Every L2 block carries an L1-info deposit that consumes part of the block gas, so a tx asking
+//! for the full block gas limit could never be included. op-geth rejects such a tx at admission;
+//! this test pins the same behaviour for op-reth's tx-pool.
+
+use crate::helpers::{mantle_payload_attributes, mantle_test_chain_spec};
+use alloy_network::eip2718::Encodable2718;
+use alloy_primitives::{B256, Bytes, TxKind, U256};
+use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
+use mantle_reth_cli::node::MantleNode;
+use reth_chainspec::EthChainSpec;
+use reth_db::test_utils::create_test_rw_db_with_path;
+use reth_e2e_test_utils::{
+    node::NodeTestContext, transaction::TransactionTestContext, wallet::Wallet,
+};
+use reth_node_builder::{EngineNodeLauncher, Node, NodeBuilder, NodeConfig};
+use reth_node_core::args::DatadirArgs;
+use reth_provider::providers::BlockchainProvider;
+use reth_tasks::Runtime;
+
+/// Test genesis `gasLimit` (`assets/genesis.json` → `0x1c9c380`).
+const BLOCK_GAS_LIMIT: u64 = 30_000_000;
+/// Must match `op-reth/crates/txpool/src/validator.rs::MANTLE_L1_INFO_GAS_OVERHEAD`.
+const L1_INFO_GAS_OVERHEAD: u64 = 1_000_000;
+/// Largest gas a normal tx may request and still be admitted: 29M on a 30M block.
+const EFFECTIVE_CAP: u64 = BLOCK_GAS_LIMIT - L1_INFO_GAS_OVERHEAD;
+
+async fn signed_raw_tx(chain_id: u64, wallet: &Wallet, nonce: u64, gas: u64) -> Bytes {
+    let request = TransactionRequest {
+        chain_id: Some(chain_id),
+        nonce: Some(nonce),
+        to: Some(TxKind::Call(Default::default())),
+        gas: Some(gas),
+        max_fee_per_gas: Some(20e9 as u128),
+        max_priority_fee_per_gas: Some(20e9 as u128),
+        value: Some(U256::ZERO),
+        input: TransactionInput::default(),
+        ..Default::default()
+    };
+    TransactionTestContext::sign_tx(wallet.inner.clone(), request).await.encoded_2718().into()
+}
+
+/// A tx whose gas exceeds `block_gas_limit - L1_INFO_GAS_OVERHEAD` is rejected by the pool;
+/// a tx at or below that effective cap is accepted.
+#[tokio::test]
+async fn txpool_reserves_l1_info_gas_overhead() {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = mantle_test_chain_spec();
+    let chain_id = chain_spec.chain().id();
+    let wallet = Wallet::default().with_chain_id(chain_id);
+
+    let mut config: NodeConfig<reth_optimism_chainspec::OpChainSpec> =
+        NodeConfig::new(chain_spec).with_unused_ports().with_datadir_args(DatadirArgs {
+            datadir: reth_db::test_utils::tempdir_path().into(),
+            ..Default::default()
+        });
+    config.network.discovery.discv5_port = 0;
+    config.network.discovery.discv5_port_ipv6 = 0;
+
+    let db = create_test_rw_db_with_path(
+        config
+            .datadir
+            .datadir
+            .unwrap_or_chain_default(config.chain.chain(), config.datadir.clone())
+            .db(),
+    );
+    let runtime = Runtime::test();
+    let node_handle = NodeBuilder::new(config)
+        .with_database(db)
+        .with_types_and_provider::<MantleNode, BlockchainProvider<_>>()
+        .with_components(MantleNode::default().components())
+        .with_add_ons(MantleNode::default().add_ons())
+        .launch_with_fn(|builder| {
+            let launcher = EngineNodeLauncher::new(
+                runtime.clone(),
+                builder.config.datadir(),
+                Default::default(),
+            );
+            builder.launch_with(launcher)
+        })
+        .await
+        .expect("MantleNode failed to launch");
+
+    let node = NodeTestContext::new(node_handle.node, mantle_payload_attributes).await.unwrap();
+
+    // Over the effective cap → rejected at admission (would otherwise be stuck forever).
+    // Both gas values are <= the full block gas limit, so upstream's `gas > block_gas_limit`
+    // check (strict `>`) would NOT reject them — only the Mantle L1-info reservation does.
+    // The pool's `ExceedsGasLimit` surfaces through the RPC layer as "exceeds block gas limit".
+    // A rejected tx does not consume the sender's nonce, so all use nonce 0.
+    for (label, gas) in
+        [("block gas limit", BLOCK_GAS_LIMIT), ("effective cap + 1", EFFECTIVE_CAP + 1)]
+    {
+        let raw = signed_raw_tx(chain_id, &wallet, 0, gas).await;
+        let err = node.rpc.inject_tx(raw).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exceeds block gas limit"),
+            "{label} ({gas}) should be rejected by the L1-info gas reservation, got: {msg}"
+        );
+    }
+
+    // Exactly at the effective cap → accepted.
+    let raw = signed_raw_tx(chain_id, &wallet, 0, EFFECTIVE_CAP).await;
+    let hash: B256 =
+        node.rpc.inject_tx(raw).await.expect("tx at the effective cap should be accepted");
+    assert_ne!(hash, B256::ZERO);
+
+    // Comfortably below the cap → accepted.
+    let raw = signed_raw_tx(chain_id, &wallet, 1, EFFECTIVE_CAP - 1_000_000).await;
+    let hash: B256 =
+        node.rpc.inject_tx(raw).await.expect("tx below the effective cap should be accepted");
+    assert_ne!(hash, B256::ZERO);
+}

--- a/mantle-reth/crates/integration-tests/tests/gas_limit.rs
+++ b/mantle-reth/crates/integration-tests/tests/gas_limit.rs
@@ -1,4 +1,4 @@
-//! TxPool gas-limit reservation: a non-deposit transaction may use at most
+//! Tx-pool gas-limit reservation: a non-deposit transaction may use at most
 //! `block_gas_limit - MANTLE_L1_INFO_GAS_OVERHEAD` gas, matching op-geth's `EffectiveGasLimit`.
 //!
 //! Every L2 block carries an L1-info deposit that consumes part of the block gas, so a tx asking

--- a/mantle-reth/crates/integration-tests/tests/main.rs
+++ b/mantle-reth/crates/integration-tests/tests/main.rs
@@ -4,4 +4,5 @@ mod helpers;
 
 mod fill_transaction;
 mod gas_estimation;
+mod gas_limit;
 mod txpool;

--- a/op-reth/crates/txpool/src/validator.rs
+++ b/op-reth/crates/txpool/src/validator.rs
@@ -23,6 +23,23 @@ use std::sync::{
 /// The timeout for cross-chain transaction validation against the supervisor/interop-filter.
 pub(crate) const CHECK_ACCESS_LIST_TIMEOUT_SECS: u64 = 7200;
 
+/// Gas reserved on every L2 block for the always-present L1-info deposit transaction.
+///
+/// Mirrors op-geth `l1InfoGasOverhead` (`core/txpool/validation.go`): the L1-info deposit is
+/// injected into every L2 block, so a non-deposit transaction can never consume the full block
+/// gas limit. Upstream reth caps the tx-pool gas limit at the full block limit, so without this
+/// reservation a transaction with gas in `(block_gas_limit - overhead, block_gas_limit]` would be
+/// admitted to the pool yet could never be included — it would sit there until it expires. We
+/// reserve the overhead so such transactions are rejected up front, as geth does.
+pub(crate) const MANTLE_L1_INFO_GAS_OVERHEAD: u64 = 1_000_000;
+
+/// Effective per-transaction gas limit for the Mantle tx-pool: the block gas limit minus the
+/// L1-info deposit reservation. Port of the Optimism branch of op-geth's `EffectiveGasLimit`
+/// (`core/txpool/validation.go`). Saturates to `0` when the block limit is below the reservation.
+pub(crate) fn mantle_effective_gas_limit(block_gas_limit: u64) -> u64 {
+    block_gas_limit.saturating_sub(MANTLE_L1_INFO_GAS_OVERHEAD)
+}
+
 /// Tracks additional infos for the current block.
 #[derive(Debug, Default)]
 pub struct OpL1BlockInfo {
@@ -220,6 +237,22 @@ where
             _ => {}
         }
 
+        // [MANTLE] Reserve gas for the L1-info deposit present in every L2 block, matching
+        // op-geth `EffectiveGasLimit` (`core/txpool/validation.go`). Upstream reth caps at the
+        // full block gas limit, so without this a tx with gas_limit in
+        // `(block_gas_limit - overhead, block_gas_limit]` would be admitted but could never be
+        // included (the L1-info deposit always consumes part of the block), leaving it stuck.
+        if self.chain_spec().is_mantle() {
+            let gas_limit = transaction.gas_limit();
+            let effective_limit = mantle_effective_gas_limit(self.inner.block_gas_limit());
+            if gas_limit > effective_limit {
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    InvalidPoolTransactionError::ExceedsGasLimit(gas_limit, effective_limit),
+                );
+            }
+        }
+
         let outcome = self.inner.validate_one_with_state(origin, transaction, state);
 
         self.apply_op_checks(outcome)
@@ -339,5 +372,28 @@ impl OpForkTracker {
     /// Returns `true` if Interop fork is activated.
     pub(crate) fn is_interop_activated(&self) -> bool {
         self.interop.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MANTLE_L1_INFO_GAS_OVERHEAD, mantle_effective_gas_limit};
+
+    #[test]
+    fn effective_gas_limit_subtracts_l1_info_overhead() {
+        // 30M block → 29M effective; 60M block → 59M (matches op-geth EffectiveGasLimit).
+        assert_eq!(
+            mantle_effective_gas_limit(30_000_000),
+            30_000_000 - MANTLE_L1_INFO_GAS_OVERHEAD
+        );
+        assert_eq!(mantle_effective_gas_limit(60_000_000), 59_000_000);
+    }
+
+    #[test]
+    fn effective_gas_limit_saturates_below_overhead() {
+        // A block limit at or below the reservation leaves no room for user txs.
+        assert_eq!(mantle_effective_gas_limit(MANTLE_L1_INFO_GAS_OVERHEAD), 0);
+        assert_eq!(mantle_effective_gas_limit(500_000), 0);
+        assert_eq!(mantle_effective_gas_limit(0), 0);
     }
 }


### PR DESCRIPTION
## Problem

op-reth's tx-pool inherits upstream reth's gas-limit check, which caps a transaction at the **full block gas limit** (`transaction-pool/src/validate/eth.rs`: `transaction_gas_limit > block_gas_limit`).

op-geth instead reserves gas for the L1-info deposit that is present in **every** L2 block (`core/txpool/validation.go`):
- `l1InfoGasOverhead = 1_000_000`
- `EffectiveGasLimit()` subtracts it for Optimism chains
- admission rejects `tx.Gas() > head.GasLimit - 1_000_000` → `ErrGasLimit`

Because reth lacks this reservation, a transaction with gas in `(block_gas_limit - 1_000_000, block_gas_limit]` is **admitted to the pool but can never be included** — the L1-info deposit always consumes part of the block (`payload/src/builder.rs`: `cumulative_gas_used + tx_gas_limit > block_gas_limit`), so it sits in the pool until it expires. A wallet broadcasting at the block gas limit gets a tx that never confirms, instead of an immediate rejection.

This is a tx-pool **admission** divergence, not a consensus one.

## Fix

In `OpTransactionValidator::validate_one_with_state`, for Mantle, reject transactions whose gas exceeds `block_gas_limit - MANTLE_L1_INFO_GAS_OVERHEAD` (`mantle_effective_gas_limit`, the port of op-geth's `EffectiveGasLimit`), with `ExceedsGasLimit`. This runs before delegating to the inner upstream validator.

The other op-geth per-tx gas caps are already symmetric and need no change:
- **EIP-7825 `MaxTxGas`** (`1<<24`): gated `!IsOptimism()` in geth at all three sites (admission `validation.go:128`, pool reset `legacypool.go:1307`, builder `miner/worker.go:766`) → disabled on Mantle; reth's `tx_gas_limit_cap` is likewise no-cap on Mantle.
- **per-tx pool cap**: reth's `max_tx_gas_limit` is `None` by default; geth has no equivalent tx-pool admission cap.

## Tests

**Unit** — `op-reth/crates/txpool/src/validator.rs`:
- `mantle_effective_gas_limit` subtracts the overhead (30M→29M, 60M→59M)
- saturates to 0 when the block limit ≤ overhead

**Integration** — `mantle-reth/crates/integration-tests/tests/gas_limit.rs` (live node, 30M genesis block → 29M effective cap):
- tx at block gas limit (30M) and at effective+1 (29,000,001) → rejected (both ≤ full block limit, so only the reservation rejects them)
- tx at the effective cap (29M) and below (28M) → accepted

## Test plan

- [x] `cargo test -p reth-optimism-txpool --lib effective_gas_limit` → 2 passed
- [x] `cargo test -p mantle-reth-integration-tests --test it gas_limit` → 1 passed
- [x] `cargo +nightly fmt --check` clean on changed files