### PR TITLE
fix(consensus): disable EIP-7825 tx gas cap for OP-stack chains (defensive)

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -148,7 +148,7 @@ pub fn validate_block_pre_execution<B, ChainSpec>(
 ) -> Result<(), ConsensusError>
 where
     B: Block,
-    ChainSpec: EthereumHardforks,
+    ChainSpec: EthChainSpec + EthereumHardforks,
 {
     post_merge_hardfork_fields(block, chain_spec)?;
 
@@ -156,8 +156,14 @@ where
     if let Err(error) = block.ensure_transaction_root_valid() {
         return Err(ConsensusError::BodyTransactionRootDiff(error.into()))
     }
-    // EIP-7825 validation
-    if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) {
+    // EIP-7825 validation.
+    //
+    // Disabled on OP-stack chains, matching op-geth (`!IsOptimism()` in
+    // `core/txpool/validation.go`) and the per-tx-pool check: L2 block gas limits far exceed
+    // the 16,777,216 per-tx cap. Defense-in-depth — op-reth's `OpBeaconConsensus` reimplements
+    // pre-execution validation and never calls this function, but gating here ensures the cap
+    // stays disabled for Optimism even if this path is ever wired up.
+    if !chain_spec.is_optimism() && chain_spec.is_osaka_active_at_timestamp(block.timestamp()) {
         for tx in block.body().transactions() {
             if tx.gas_limit() > MAX_TX_GAS_LIMIT_OSAKA {
                 return Err(TxGasLimitTooHighErr {


### PR DESCRIPTION
## Context

EIP-7825 introduces a per-transaction gas cap (`MAX_TX_GAS_LIMIT_OSAKA` = 2²⁴ = **16,777,216**) once Osaka activates. op-geth **disables it on all OP-stack chains** — gated on `!IsOptimism()` at every site (`core/txpool/validation.go:128`, `legacypool.go:1307`, `miner/worker.go:766`) — because L2 block gas limits far exceed 16.77M (Mantle's is `0x4000000000000`), so a fixed per-tx cap would reject otherwise-valid L2 transactions. Mantle activates Osaka via **Limb**.

reth has the cap hard-coded in two places, gated only on Osaka activation (no `!IsOptimism()`):
1. tx-pool admission (`crates/transaction-pool/src/validate/eth.rs`)
2. consensus pre-execution (`crates/consensus/common/src/validation.rs`)

## What this PR changes

Gate the **consensus** check (`validate_block_pre_execution`) on `!chain_spec.is_optimism()` (overridden to `true` by `OpChainSpec`, so it covers Mantle), adding the `EthChainSpec` bound already used by sibling validators in the module.

### Why only the consensus check, and why it's defensive

This is the **block-import / sync path**, which is what matters for a verifier. On Mantle mainnet reth runs as a **verifier** (the sequencer is the op-reth v2.2.1 line, where EIP-7825 is already disabled via the revm `[MANTLE]` cfg patch).

Today this generic function is **not** on op-reth's import path — `OpBeaconConsensus::validate_block_pre_execution` (`crates/optimism/consensus/src/lib.rs`) reimplements pre-execution validation (ommers / tx-root / canyon / jovian / isthmus) and never calls it. So a Mantle verifier already imports a >16.77M-gas block fine. This change is **defensive / future-proofing**: if op-reth is ever wired to the generic path, the cap stays disabled for Optimism, preventing a verifier from rejecting a valid block that op-geth produced (which would be a sync / consensus split).

### Why the tx-pool check is intentionally left unchanged

The tx-pool check only gates **local mempool admission** (the sequencer role), not block import — it does not affect a verifier's sync, even if a >16.77M-gas transaction appears in a block. Mantle mainnet runs reth as a verifier, and the sequencer line (op-reth v2.2.1) already disables the cap. So no tx-pool change is needed on this (arsia) line.

## Test plan

- [x] `cargo test -p reth-consensus-common --lib validation` (compiles with the added `EthChainSpec` bound; existing validation tests pass)
- [x] `cargo +nightly fmt --check` clean

> Note: the OP-skip can't be unit-tested in `reth-consensus-common` (low-level crate; cannot depend on `reth-optimism-chainspec`, and the base `ChainSpec::is_optimism()` is hard-coded `false`). The Optimism behavior is covered by the chain-spec override (`OpChainSpec::is_optimism() == true`) plus the gate logic.