### PR TITLE
fix(rpc): gate eth_estimateGas allowance by maxFeePerGas, not effective price

### DIFF
--- a/mantle-reth/crates/integration-tests/tests/gas_estimation.rs
+++ b/mantle-reth/crates/integration-tests/tests/gas_estimation.rs
@@ -124,3 +124,79 @@ async fn estimate_total_fee_simple_transfer_via_rpc() {
     })
     .await;
 }
+
+/// [MANTLE] Balance-gating divisor: a low-balance caller passing a `maxFeePerGas` far
+/// above the base fee must be rejected with `gas required exceeds allowance`, matching
+/// op-geth `gasestimator.go` (`allowance = (balance - value) / feeCap`). Upstream reth
+/// divides by the *effective* gas price `min(maxFee, base + tip)`, which over-estimates
+/// the allowance and would let the estimate through. `stateOverride` pins the caller
+/// balance so the check is deterministic. With `data` present this is not a basic
+/// transfer, so it exercises the divisor directly (not the short-circuit).
+#[tokio::test]
+async fn estimate_gas_low_balance_high_maxfee_data_exceeds_allowance_via_rpc() {
+    with_mantle_rpc_client(|client| async move {
+        // balance 1e14 wei (0.0001 ETH), maxFeePerGas 1e12 (1000 gwei)
+        // → allowance = 1e14 / 1e12 = 100 < intrinsic gas, so estimation must reject.
+        let res: Result<U256, _> = client
+            .request(
+                "eth_estimateGas",
+                vec![
+                    serde_json::json!({
+                        "from": FUNDED,
+                        "to": FUNDED_2,
+                        "data": "0xa9059cbb0000000000000000000000003333333333333333333333333333333333333333000000000000000000000000000000000000000000000000000000000000000a",
+                        "maxFeePerGas": "0xe8d4a51000",
+                        "maxPriorityFeePerGas": "0x3b9aca00"
+                    }),
+                    serde_json::json!("latest"),
+                    serde_json::json!({ FUNDED: { "balance": "0x5af3107a4000" } }),
+                ],
+            )
+            .await;
+
+        let err = res
+            .expect_err("estimateGas must reject when balance / maxFeePerGas is below intrinsic gas");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("gas required exceeds allowance"),
+            "expected 'gas required exceeds allowance', got: {msg}"
+        );
+    })
+    .await;
+}
+
+/// [MANTLE] Balance-gating short-circuit guard: the same low-balance / high-`maxFeePerGas`
+/// scenario for a *basic transfer* (no calldata) must also be rejected with `gas required
+/// exceeds allowance`. Upstream reth would return `21000` via the basic-transfer
+/// short-circuit (estimation disables fee charging, so that path never checks the maxFee
+/// balance); the Mantle guard skips the short-circuit when the allowance is below 21000.
+#[tokio::test]
+async fn estimate_gas_low_balance_high_maxfee_transfer_exceeds_allowance_via_rpc() {
+    with_mantle_rpc_client(|client| async move {
+        let res: Result<U256, _> = client
+            .request(
+                "eth_estimateGas",
+                vec![
+                    serde_json::json!({
+                        "from": FUNDED,
+                        "to": FUNDED_2,
+                        "maxFeePerGas": "0xe8d4a51000",
+                        "maxPriorityFeePerGas": "0x3b9aca00"
+                    }),
+                    serde_json::json!("latest"),
+                    serde_json::json!({ FUNDED: { "balance": "0x5af3107a4000" } }),
+                ],
+            )
+            .await;
+
+        let err = res.expect_err(
+            "basic-transfer estimateGas must not short-circuit to 21000 when it is unaffordable",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("gas required exceeds allowance"),
+            "expected 'gas required exceeds allowance', got: {msg}"
+        );
+    })
+    .await;
+}

--- a/op-reth/crates/rpc/src/eth/call.rs
+++ b/op-reth/crates/rpc/src/eth/call.rs
@@ -1,17 +1,38 @@
 use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockId;
-use alloy_primitives::U256;
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{TxKind, U256};
 use alloy_rpc_types_eth::state::StateOverride;
-use reth_chainspec::ChainSpecProvider;
+use reth_chainspec::{ChainSpecProvider, MIN_TRANSACTION_GAS};
+use reth_evm::{ConfigureEvm, Evm, EvmEnvFor, TransactionEnvMut, overrides::apply_state_overrides};
 use reth_optimism_evm::extract_l1_info;
 use reth_optimism_forks::OpHardforks;
 use reth_primitives_traits::Block;
-use reth_rpc_eth_api::{
-    FromEvmError, RpcConvert, RpcTxReq,
-    helpers::{Call, EthCall, estimate::EstimateCall},
+use reth_revm::{
+    database::{EvmStateProvider, StateProviderDatabase},
+    db::State,
 };
+use reth_rpc_eth_api::{
+    AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError, RpcConvert, RpcTxReq,
+    helpers::{
+        Call, EthCall,
+        estimate::{EstimateCall, update_estimated_gas_range},
+    },
+};
+use reth_rpc_eth_types::{
+    RpcInvalidTransactionError,
+    error::api::{FromEvmHalt, FromRevert},
+};
+use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO};
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+use revm::{
+    Database,
+    context::Block as _,
+    context_interface::{Cfg as _, Transaction, result::ExecutionResult},
+    primitives::KECCAK_EMPTY,
+};
+use tracing::trace;
 
 impl<N, Rpc> EthCall for OpEthApi<N, Rpc>
 where
@@ -123,6 +144,273 @@ where
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
 {
+    /// [MANTLE] Overrides upstream `estimate_gas_with` to gate the caller balance
+    /// allowance by `maxFeePerGas` (matching op-geth `gasestimator.go`) instead of the
+    /// effective gas price used by upstream reth, and to only take the basic-transfer
+    /// short-circuit when that allowance permits it.
+    ///
+    /// Everything else is a verbatim copy of
+    /// `reth_rpc_eth_api::helpers::estimate::EstimateCall::estimate_gas_with` (reth rev
+    /// 88505c7). The two `[MANTLE]` blocks below are the only deviations. See
+    /// `docs/op-reth-estimategas-fix-and-upstream.md` for the rationale.
+    fn estimate_gas_with<S>(
+        &self,
+        mut evm_env: EvmEnvFor<Self::Evm>,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        state: S,
+        state_override: Option<StateOverride>,
+    ) -> Result<U256, Self::Error>
+    where
+        S: EvmStateProvider,
+    {
+        evm_env.cfg_env.disable_eip3607 = true;
+        evm_env.cfg_env.disable_base_fee = true;
+        evm_env.cfg_env.disable_fee_charge = true;
+
+        // set nonce to None so that the correct nonce is chosen by the EVM
+        request.as_mut().take_nonce();
+
+        // [MANTLE] Capture the fee cap (maxFeePerGas, falling back to gasPrice) before
+        // `create_txn_env` consumes `request`. op-geth gates the balance allowance by this
+        // value (`gasestimator.go` L109, `feeCap = call.GasFeeCap`), whereas upstream reth
+        // divides by `tx_env.gas_price()`, which the RPC path collapses to the effective
+        // gas price `min(maxFee, base + tip)` via `CallFees::ensure_fees`.
+        let fee_cap: u128 =
+            request.as_ref().max_fee_per_gas.unwrap_or(request.as_ref().gas_price.unwrap_or(0));
+
+        // Keep a copy of gas related request values
+        let tx_request_gas_limit = request.as_ref().gas_limit();
+        let tx_request_gas_price = request.as_ref().gas_price();
+        // the gas limit of the corresponding block
+        let max_gas_limit = evm_env
+            .cfg_env
+            .tx_gas_limit_cap
+            // If EIP-8037 is enabled, the transaction gas limit cap is not applicable
+            .filter(|_| !evm_env.cfg_env.is_amsterdam_eip8037_enabled())
+            .map_or_else(
+                || evm_env.block_env.gas_limit(),
+                |cap| cap.min(evm_env.block_env.gas_limit()),
+            );
+
+        // Determine the highest possible gas limit, considering both the request's specified
+        // limit and the block's limit.
+        let mut highest_gas_limit = tx_request_gas_limit
+            .map(|mut tx_gas_limit| {
+                if max_gas_limit < tx_gas_limit {
+                    tx_gas_limit = max_gas_limit;
+                }
+                tx_gas_limit
+            })
+            .unwrap_or(max_gas_limit);
+
+        // Configure the evm env
+        let mut db = State::builder().with_database(StateProviderDatabase::new(state)).build();
+
+        // Apply any state overrides if specified.
+        if let Some(state_override) = state_override {
+            apply_state_overrides(state_override, &mut db).map_err(Self::Error::from_eth_err)?;
+        }
+
+        let mut tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
+
+        // Check if this is a basic transfer (no input data to account with no code)
+        let is_basic_transfer = if tx_env.input().is_empty() &&
+            let TxKind::Call(to) = tx_env.kind()
+        {
+            match db.database.basic_account(&to) {
+                Ok(Some(account)) => {
+                    account.bytecode_hash.is_none() || account.bytecode_hash == Some(KECCAK_EMPTY)
+                }
+                _ => true,
+            }
+        } else {
+            false
+        };
+
+        // [MANTLE] Compute the caller's balance allowance using the *maxFeePerGas*
+        // (`fee_cap`), matching op-geth `gasestimator.go:109`
+        // (`allowance = (balance - value) / feeCap`). Upstream reth calls
+        // `caller_gas_allowance`, which divides by `tx_env.gas_price()` — the effective
+        // gas price `min(maxFee, base + tip)` on the RPC path — over-estimating the
+        // allowance when `maxFee >> effective`. The execution `tx_env` keeps its effective
+        // `gas_price`, so the GASPRICE opcode value is unchanged.
+        //
+        // `balance_allowance` is tracked separately from `highest_gas_limit` (which may also
+        // be lowered by a user-supplied `gas`) so the basic-transfer short-circuit below can
+        // gate purely on affordability, mirroring geth's `execute(21000)` buyGas check. When
+        // no fee is set (`fee_cap == 0`), geth estimates in skip-balance mode
+        // (`GasEstimationWithSkipCheckBalanceMode`), so the allowance is unbounded.
+        let balance_allowance: u64 = if fee_cap > 0 {
+            // Read the balance through the `State` overlay (`db.basic`, as
+            // `caller_gas_allowance` does), NOT `db.database` — the latter is the raw
+            // provider and bypasses `stateOverride` balances applied above.
+            let balance = db
+                .basic(tx_env.caller())
+                .map_err(Self::Error::from_eth_err)?
+                .map(|acc| acc.balance)
+                .unwrap_or_default();
+            balance
+                .saturating_sub(tx_env.value())
+                .checked_div(U256::from(fee_cap))
+                .unwrap_or_default()
+                .saturating_to()
+        } else {
+            u64::MAX
+        };
+        if fee_cap > 0 {
+            // [MANTLE] Explicit fee: gate by maxFeePerGas (`balance_allowance`).
+            highest_gas_limit = highest_gas_limit.min(balance_allowance);
+        } else if tx_env.gas_price() > 0 {
+            // No explicit fee: preserve upstream effective-based gating verbatim, so the
+            // no-fee path (message and value) is unchanged from stock reth.
+            highest_gas_limit =
+                highest_gas_limit.min(self.caller_gas_allowance(&mut db, &evm_env, &tx_env)?);
+        }
+
+        // If the provided gas limit is less than computed cap, use that
+        tx_env.set_gas_limit(tx_env.gas_limit().min(highest_gas_limit));
+
+        // Create EVM instance once and reuse it throughout the entire estimation process
+        let mut evm = self.evm_config().evm_with_env(&mut db, evm_env);
+
+        // [MANTLE] Only take the 21000 basic-transfer short-circuit when the caller can
+        // actually afford 21000 gas at `maxFeePerGas` (`balance_allowance`). Upstream reth
+        // returns `MIN_TRANSACTION_GAS` here unconditionally: estimation disables fee
+        // charging (`disable_fee_charge`), so the short-circuit execution never checks the
+        // maxFee balance and would hand back an unaffordable estimate. geth's equivalent
+        // `execute(21000)` fails `buyGas` when the balance can't cover `21000 * maxFee` and
+        // falls through to `gas required exceeds allowance`. We gate on `balance_allowance`
+        // (not `highest_gas_limit`, which a low user-supplied `gas` can also reduce — geth
+        // ignores a `gas` below the intrinsic cost, so gating on it would wrongly reject
+        // those requests).
+        if is_basic_transfer && balance_allowance >= MIN_TRANSACTION_GAS {
+            // If the tx is a simple transfer (call to an account with no code) we can
+            // shortcircuit. But simply returning `MIN_TRANSACTION_GAS` is dangerous because
+            // there might be additional field combos that bump the price up, so we try
+            // executing the function with the minimum gas limit to make sure.
+            let mut min_tx_env = tx_env.clone();
+            min_tx_env.set_gas_limit(MIN_TRANSACTION_GAS);
+
+            // Reuse the same EVM instance
+            if let Ok(res) = evm.transact(min_tx_env).map_err(Self::Error::from_evm_err) &&
+                res.result.is_success()
+            {
+                return Ok(U256::from(MIN_TRANSACTION_GAS));
+            }
+        }
+
+        trace!(target: "rpc::eth::estimate", ?tx_env, gas_limit = tx_env.gas_limit(), is_basic_transfer, "Starting gas estimation");
+
+        // Execute the transaction with the highest possible gas limit.
+        let mut res = match evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err) {
+            Err(err)
+                if err.is_gas_too_high() &&
+                    (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
+            {
+                return Self::map_out_of_gas_err(&mut evm, tx_env, max_gas_limit);
+            }
+            Err(err) if err.is_gas_too_low() => {
+                // This failed because the configured gas cost of the tx was lower than what
+                // actually consumed by the tx. This can happen if the request provided fee
+                // values manually and the resulting gas cost exceeds the sender's allowance,
+                // so we return the appropriate error here
+                return Err(RpcInvalidTransactionError::GasRequiredExceedsAllowance {
+                    gas_limit: tx_env.gas_limit(),
+                }
+                .into_eth_err());
+            }
+            // Propagate other results (successful or other errors).
+            ethres => ethres?,
+        };
+
+        let gas_refund = match res.result {
+            ExecutionResult::Success { gas, .. } => gas.final_refunded(),
+            ExecutionResult::Halt { reason, .. } => {
+                return Err(Self::Error::from_evm_halt(reason, tx_env.gas_limit()));
+            }
+            ExecutionResult::Revert { output, .. } => {
+                return if tx_request_gas_limit.is_some() || tx_request_gas_price.is_some() {
+                    Self::map_out_of_gas_err(&mut evm, tx_env, max_gas_limit)
+                } else {
+                    Err(Self::Error::from_revert(output))
+                };
+            }
+        };
+
+        // At this point we know the call succeeded but want to find the _best_ (lowest) gas
+        // the transaction succeeds with. We find this by doing a binary search over the
+        // possible range.
+
+        // we know the tx succeeded with the configured gas limit, so we can use that as the
+        // highest, in case we applied a gas cap due to caller allowance above
+        highest_gas_limit = tx_env.gas_limit();
+
+        // NOTE: this is the gas the transaction used, which is less than the transaction
+        // requires to succeed.
+        let mut gas_used = res.result.tx_gas_used();
+        // the lowest value is capped by the gas used by the unconstrained transaction
+        let mut lowest_gas_limit = gas_used.saturating_sub(1);
+
+        // As stated in Geth, there is a good chance that the transaction will pass if we set
+        // the gas limit to the execution gas used plus the gas refund, so we check this first
+        let optimistic_gas_limit = (gas_used + gas_refund + CALL_STIPEND_GAS) * 64 / 63;
+        if optimistic_gas_limit < highest_gas_limit {
+            let mut optimistic_tx_env = tx_env.clone();
+            optimistic_tx_env.set_gas_limit(optimistic_gas_limit);
+            res = evm.transact(optimistic_tx_env).map_err(Self::Error::from_evm_err)?;
+            gas_used = res.result.tx_gas_used();
+            update_estimated_gas_range(
+                res.result,
+                optimistic_gas_limit,
+                &mut highest_gas_limit,
+                &mut lowest_gas_limit,
+            )?;
+        };
+
+        // Pick a point that's close to the estimated gas
+        let mut mid_gas_limit = std::cmp::min(
+            gas_used * 3,
+            ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64,
+        );
+
+        trace!(target: "rpc::eth::estimate", ?highest_gas_limit, ?lowest_gas_limit, ?mid_gas_limit, "Starting binary search for gas");
+
+        // Binary search narrows the range to find the minimum gas limit needed for the
+        // transaction to succeed.
+        while lowest_gas_limit + 1 < highest_gas_limit {
+            // An estimation error is allowed once the current gas limit range used in the
+            // binary search is small enough (less than 1.5% of the highest gas limit)
+            let ratio = (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64);
+            if ratio < ESTIMATE_GAS_ERROR_RATIO {
+                break;
+            };
+
+            let mut mid_tx_env = tx_env.clone();
+            mid_tx_env.set_gas_limit(mid_gas_limit);
+
+            match evm.transact(mid_tx_env).map_err(Self::Error::from_evm_err) {
+                Err(err) if err.is_gas_too_high() => {
+                    highest_gas_limit = mid_gas_limit;
+                }
+                Err(err) if err.is_gas_too_low() => {
+                    lowest_gas_limit = mid_gas_limit;
+                }
+                ethres => {
+                    res = ethres?;
+                    update_estimated_gas_range(
+                        res.result,
+                        mid_gas_limit,
+                        &mut highest_gas_limit,
+                        &mut lowest_gas_limit,
+                    )?;
+                }
+            }
+
+            mid_gas_limit = ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64;
+        }
+
+        Ok(U256::from(highest_gas_limit))
+    }
 }
 
 impl<N, Rpc> Call for OpEthApi<N, Rpc>


### PR DESCRIPTION
## Problem

`eth_estimateGas` caps the searched gas limit by what the caller can afford:
`allowance = (balance - value) / gasPrice`. op-geth divides by **`maxFeePerGas`**
(`eth/gasestimator/gasestimator.go`), but reth divides by `tx_env.gas_price()`,
which the RPC path collapses to the **effective** price `min(maxFee, base + tip)`
via `CallFees::ensure_fees`.

When `maxFee >> baseFee` and the sender is low on funds, reth over-estimates the
allowance and returns a gas estimate (or the 21000 basic-transfer short-circuit)
that the caller **cannot actually submit** at that `maxFee` — reth's own tx
validation (`revm` `max_balance_spending`) requires `balance >= gas_limit * maxFee`.
So `eth_estimateGas` and transaction submission are internally inconsistent, and
reth diverges from op-geth.

Reproduction (low balance via `stateOverride`, high `maxFeePerGas`):

| request | op-geth | reth (before) | reth (after) |
|---|---|---|---|
| ERC20 transfer, bal 1e14, maxFee 1e12 | `gas required exceeds allowance (100)` (-32000) | returns an estimate / `-32602` | `gas required exceeds allowance (100)` (-32000) |
| value→EOA, same | `gas required exceeds allowance (100)` | returns `21000` | `gas required exceeds allowance (100)` |

This is the same area as #14212 (C-bug); the fix there (#14232) aligned the error
message/code but kept the effective-price divisor.

## Fix

Override `estimate_gas_with` for `OpEthApi` — a verbatim copy of the upstream
default (reth-88505c7) with two `[MANTLE]` deviations:

1. **Gate the balance allowance by `maxFeePerGas` (`fee_cap`)**, computed inline from
   the override-aware `db.basic` balance. The execution `tx_env` keeps its effective
   `gas_price`, so the `GASPRICE` opcode value during simulation is unchanged.
2. **Guard the basic-transfer short-circuit on affordability**
   (`balance_allowance >= MIN_TRANSACTION_GAS`), not `highest_gas_limit`. Estimation
   sets `disable_fee_charge = true`, so the short-circuit's `execute(21000)` never
   checks the maxFee balance and would hand back an unaffordable `21000`. Gating on
   `highest_gas_limit` would wrongly reject requests with a user-supplied `gas` below
   the intrinsic cost (which geth ignores) — so we gate purely on affordability.

No-fee requests (`fee_cap == 0`) keep the upstream gating unchanged.

## Tests

- Node-spawning integration tests in `gas_estimation.rs`: low-balance + high
  `maxFeePerGas`, for both a contract call (data) and a basic transfer, assert
  `gas required exceeds allowance`.
- Cross-checked against op-geth via the repo's `tests/rpc_compat` harness
  (`eth_estimateGas_full.json`, added two `balance_gate` cases): both now return an
  identical `gas required exceeds allowance (N)` / `-32000`; the `eth_call` and
  `boundary_gas` suites remain green.

## Upstream

The same two-line change applies to `paradigmxyz/reth`
`crates/rpc/rpc-eth-api/src/helpers/estimate.rs`; a follow-up upstream PR is planned.
Refs: paradigmxyz/reth#14212, paradigmxyz/reth#14232.