### PR TITLE
fix(txpool): enforce --rpc.txfeecap for all RPC-submitted txs (op-geth parity)

### DIFF
--- a/mantle-reth/crates/cli/src/node.rs
+++ b/mantle-reth/crates/cli/src/node.rs
@@ -127,7 +127,10 @@ where
                 .map(|validator| {
                     let op_validator = reth_optimism_txpool::OpTransactionValidator::new(validator)
                         .require_l1_data_gas_fee(!ctx.config().dev.dev);
-                    MantleTransactionValidator::new(op_validator)
+                    // Enforce `--rpc.txfeecap` for all RPC-submitted txs (op-geth parity);
+                    // see MantleTransactionValidator docs for why this can't live in the
+                    // inner (upstream) validator. Same config source as `set_tx_fee_cap` above.
+                    MantleTransactionValidator::new(op_validator, ctx.config().rpc.rpc_tx_fee_cap)
                 });
 
         let final_pool_config = self.pool_config_overrides.apply(ctx.pool_config());

--- a/mantle-reth/crates/cli/src/txpool.rs
+++ b/mantle-reth/crates/cli/src/txpool.rs
@@ -12,8 +12,8 @@ use alloy_op_hardforks::is_mantle_meta_tx;
 use reth_optimism_txpool::OpPooledTx;
 use reth_primitives_traits::SealedBlock;
 use reth_transaction_pool::{
-    EthPoolTransaction, TransactionOrigin, TransactionValidationOutcome, TransactionValidator,
-    error::InvalidPoolTransactionError,
+    EthPoolTransaction, PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
+    TransactionValidator, error::InvalidPoolTransactionError,
 };
 use std::any::Any;
 
@@ -51,17 +51,32 @@ impl reth_transaction_pool::error::PoolTransactionError for UnprotectedTxDisable
 ///
 /// - EIP-155 unprotected legacy transactions (type 0 without `chain_id`)
 /// - Legacy `MetaTx` transactions (disabled since `MantleEverest`)
+/// - Transactions whose max fee (`gas_limit * max_fee_per_gas`) exceeds the configured
+///   RPC tx fee cap (`--rpc.txfeecap`), matching op-geth's `RPCTxFeeCap` behavior
 ///
 /// All other transactions are forwarded to the inner validator unchanged.
+///
+/// # Why the fee cap lives here
+///
+/// The inner (upstream) validator only enforces `--rpc.txfeecap` for transactions it
+/// considers *local* (`is_local`). Since upstream now submits `eth_sendRawTransaction`
+/// with [`TransactionOrigin::External`], that gate is never hit for RPC-submitted
+/// transactions, so `--rpc.txfeecap` is effectively dead for them. op-geth instead
+/// enforces the cap unconditionally at the RPC submission layer. To keep op-reth's
+/// user-facing behavior aligned with op-geth we enforce the cap here, for all origins.
 #[derive(Debug, Clone)]
 pub struct MantleTransactionValidator<V> {
     inner: V,
+    /// Max transaction fee in wei allowed via RPC (`--rpc.txfeecap`). `0` disables the cap.
+    rpc_tx_fee_cap: u128,
 }
 
 impl<V> MantleTransactionValidator<V> {
     /// Creates a new [`MantleTransactionValidator`] wrapping the given inner validator.
-    pub const fn new(inner: V) -> Self {
-        Self { inner }
+    ///
+    /// `rpc_tx_fee_cap` is the configured `--rpc.txfeecap` value in wei (`0` disables it).
+    pub const fn new(inner: V, rpc_tx_fee_cap: u128) -> Self {
+        Self { inner, rpc_tx_fee_cap }
     }
 
     /// Returns a reference to the inner validator.
@@ -97,6 +112,26 @@ where
                 transaction,
                 InvalidPoolTransactionError::Other(Box::new(MetaTxDisabled)),
             );
+        }
+
+        // [MANTLE] Enforce the RPC tx fee cap (`--rpc.txfeecap`) for ALL origins.
+        //
+        // Upstream only enforces this cap for `is_local` transactions, but
+        // `eth_sendRawTransaction` now submits as `External`, so the upstream gate never
+        // fires for RPC-submitted transactions. op-geth enforces the cap unconditionally
+        // at the RPC layer; we mirror that here so op-reth stays aligned with op-geth.
+        // `0` disables the cap (same convention as op-geth / upstream reth).
+        if self.rpc_tx_fee_cap != 0 {
+            let max_tx_fee_wei = transaction.cost().saturating_sub(transaction.value());
+            if max_tx_fee_wei > self.rpc_tx_fee_cap {
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    InvalidPoolTransactionError::ExceedsFeeCap {
+                        max_tx_fee_wei: max_tx_fee_wei.saturating_to(),
+                        tx_fee_cap_wei: self.rpc_tx_fee_cap,
+                    },
+                );
+            }
         }
 
         self.inner.validate_transaction(origin, transaction).await


### PR DESCRIPTION
## Problem

On the v2.2.1 line, `--rpc.txfeecap` is effectively dead for `eth_sendRawTransaction`.

Upstream now submits `eth_sendRawTransaction` with `TransactionOrigin::External`
(`rpc-eth-api/.../helpers/transaction.rs`, `send_transaction(TransactionOrigin::External, ...)`),
but the inner validator only enforces the cap for `is_local` transactions
(`transaction-pool/.../validate/eth.rs`, `if is_local { ... tx_fee_cap ... }`).
Since `is_local(External) == false`, the cap is never checked for RPC-submitted txs.

Result — a user-visible divergence from op-geth (which enforces `RPCTxFeeCap`
unconditionally at the RPC layer):

- 0-balance account, `fee = 6000 MNT` (> the configured 5000 MNT cap):
  - **op-geth** → `tx fee (6000.00 ether) exceeds the configured cap (5000.00 ether)`
  - **op-reth** → `insufficient funds ...` (cap never fired; only fails later on balance)

On the old v1.9.3 line the op override hardcoded `TransactionOrigin::Local`, so the cap
did fire — this regressed when the submission origin changed to `External`.

## Fix

Enforce the cap in `MantleTransactionValidator` for **all origins** (`0` disables),
mirroring op-geth. The value comes from the same config already used for the inner
validator's `set_tx_fee_cap` (`ctx.config().rpc.rpc_tx_fee_cap`).

Enforcing at the pool-validator layer means p2p-received txs are also capped (they are
`External` too and indistinguishable from RPC submissions at this layer). This is
acceptable: a >5000 MNT-fee p2p tx is not a realistic case, and a pool rejection only
affects mempool relay — it does not affect block execution / sync / consensus.

(A "faithful geth" variant that caps only RPC submissions would have to live at the RPC
submission layer, but `rpc_tx_fee_cap` is not reachable there without invasively threading
`NodeConfig` into the eth-api builder — so the pool-layer approach was chosen.)

## Changes

- `mantle-reth/crates/cli/src/txpool.rs`: add `rpc_tx_fee_cap: u128` to
  `MantleTransactionValidator` (+ constructor arg); reject `cost - value > cap` with
  `InvalidPoolTransactionError::ExceedsFeeCap` before delegating to the inner validator;
  import `PoolTransaction` (needed for `cost()`).
- `mantle-reth/crates/cli/src/node.rs`: pass `ctx.config().rpc.rpc_tx_fee_cap` into the
  validator.

## Testing

- `just pr` (fmt + `clippy --all-features -D warnings` + unit/integration tests + doctests):
  **green** (exit 0, no clippy warnings, all `test result: ok`).
- Pre-fix behavior reproduced live against a deployed v2.2.1 sequencer (see Problem).
- Post-fix: a `fee > cap` `eth_sendRawTransaction` should return `ExceedsFeeCap` (not
  `insufficient funds`); `fee <= cap` still hits the balance check.

## Upstream note

The underlying inconsistency is upstream: `eth_sendRawTransaction` moved to `External`
while the tx fee cap stayed `is_local`-gated, making `--rpc.txfeecap` dead for raw txs.
Worth a follow-up upstream issue.
