### PR TITLE
ci: add sccache to cut redundant recompiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  # sccache caches individual rustc compilations across runs — including the cfg(test)
+  # builds and git-dependency crates that Swatinem's target/ cache misses. Today ~250
+  # upstream op-reth/revm/alloy crates recompile on every PR *despite* a Swatinem cache
+  # hit (they rebuild because cargo's per-run fingerprints differ); sccache replays their
+  # cached object output instead. Requires incremental compilation to be off.
+  CARGO_INCREMENTAL: "0"
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   lint:
@@ -28,12 +36,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      # Install sccache before any cargo step so RUSTC_WRAPPER resolves.
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - uses: extractions/setup-just@v2
       - run: just fmt
       - run: just clippy
+      - run: sccache --show-stats
 
   test:
     name: test
@@ -41,18 +52,17 @@ jobs:
     timeout-minutes: 60
     # Tests compile a lot of code; do not fail the build on warnings here
     # (warnings are already gated by the clippy job above).
-    # Disable incremental compilation: it gives little benefit on CI's mostly
-    # cold builds and avoids stale-cache rustc ICEs on large trait graphs.
     env:
       RUSTFLAGS: ""
-      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94"
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - uses: extractions/setup-just@v2
       - run: just test-ci
+      - run: sccache --show-stats


### PR DESCRIPTION
## Why

#76's test job took ~25min. Investigating the log:
```
Swatinem: Cache restored successfully (~2225 MB)   ← cache HIT, not a miss
…then 332 crates Compiling (258 = revm/alloy/op-reth/reth-*)
```
So it's **not** a cache miss — Swatinem restores the dep sources/artifacts, but ~250 upstream crates still recompile every run (cfg(test) builds + git-dep fingerprints that target/ caching doesn't match). That recompile is ~16min of the 25.

## What

Enable **sccache** (GHA cache backend) on both jobs. sccache caches each rustc invocation keyed on its inputs, so the upstream crates — whose sources rarely change — are replayed from cache instead of rebuilt.

- `RUSTC_WRAPPER=sccache`, `SCCACHE_GHA_ENABLED=true`, `CARGO_INCREMENTAL=0` (already set), `mozilla-actions/sccache-action@v0.0.10` installed before any cargo step.
- Kept Swatinem for cargo-home (registry/git source) caching.
- `sccache --show-stats` printed per job to track hit rate.

## Expectations / caveats

- **First run is cold** (populates the sccache GHA cache); the speedup shows from the **second run onward** — judge by run #2+, not this PR's first CI.
- GHA cache is capped at 10GB/repo (Swatinem + sccache share it); if eviction thrashes, drop Swatinem's target/ caching and keep only cargo-home.
- Independent of #76 (ci.yml only) — orthogonal to #76's justfile/test changes.

## Validate
Watch `sccache --show-stats` across consecutive runs: cache hit rate should climb and the test-job compile time should drop materially on warm runs.