### PR TITLE
feat(txpool): reserve L1 + operator fee in the pool's cumulative balance check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10058,7 +10058,6 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=88505c7fcbfdebfd3b56d88c86b62e950043c6c4#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,14 @@ lto = "thin"
 # ==================== WORKSPACE DEPENDENCIES ====================
 [workspace.dependencies]
 
+# Transitive deps pulled in by the vendored `patches/reth-transaction-pool` (versions match
+# paradigmxyz/reth rev 88505c7). Remove once the extra_balance_cost hook lands upstream and the
+# patch is dropped.
+bitflags = "2.4"
+imbl = "7"
+rustc-hash = { version = "2.0", default-features = false }
+smallvec = "1"
+
 # ==================== OP-RETH INTERNAL CRATES ====================
 op-reth = { path = "op-reth/bin/" }
 reth-optimism-chainspec = { path = "op-reth/crates/chainspec/", default-features = false }
@@ -403,7 +411,7 @@ url = "2.5"
 [patch."https://github.com/paradigmxyz/reth"]
 reth-trie-common = { path = "patches/reth-trie-common" }
 # reth-rpc = { path = "patches/reth-rpc" }
-# reth-transaction-pool = { path = "patches/reth-transaction-pool" }
+reth-transaction-pool = { path = "patches/reth-transaction-pool" }
 
 # ==================== [patch.crates-io] — Force all deps to use our git versions ====================
 # Without this, paradigmxyz/reth uses crates.io revm while we use git revm,

--- a/op-reth/crates/txpool/src/transaction.rs
+++ b/op-reth/crates/txpool/src/transaction.rs
@@ -54,6 +54,9 @@ pub struct OpPooledTransaction<
 
     /// Cached EIP-2718 encoded bytes of the transaction, lazily computed.
     encoded_2718: OnceLock<Bytes>,
+
+    /// L1 data fee + operator fee overlay, stashed by the validator (see `extra_balance_cost`).
+    extra_balance_cost: U256,
 }
 
 impl<Cons: SignedTransaction, Pooled> OpPooledTransaction<Cons, Pooled> {
@@ -66,6 +69,7 @@ impl<Cons: SignedTransaction, Pooled> OpPooledTransaction<Cons, Pooled> {
             interop: Arc::new(AtomicU64::new(NO_INTEROP_TX)),
             _pd: core::marker::PhantomData,
             encoded_2718: Default::default(),
+            extra_balance_cost: U256::ZERO,
         }
     }
 
@@ -166,6 +170,10 @@ where
 
     fn cost(&self) -> &U256 {
         &self.inner.cost
+    }
+
+    fn extra_balance_cost(&self) -> U256 {
+        self.extra_balance_cost
     }
 
     fn encoded_length(&self) -> usize {
@@ -299,6 +307,9 @@ pub trait OpPooledTx:
 {
     /// Returns the EIP-2718 encoded bytes of the transaction.
     fn encoded_2718(&self) -> Cow<'_, Bytes>;
+
+    /// Stashes the L1 + operator fee overlay (surfaced via `PoolTransaction::extra_balance_cost`).
+    fn set_extra_balance_cost(&mut self, cost: U256);
 }
 
 impl<Cons, Pooled> OpPooledTx for OpPooledTransaction<Cons, Pooled>
@@ -309,6 +320,10 @@ where
 {
     fn encoded_2718(&self) -> Cow<'_, Bytes> {
         Cow::Borrowed(self.encoded_2718())
+    }
+
+    fn set_extra_balance_cost(&mut self, cost: U256) {
+        self.extra_balance_cost = cost;
     }
 }
 
@@ -364,5 +379,38 @@ mod tests {
             _ => panic!("Expected invalid transaction"),
         };
         assert_eq!(err.to_string(), "transaction type not supported");
+    }
+
+    #[test]
+    fn extra_balance_cost_roundtrip() {
+        use crate::OpPooledTx;
+        use reth_transaction_pool::PoolTransaction;
+
+        let signer = Default::default();
+        let deposit_tx = TxDeposit {
+            source_hash: Default::default(),
+            from: signer,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 0,
+            is_system_transaction: false,
+            eth_value: 0,
+            input: Default::default(),
+            eth_tx_value: None,
+        };
+        let signed_tx: OpTransactionSigned = deposit_tx.into();
+        let signed_recovered = Recovered::new_unchecked(signed_tx, signer);
+        let len = signed_recovered.encode_2718_len();
+        let mut tx: OpPooledTransaction = OpPooledTransaction::new(signed_recovered, len);
+
+        // Default: no overlay.
+        assert_eq!(tx.extra_balance_cost(), U256::ZERO);
+        let intrinsic = *tx.cost();
+
+        // Stashing the overlay is reflected by extra_balance_cost() and leaves cost() intrinsic.
+        tx.set_extra_balance_cost(U256::from(12_345u64));
+        assert_eq!(tx.extra_balance_cost(), U256::from(12_345u64));
+        assert_eq!(*tx.cost(), intrinsic, "cost() must stay intrinsic");
     }
 }

--- a/op-reth/crates/txpool/src/validator.rs
+++ b/op-reth/crates/txpool/src/validator.rs
@@ -14,7 +14,7 @@ use reth_primitives_traits::{
 use reth_storage_api::{AccountInfoReader, BlockReaderIdExt, StateProviderFactory};
 use reth_transaction_pool::{
     EthPoolTransaction, EthTransactionValidator, TransactionOrigin, TransactionValidationOutcome,
-    TransactionValidator, error::InvalidPoolTransactionError,
+    TransactionValidator, error::InvalidPoolTransactionError, validate::ValidTransaction,
 };
 use std::sync::{
     Arc,
@@ -354,10 +354,15 @@ where
                 );
             }
 
+            // [MANTLE] Stash the overlay so the pool's cumulative accounting reserves it too. OP
+            // txs are never EIP-4844, so the sidecar-less `Valid` variant is correct.
+            let mut tx = valid_tx.into_transaction();
+            tx.set_extra_balance_cost(cost_addition);
+
             return TransactionValidationOutcome::Valid {
                 balance,
                 state_nonce,
-                transaction: valid_tx,
+                transaction: ValidTransaction::Valid(tx),
                 propagate,
                 bytecode_hash,
                 authorities,

--- a/patches/reth-transaction-pool/Cargo.toml
+++ b/patches/reth-transaction-pool/Cargo.toml
@@ -1,0 +1,131 @@
+[package]
+name = "reth-transaction-pool"
+version = "2.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Transaction pool implementation. [MANTLE PATCH: PoolTransaction::extra_balance_cost hook]"
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-chain-state.workspace = true
+reth-ethereum-primitives.workspace = true
+reth-chainspec.workspace = true
+reth-eth-wire-types.workspace = true
+reth-evm.workspace = true
+reth-evm-ethereum.workspace = true
+reth-primitives-traits.workspace = true
+reth-execution-types.workspace = true
+reth-fs-util.workspace = true
+reth-storage-api.workspace = true
+reth-tasks.workspace = true
+revm.workspace = true
+revm-interpreter.workspace = true
+revm-primitives.workspace = true
+
+# ethereum
+alloy-eips = { workspace = true, features = ["kzg"] }
+alloy-primitives.workspace = true
+alloy-rlp.workspace = true
+alloy-consensus = { workspace = true, features = ["kzg"] }
+
+# async/futures
+futures-util.workspace = true
+parking_lot.workspace = true
+pin-project.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream.workspace = true
+
+# metrics
+reth-metrics.workspace = true
+metrics.workspace = true
+
+# misc
+aquamarine.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+rustc-hash.workspace = true
+schnellru.workspace = true
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json.workspace = true
+bitflags.workspace = true
+auto_impl.workspace = true
+imbl.workspace = true
+smallvec.workspace = true
+
+# testing
+rand = { workspace = true, optional = true }
+paste = { workspace = true, optional = true }
+proptest = { workspace = true, optional = true }
+proptest-arbitrary-interop = { workspace = true, optional = true }
+
+[dev-dependencies]
+reth-provider = { workspace = true, features = ["test-utils"] }
+reth-tracing.workspace = true
+alloy-primitives = { workspace = true, features = ["rand"] }
+paste.workspace = true
+rand.workspace = true
+proptest.workspace = true
+proptest-arbitrary-interop.workspace = true
+assert_matches.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+futures.workspace = true
+
+[features]
+serde = [
+    "reth-execution-types/serde",
+    "reth-eth-wire-types/serde",
+    "alloy-consensus/serde",
+    "alloy-eips/serde",
+    "alloy-primitives/serde",
+    "bitflags/serde",
+    "imbl/serde",
+    "parking_lot/serde",
+    "rand?/serde",
+    "smallvec/serde",
+    "revm-interpreter/serde",
+    "revm-primitives/serde",
+    "reth-primitives-traits/serde",
+    "reth-ethereum-primitives/serde",
+    "reth-chain-state/serde",
+    "reth-storage-api/serde",
+    "revm/serde",
+]
+test-utils = [
+    "rand",
+    "paste",
+    "serde",
+    "reth-chain-state/test-utils",
+    "reth-chainspec/test-utils",
+    "reth-provider/test-utils",
+    "reth-primitives-traits/test-utils",
+    "reth-ethereum-primitives/test-utils",
+    "alloy-primitives/rand",
+    "reth-evm/test-utils",
+    "reth-evm-ethereum/test-utils",
+    "reth-tasks/test-utils",
+]
+arbitrary = [
+    "proptest",
+    "proptest-arbitrary-interop",
+    "imbl/arbitrary",
+    "reth-chainspec/arbitrary",
+    "reth-eth-wire-types/arbitrary",
+    "alloy-consensus/arbitrary",
+    "alloy-eips/arbitrary",
+    "alloy-primitives/arbitrary",
+    "bitflags/arbitrary",
+    "reth-primitives-traits/arbitrary",
+    "smallvec/arbitrary",
+    "revm-interpreter/arbitrary",
+    "reth-ethereum-primitives/arbitrary",
+    "revm-primitives/arbitrary",
+    "revm/arbitrary",
+    "imbl/arbitrary",
+]

--- a/patches/reth-transaction-pool/src/batcher.rs
+++ b/patches/reth-transaction-pool/src/batcher.rs
@@ -1,0 +1,250 @@
+//! Transaction batching for `Pool` insertion for high-throughput scenarios
+//!
+//! This module provides transaction batching logic to reduce lock contention when processing
+//! many concurrent transaction pool insertions.
+
+use crate::{
+    error::PoolError, AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool,
+};
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+use tokio::sync::{mpsc, oneshot};
+
+/// A single batch transaction request
+#[derive(Debug)]
+pub struct BatchTxRequest<T: PoolTransaction> {
+    /// Origin of the transaction (e.g. Local, External)
+    origin: TransactionOrigin,
+    /// Tx to be inserted in to the pool
+    pool_tx: T,
+    /// Channel to send result back to caller
+    response_tx: oneshot::Sender<Result<AddedTransactionOutcome, PoolError>>,
+}
+
+impl<T> BatchTxRequest<T>
+where
+    T: PoolTransaction,
+{
+    /// Create a new batch transaction request
+    pub const fn new(
+        origin: TransactionOrigin,
+        pool_tx: T,
+        response_tx: oneshot::Sender<Result<AddedTransactionOutcome, PoolError>>,
+    ) -> Self {
+        Self { origin, pool_tx, response_tx }
+    }
+}
+
+/// Transaction batch processor that handles batch processing
+#[pin_project]
+#[derive(Debug)]
+pub struct BatchTxProcessor<Pool: TransactionPool> {
+    pool: Pool,
+    max_batch_size: usize,
+    buf: Vec<BatchTxRequest<Pool::Transaction>>,
+    #[pin]
+    request_rx: mpsc::UnboundedReceiver<BatchTxRequest<Pool::Transaction>>,
+}
+
+impl<Pool> BatchTxProcessor<Pool>
+where
+    Pool: TransactionPool + 'static,
+{
+    /// Create a new `BatchTxProcessor`
+    pub fn new(
+        pool: Pool,
+        max_batch_size: usize,
+    ) -> (Self, mpsc::UnboundedSender<BatchTxRequest<Pool::Transaction>>) {
+        let (request_tx, request_rx) = mpsc::unbounded_channel();
+
+        let processor = Self { pool, max_batch_size, buf: Vec::with_capacity(1), request_rx };
+
+        (processor, request_tx)
+    }
+
+    async fn process_request(pool: &Pool, req: BatchTxRequest<Pool::Transaction>) {
+        let BatchTxRequest { origin, pool_tx, response_tx } = req;
+        let pool_result = pool.add_transaction(origin, pool_tx).await;
+        let _ = response_tx.send(pool_result);
+    }
+
+    /// Process a batch of transaction requests with per-transaction origins
+    async fn process_batch(pool: &Pool, batch: Vec<BatchTxRequest<Pool::Transaction>>) {
+        if batch.len() == 1 {
+            Self::process_request(pool, batch.into_iter().next().expect("batch is not empty"))
+                .await;
+            return
+        }
+
+        let (transactions, response_txs): (Vec<_>, Vec<_>) =
+            batch.into_iter().map(|req| ((req.origin, req.pool_tx), req.response_tx)).unzip();
+
+        let pool_results = pool.add_transactions_with_origins(transactions).await;
+        for (response_tx, pool_result) in response_txs.into_iter().zip(pool_results) {
+            let _ = response_tx.send(pool_result);
+        }
+    }
+}
+
+impl<Pool> Future for BatchTxProcessor<Pool>
+where
+    Pool: TransactionPool + 'static,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        loop {
+            // Drain all available requests from the receiver
+            ready!(this.request_rx.poll_recv_many(cx, this.buf, *this.max_batch_size));
+
+            if !this.buf.is_empty() {
+                let batch = std::mem::take(this.buf);
+                let pool = this.pool.clone();
+                tokio::spawn(async move {
+                    Self::process_batch(&pool, batch).await;
+                });
+                this.buf.reserve(1);
+
+                continue;
+            }
+
+            // No requests available, return Pending to wait for more
+            return Poll::Pending;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{testing_pool, MockTransaction};
+    use futures::stream::{FuturesUnordered, StreamExt};
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn test_process_batch() {
+        let pool = testing_pool();
+
+        let mut batch_requests = Vec::new();
+        let mut responses = Vec::new();
+
+        for i in 0..100 {
+            let tx = MockTransaction::legacy().with_nonce(i).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+            batch_requests.push(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx));
+            responses.push(response_rx);
+        }
+
+        BatchTxProcessor::process_batch(&pool, batch_requests).await;
+
+        for response_rx in responses {
+            let result = timeout(Duration::from_millis(5), response_rx)
+                .await
+                .expect("Timeout waiting for response")
+                .expect("Response channel was closed unexpectedly");
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batch_processor() {
+        let pool = testing_pool();
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000);
+
+        // Spawn the processor
+        let handle = tokio::spawn(processor);
+
+        let mut responses = Vec::new();
+
+        for i in 0..50 {
+            let tx = MockTransaction::legacy().with_nonce(i).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+            request_tx
+                .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+                .expect("Could not send batch tx");
+            responses.push(response_rx);
+        }
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        for rx in responses {
+            let result = timeout(Duration::from_millis(10), rx)
+                .await
+                .expect("Timeout waiting for response")
+                .expect("Response channel was closed unexpectedly");
+            assert!(result.is_ok());
+        }
+
+        drop(request_tx);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_add_transaction() {
+        let pool = testing_pool();
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000);
+
+        // Spawn the processor
+        let handle = tokio::spawn(processor);
+
+        let mut results = Vec::new();
+        for i in 0..10 {
+            let tx = MockTransaction::legacy().with_nonce(i).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            let request = BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx);
+            request_tx.send(request).expect("Could not send batch tx");
+            results.push(response_rx);
+        }
+
+        for res in results {
+            let result = timeout(Duration::from_millis(10), res)
+                .await
+                .expect("Timeout waiting for transaction result");
+            assert!(result.is_ok());
+        }
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_max_batch_size() {
+        let pool = testing_pool();
+        let max_batch_size = 10;
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), max_batch_size);
+
+        // Spawn batch processor with threshold
+        let handle = tokio::spawn(processor);
+
+        let mut futures = FuturesUnordered::new();
+        for i in 0..max_batch_size {
+            let tx = MockTransaction::legacy().with_nonce(i as u64).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            let request = BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx);
+            let request_tx_clone = request_tx.clone();
+
+            let tx_fut = async move {
+                request_tx_clone.send(request).expect("Could not send batch tx");
+                response_rx.await.expect("Could not receive batch response")
+            };
+            futures.push(tx_fut);
+        }
+
+        while let Some(result) = timeout(Duration::from_millis(5), futures.next())
+            .await
+            .expect("Timeout waiting for transaction result")
+        {
+            assert!(result.is_ok());
+        }
+
+        handle.abort();
+    }
+}

--- a/patches/reth-transaction-pool/src/blobstore/converter.rs
+++ b/patches/reth-transaction-pool/src/blobstore/converter.rs
@@ -1,0 +1,30 @@
+use alloy_consensus::{BlobTransactionSidecar, EnvKzgSettings};
+use alloy_eips::eip7594::BlobTransactionSidecarEip7594;
+use tokio::sync::Semaphore;
+
+// We allow up to 5 concurrent conversions to avoid excessive memory usage.
+static SEMAPHORE: Semaphore = Semaphore::const_new(5);
+
+/// A simple semaphore-based blob sidecar converter.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct BlobSidecarConverter;
+
+impl BlobSidecarConverter {
+    /// Creates a new blob sidecar converter.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Converts the blob sidecar to the EIP-7594 format.
+    pub async fn convert(
+        &self,
+        sidecar: BlobTransactionSidecar,
+    ) -> Option<BlobTransactionSidecarEip7594> {
+        let _permit = SEMAPHORE.acquire().await.ok()?;
+        tokio::task::spawn_blocking(move || sidecar.try_into_7594(EnvKzgSettings::Default.get()))
+            .await
+            .ok()?
+            .ok()
+    }
+}

--- a/patches/reth-transaction-pool/src/blobstore/disk.rs
+++ b/patches/reth-transaction-pool/src/blobstore/disk.rs
@@ -1,0 +1,1076 @@
+//! A simple diskstore for blobs
+
+use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobStoreSize};
+use alloy_eips::{
+    eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant},
+    eip7840::BlobParams,
+    merge::EPOCH_SLOTS,
+};
+use alloy_primitives::{map::B256Set, TxHash, B128, B256};
+use parking_lot::{Mutex, RwLock};
+use schnellru::{ByLength, LruMap};
+use std::{fmt, fs, io, path::PathBuf, sync::Arc};
+use tracing::{debug, trace};
+
+/// How many [`BlobTransactionSidecarVariant`] to cache in memory.
+pub const DEFAULT_MAX_CACHED_BLOBS: u32 = 100;
+
+/// A cache size heuristic based on the highest blob params
+///
+/// This uses the max blobs per tx and max blobs per block over 16 epochs: `21 * 6 * 512 = 64512`
+/// This should be ~4MB
+const VERSIONED_HASH_TO_TX_HASH_CACHE_SIZE: u64 =
+    BlobParams::bpo2().max_blobs_per_tx * BlobParams::bpo2().max_blob_count * EPOCH_SLOTS * 16;
+
+/// A blob store that stores blob data on disk.
+///
+/// The type uses deferred deletion, meaning that blobs are not immediately deleted from disk, but
+/// it's expected that the maintenance task will call [`BlobStore::cleanup`] to remove the deleted
+/// blobs from disk.
+#[derive(Clone, Debug)]
+pub struct DiskFileBlobStore {
+    inner: Arc<DiskFileBlobStoreInner>,
+}
+
+impl DiskFileBlobStore {
+    /// Opens and initializes a new disk file blob store according to the given options.
+    pub fn open(
+        blob_dir: impl Into<PathBuf>,
+        opts: DiskFileBlobStoreConfig,
+    ) -> Result<Self, DiskFileBlobStoreError> {
+        let blob_dir = blob_dir.into();
+        let DiskFileBlobStoreConfig { max_cached_entries, .. } = opts;
+        let inner = DiskFileBlobStoreInner::new(blob_dir, max_cached_entries);
+
+        // initialize the blob store
+        inner.delete_all()?;
+        inner.create_blob_dir()?;
+
+        Ok(Self { inner: Arc::new(inner) })
+    }
+
+    #[cfg(test)]
+    fn is_cached(&self, tx: &B256) -> bool {
+        self.inner.blob_cache.lock().get(tx).is_some()
+    }
+
+    #[cfg(test)]
+    fn clear_cache(&self) {
+        self.inner.blob_cache.lock().clear()
+    }
+
+    /// Look up EIP-7594 blobs by their versioned hashes.
+    ///
+    /// This returns a result vector with the **same length and order** as the input
+    /// `versioned_hashes`. Each element is `Some(BlobAndProofV2)` if the blob is available, or
+    /// `None` if it is missing or an older sidecar version.
+    ///
+    /// The lookup first scans the in-memory cache and, if not all blobs are found, falls back to
+    /// reading candidate sidecars from disk using the `versioned_hash -> tx_hash` index.
+    fn get_by_versioned_hashes_eip7594(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
+        // we must return the blobs in order but we don't necessarily find them in the requested
+        // order
+        let mut result = vec![None; versioned_hashes.len()];
+        let mut missing_count = result.len();
+        // first scan all cached full sidecars
+        for (_tx_hash, blob_sidecar) in self.inner.blob_cache.lock().iter() {
+            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
+                for (hash_idx, match_result) in
+                    blob_sidecar.match_versioned_hashes(versioned_hashes)
+                {
+                    let slot = &mut result[hash_idx];
+                    if slot.is_none() {
+                        missing_count -= 1;
+                    }
+                    *slot = Some(match_result);
+                }
+            }
+
+            // return early if all blobs are found.
+            if missing_count == 0 {
+                // since versioned_hashes may have duplicates, we double check here
+                if result.iter().all(|blob| blob.is_some()) {
+                    return Ok(result);
+                }
+            }
+        }
+
+        // not all versioned hashes were found, try to look up a matching tx
+        let mut missing_tx_hashes = Vec::new();
+
+        {
+            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
+            for (idx, _) in
+                result.iter().enumerate().filter(|(_, blob_and_proof)| blob_and_proof.is_none())
+            {
+                // this is safe because the result vec has the same len
+                let versioned_hash = versioned_hashes[idx];
+                if let Some(tx_hash) = versioned_to_txhashes.get(&versioned_hash).copied() {
+                    missing_tx_hashes.push(tx_hash);
+                }
+            }
+        }
+
+        // if we have missing blobs, try to read them from disk and try again
+        if !missing_tx_hashes.is_empty() {
+            let blobs_from_disk = self.inner.read_many_decoded(missing_tx_hashes);
+            for (_, blob_sidecar) in blobs_from_disk {
+                if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
+                    for (hash_idx, match_result) in
+                        blob_sidecar.match_versioned_hashes(versioned_hashes)
+                    {
+                        if result[hash_idx].is_none() {
+                            result[hash_idx] = Some(match_result);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Look up EIP-7594 blob cells by their versioned hashes.
+    fn get_by_versioned_hashes_cells_eip7594(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        let cell_mask = BlobCellMask::new(indices_bitarray);
+        let mut result = vec![None; versioned_hashes.len()];
+        let mut missing_count = result.len();
+
+        let cached_blob_sidecars = self
+            .inner
+            .blob_cache
+            .lock()
+            .iter()
+            .map(|(_, blob_sidecar)| Arc::clone(blob_sidecar))
+            .collect::<Vec<_>>();
+        for blob_sidecar in cached_blob_sidecars {
+            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
+                for (hash_idx, match_result) in blob_sidecar
+                    .match_versioned_hashes_cells(versioned_hashes, cell_mask)
+                    .map_err(|err| BlobStoreError::Other(Box::new(err)))?
+                {
+                    let slot = &mut result[hash_idx];
+                    if slot.is_none() {
+                        missing_count -= 1;
+                    }
+                    *slot = Some(match_result);
+                }
+            }
+
+            if missing_count == 0 && result.iter().all(Option::is_some) {
+                return Ok(result)
+            }
+        }
+
+        let mut missing_tx_hashes = Vec::new();
+        {
+            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
+            for (idx, _) in
+                result.iter().enumerate().filter(|(_, cells_and_proofs)| cells_and_proofs.is_none())
+            {
+                let versioned_hash = versioned_hashes[idx];
+                if let Some(tx_hash) = versioned_to_txhashes.get(&versioned_hash).copied() {
+                    missing_tx_hashes.push(tx_hash);
+                }
+            }
+        }
+
+        if !missing_tx_hashes.is_empty() {
+            let blobs_from_disk = self.inner.read_many_decoded(missing_tx_hashes);
+            for (_, blob_sidecar) in blobs_from_disk {
+                if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
+                    for (hash_idx, match_result) in blob_sidecar
+                        .match_versioned_hashes_cells(versioned_hashes, cell_mask)
+                        .map_err(|err| BlobStoreError::Other(Box::new(err)))?
+                    {
+                        if result[hash_idx].is_none() {
+                            result[hash_idx] = Some(match_result);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl BlobStore for DiskFileBlobStore {
+    fn insert(&self, tx: B256, data: BlobTransactionSidecarVariant) -> Result<(), BlobStoreError> {
+        self.inner.insert_one(tx, data)
+    }
+
+    fn insert_all(
+        &self,
+        txs: Vec<(B256, BlobTransactionSidecarVariant)>,
+    ) -> Result<(), BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(())
+        }
+        self.inner.insert_many(txs)
+    }
+
+    fn delete(&self, tx: B256) -> Result<(), BlobStoreError> {
+        if self.inner.contains(tx)? {
+            self.inner.txs_to_delete.write().insert(tx);
+        }
+        Ok(())
+    }
+
+    fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(())
+        }
+        let txs = self.inner.retain_existing(txs)?;
+        self.inner.txs_to_delete.write().extend(txs);
+        Ok(())
+    }
+
+    fn cleanup(&self) -> BlobStoreCleanupStat {
+        let txs_to_delete = std::mem::take(&mut *self.inner.txs_to_delete.write());
+        let mut stat = BlobStoreCleanupStat::default();
+        let mut subsize = 0;
+        debug!(target:"txpool::blob", num_blobs=%txs_to_delete.len(), "Removing blobs from disk");
+        for tx in txs_to_delete {
+            let path = self.inner.blob_disk_file(tx);
+            let filesize = fs::metadata(&path).map_or(0, |meta| meta.len());
+            match fs::remove_file(&path) {
+                Ok(_) => {
+                    stat.delete_succeed += 1;
+                    subsize += filesize;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Already deleted by a concurrent cleanup task
+                    stat.delete_succeed += 1;
+                }
+                Err(e) => {
+                    stat.delete_failed += 1;
+                    let err = DiskFileBlobStoreError::DeleteFile(tx, path, e);
+                    debug!(target:"txpool::blob", %err);
+                }
+            };
+        }
+        self.inner.size_tracker.sub_size(subsize as usize);
+        self.inner.size_tracker.sub_len(stat.delete_succeed);
+        stat
+    }
+
+    fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        self.inner.get_one(tx)
+    }
+
+    fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
+        self.inner.contains(tx)
+    }
+
+    fn get_all(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(Vec::new())
+        }
+        self.inner.get_all(txs)
+    }
+
+    fn get_exact(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(Vec::new())
+        }
+        self.inner.get_exact(txs)
+    }
+
+    fn get_by_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
+        // the response must always be the same len as the request, misses must be None
+        let mut result = vec![None; versioned_hashes.len()];
+
+        // first scan all cached full sidecars
+        for (_tx_hash, blob_sidecar) in self.inner.blob_cache.lock().iter() {
+            if let Some(blob_sidecar) = blob_sidecar.as_eip4844() {
+                for (hash_idx, match_result) in
+                    blob_sidecar.match_versioned_hashes(versioned_hashes)
+                {
+                    result[hash_idx] = Some(match_result);
+                }
+            }
+
+            // return early if all blobs are found.
+            if result.iter().all(|blob| blob.is_some()) {
+                return Ok(result);
+            }
+        }
+
+        // not all versioned hashes were be found, try to look up a matching tx
+
+        let mut missing_tx_hashes = Vec::new();
+
+        {
+            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
+            for (idx, _) in
+                result.iter().enumerate().filter(|(_, blob_and_proof)| blob_and_proof.is_none())
+            {
+                // this is safe because the result vec has the same len
+                let versioned_hash = versioned_hashes[idx];
+                if let Some(tx_hash) = versioned_to_txhashes.get(&versioned_hash).copied() {
+                    missing_tx_hashes.push(tx_hash);
+                }
+            }
+        }
+
+        // if we have missing blobs, try to read them from disk and try again
+        if !missing_tx_hashes.is_empty() {
+            let blobs_from_disk = self.inner.read_many_decoded(missing_tx_hashes);
+            for (_, blob_sidecar) in blobs_from_disk {
+                if let Some(blob_sidecar) = blob_sidecar.as_eip4844() {
+                    for (hash_idx, match_result) in
+                        blob_sidecar.match_versioned_hashes(versioned_hashes)
+                    {
+                        if result[hash_idx].is_none() {
+                            result[hash_idx] = Some(match_result);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    fn get_by_versioned_hashes_v2(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
+        let result = self.get_by_versioned_hashes_eip7594(versioned_hashes)?;
+
+        // only return the blobs if we found all requested versioned hashes
+        if result.iter().all(|blob| blob.is_some()) {
+            Ok(Some(result.into_iter().map(Option::unwrap).collect()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_by_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
+        self.get_by_versioned_hashes_eip7594(versioned_hashes)
+    }
+
+    fn get_by_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, indices_bitarray)
+    }
+
+    fn data_size_hint(&self) -> Option<usize> {
+        Some(self.inner.size_tracker.data_size())
+    }
+
+    fn blobs_len(&self) -> usize {
+        self.inner.size_tracker.blobs_len()
+    }
+}
+
+struct DiskFileBlobStoreInner {
+    blob_dir: PathBuf,
+    blob_cache: Mutex<LruMap<TxHash, Arc<BlobTransactionSidecarVariant>, ByLength>>,
+    size_tracker: BlobStoreSize,
+    file_lock: RwLock<()>,
+    txs_to_delete: RwLock<B256Set>,
+    /// Tracks of known versioned hashes and a transaction they exist in
+    ///
+    /// Note: It is possible that one blob can appear in multiple transactions but this only tracks
+    /// the most recent one.
+    versioned_hashes_to_txhash: Mutex<LruMap<B256, B256>>,
+}
+
+impl DiskFileBlobStoreInner {
+    /// Creates a new empty disk file blob store with the given maximum length of the blob cache.
+    fn new(blob_dir: PathBuf, max_length: u32) -> Self {
+        Self {
+            blob_dir,
+            blob_cache: Mutex::new(LruMap::new(ByLength::new(max_length))),
+            size_tracker: Default::default(),
+            file_lock: Default::default(),
+            txs_to_delete: Default::default(),
+            versioned_hashes_to_txhash: Mutex::new(LruMap::new(ByLength::new(
+                VERSIONED_HASH_TO_TX_HASH_CACHE_SIZE as u32,
+            ))),
+        }
+    }
+
+    /// Creates the directory where blobs will be stored on disk.
+    fn create_blob_dir(&self) -> Result<(), DiskFileBlobStoreError> {
+        debug!(target:"txpool::blob", blob_dir = ?self.blob_dir, "Creating blob store");
+        fs::create_dir_all(&self.blob_dir)
+            .map_err(|e| DiskFileBlobStoreError::Open(self.blob_dir.clone(), e))
+    }
+
+    /// Deletes the entire blob store.
+    fn delete_all(&self) -> Result<(), DiskFileBlobStoreError> {
+        match fs::remove_dir_all(&self.blob_dir) {
+            Ok(_) => {
+                debug!(target:"txpool::blob", blob_dir = ?self.blob_dir, "Removed blob store directory");
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(DiskFileBlobStoreError::Open(self.blob_dir.clone(), err)),
+        }
+        Ok(())
+    }
+
+    /// Ensures blob is in the blob cache and written to the disk.
+    fn insert_one(
+        &self,
+        tx: B256,
+        data: BlobTransactionSidecarVariant,
+    ) -> Result<(), BlobStoreError> {
+        let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
+        data.rlp_encode_fields(&mut buf);
+
+        {
+            // cache the versioned hashes to tx hash
+            let mut map = self.versioned_hashes_to_txhash.lock();
+            data.versioned_hashes().for_each(|hash| {
+                map.insert(hash, tx);
+            });
+        }
+
+        self.blob_cache.lock().insert(tx, Arc::new(data));
+
+        let size = self.write_one_encoded(tx, &buf)?;
+
+        self.size_tracker.add_size(size);
+        self.size_tracker.inc_len(1);
+        Ok(())
+    }
+
+    /// Ensures blobs are in the blob cache and written to the disk.
+    fn insert_many(
+        &self,
+        txs: Vec<(B256, BlobTransactionSidecarVariant)>,
+    ) -> Result<(), BlobStoreError> {
+        let raw = txs
+            .iter()
+            .map(|(tx, data)| {
+                let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
+                data.rlp_encode_fields(&mut buf);
+                (self.blob_disk_file(*tx), buf)
+            })
+            .collect::<Vec<_>>();
+
+        {
+            // cache versioned hashes to tx hash
+            let mut map = self.versioned_hashes_to_txhash.lock();
+            for (tx, data) in &txs {
+                data.versioned_hashes().for_each(|hash| {
+                    map.insert(hash, *tx);
+                });
+            }
+        }
+
+        {
+            // cache blobs
+            let mut cache = self.blob_cache.lock();
+            for (tx, data) in txs {
+                cache.insert(tx, Arc::new(data));
+            }
+        }
+
+        let mut add = 0;
+        let mut num = 0;
+        {
+            let _lock = self.file_lock.write();
+            for (path, data) in raw {
+                if path.exists() {
+                    debug!(target:"txpool::blob", ?path, "Blob already exists");
+                } else if let Err(err) = fs::write(&path, &data) {
+                    debug!(target:"txpool::blob", %err, ?path, "Failed to write blob file");
+                } else {
+                    add += data.len();
+                    num += 1;
+                }
+            }
+        }
+        self.size_tracker.add_size(add);
+        self.size_tracker.inc_len(num);
+
+        Ok(())
+    }
+
+    /// Returns true if the blob for the given transaction hash is in the blob cache or on disk.
+    fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
+        if self.blob_cache.lock().get(&tx).is_some() {
+            return Ok(true)
+        }
+        // we only check if the file exists and assume it's valid
+        Ok(self.blob_disk_file(tx).is_file())
+    }
+
+    /// Returns all the blob transactions which are in the cache or on the disk.
+    fn retain_existing(&self, txs: Vec<B256>) -> Result<Vec<B256>, BlobStoreError> {
+        let (in_cache, not_in_cache): (Vec<B256>, Vec<B256>) = {
+            let mut cache = self.blob_cache.lock();
+            txs.into_iter().partition(|tx| cache.get(tx).is_some())
+        };
+
+        let mut existing = in_cache;
+        for tx in not_in_cache {
+            if self.blob_disk_file(tx).is_file() {
+                existing.push(tx);
+            }
+        }
+
+        Ok(existing)
+    }
+
+    /// Retrieves the blob for the given transaction hash from the blob cache or disk.
+    fn get_one(
+        &self,
+        tx: B256,
+    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        if let Some(blob) = self.blob_cache.lock().get(&tx) {
+            return Ok(Some(blob.clone()))
+        }
+
+        if let Some(blob) = self.read_one(tx)? {
+            let blob_arc = Arc::new(blob);
+            self.blob_cache.lock().insert(tx, blob_arc.clone());
+            return Ok(Some(blob_arc))
+        }
+
+        Ok(None)
+    }
+
+    /// Returns the path to the blob file for the given transaction hash.
+    #[inline]
+    fn blob_disk_file(&self, tx: B256) -> PathBuf {
+        self.blob_dir.join(format!("{tx:x}"))
+    }
+
+    /// Retrieves the blob data for the given transaction hash.
+    #[inline]
+    fn read_one(&self, tx: B256) -> Result<Option<BlobTransactionSidecarVariant>, BlobStoreError> {
+        let path = self.blob_disk_file(tx);
+        let data = {
+            let _lock = self.file_lock.read();
+            match fs::read(&path) {
+                Ok(data) => data,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+                Err(e) => {
+                    return Err(BlobStoreError::Other(Box::new(DiskFileBlobStoreError::ReadFile(
+                        tx, path, e,
+                    ))))
+                }
+            }
+        };
+        BlobTransactionSidecarVariant::rlp_decode_fields(&mut data.as_slice())
+            .map(Some)
+            .map_err(BlobStoreError::DecodeError)
+    }
+
+    /// Returns decoded blobs read from disk.
+    ///
+    /// Only returns sidecars that were found and successfully decoded.
+    fn read_many_decoded(&self, txs: Vec<TxHash>) -> Vec<(TxHash, BlobTransactionSidecarVariant)> {
+        self.read_many_raw(txs)
+            .into_iter()
+            .filter_map(|(tx, data)| {
+                BlobTransactionSidecarVariant::rlp_decode_fields(&mut data.as_slice())
+                    .map(|sidecar| (tx, sidecar))
+                    .ok()
+            })
+            .collect()
+    }
+
+    /// Retrieves the raw blob data for the given transaction hashes.
+    ///
+    /// Only returns the blobs that were found in file.
+    #[inline]
+    fn read_many_raw(&self, txs: Vec<TxHash>) -> Vec<(TxHash, Vec<u8>)> {
+        let mut res = Vec::with_capacity(txs.len());
+        let _lock = self.file_lock.read();
+        for tx in txs {
+            let path = self.blob_disk_file(tx);
+            match fs::read(&path) {
+                Ok(data) => {
+                    res.push((tx, data));
+                }
+                Err(err) => {
+                    debug!(target:"txpool::blob", %err, ?tx, "Failed to read blob file");
+                }
+            };
+        }
+        res
+    }
+
+    /// Writes the blob data for the given transaction hash to the disk.
+    #[inline]
+    fn write_one_encoded(&self, tx: B256, data: &[u8]) -> Result<usize, DiskFileBlobStoreError> {
+        trace!(target:"txpool::blob", "[{:?}] writing blob file", tx);
+        let mut add = 0;
+        let path = self.blob_disk_file(tx);
+        {
+            let _lock = self.file_lock.write();
+            if !path.exists() {
+                fs::write(&path, data)
+                    .map_err(|e| DiskFileBlobStoreError::WriteFile(tx, path, e))?;
+                add = data.len();
+            }
+        }
+        Ok(add)
+    }
+
+    /// Retrieves blobs for the given transaction hashes from the blob cache or disk.
+    ///
+    /// This will not return an error if there are missing blobs. Therefore, the result may be a
+    /// subset of the request or an empty vector if none of the blobs were found.
+    #[inline]
+    fn get_all(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
+        let mut res = Vec::with_capacity(txs.len());
+        let mut cache_miss = Vec::new();
+        {
+            let mut cache = self.blob_cache.lock();
+            for tx in txs {
+                if let Some(blob) = cache.get(&tx) {
+                    res.push((tx, blob.clone()));
+                } else {
+                    cache_miss.push(tx)
+                }
+            }
+        }
+        if cache_miss.is_empty() {
+            return Ok(res)
+        }
+        let from_disk = self.read_many_decoded(cache_miss);
+        if from_disk.is_empty() {
+            return Ok(res)
+        }
+        let from_disk = from_disk
+            .into_iter()
+            .map(|(tx, data)| {
+                let data = Arc::new(data);
+                res.push((tx, data.clone()));
+                (tx, data)
+            })
+            .collect::<Vec<_>>();
+
+        let mut cache = self.blob_cache.lock();
+        for (tx, data) in from_disk {
+            cache.insert(tx, data);
+        }
+
+        Ok(res)
+    }
+
+    /// Retrieves blobs for the given transaction hashes from the blob cache or disk.
+    ///
+    /// Returns an error if there are any missing blobs.
+    #[inline]
+    fn get_exact(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        txs.into_iter()
+            .map(|tx| self.get_one(tx)?.ok_or(BlobStoreError::MissingSidecar(tx)))
+            .collect()
+    }
+}
+
+impl fmt::Debug for DiskFileBlobStoreInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DiskFileBlobStoreInner")
+            .field("blob_dir", &self.blob_dir)
+            .field("cached_blobs", &self.blob_cache.try_lock().map(|lock| lock.len()))
+            .field("txs_to_delete", &self.txs_to_delete.try_read())
+            .finish()
+    }
+}
+
+/// Errors that can occur when interacting with a disk file blob store.
+#[derive(Debug, thiserror::Error)]
+pub enum DiskFileBlobStoreError {
+    /// Thrown during [`DiskFileBlobStore::open`] if the blob store directory cannot be opened.
+    #[error("failed to open blobstore at {0}: {1}")]
+    /// Indicates a failure to open the blob store directory.
+    Open(PathBuf, io::Error),
+    /// Failure while reading a blob file.
+    #[error("[{0}] failed to read blob file at {1}: {2}")]
+    /// Indicates a failure while reading a blob file.
+    ReadFile(TxHash, PathBuf, io::Error),
+    /// Failure while writing a blob file.
+    #[error("[{0}] failed to write blob file at {1}: {2}")]
+    /// Indicates a failure while writing a blob file.
+    WriteFile(TxHash, PathBuf, io::Error),
+    /// Failure while deleting a blob file.
+    #[error("[{0}] failed to delete blob file at {1}: {2}")]
+    /// Indicates a failure while deleting a blob file.
+    DeleteFile(TxHash, PathBuf, io::Error),
+}
+
+impl From<DiskFileBlobStoreError> for BlobStoreError {
+    fn from(value: DiskFileBlobStoreError) -> Self {
+        Self::Other(Box::new(value))
+    }
+}
+
+/// Configuration for a disk file blob store.
+#[derive(Debug, Clone)]
+pub struct DiskFileBlobStoreConfig {
+    /// The maximum number of blobs to keep in the in memory blob cache.
+    pub max_cached_entries: u32,
+    /// How to open the blob store.
+    pub open: OpenDiskFileBlobStore,
+}
+
+impl Default for DiskFileBlobStoreConfig {
+    fn default() -> Self {
+        Self { max_cached_entries: DEFAULT_MAX_CACHED_BLOBS, open: Default::default() }
+    }
+}
+
+impl DiskFileBlobStoreConfig {
+    /// Set maximum number of blobs to keep in the in memory blob cache.
+    pub const fn with_max_cached_entries(mut self, max_cached_entries: u32) -> Self {
+        self.max_cached_entries = max_cached_entries;
+        self
+    }
+}
+
+/// How to open a disk file blob store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OpenDiskFileBlobStore {
+    /// Clear everything in the blob store.
+    #[default]
+    Clear,
+    /// Keep the existing blob store and index
+    ReIndex,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::BlobTransactionSidecar;
+    use alloy_eips::{
+        eip4844::{kzg_to_versioned_hash, Blob, BlobAndProofV2, Bytes48},
+        eip7594::{
+            BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant, CELLS_PER_EXT_BLOB,
+        },
+    };
+
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    fn tmp_store() -> (DiskFileBlobStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DiskFileBlobStore::open(dir.path(), Default::default()).unwrap();
+        (store, dir)
+    }
+
+    fn rng_blobs(num: usize) -> Vec<(TxHash, BlobTransactionSidecarVariant)> {
+        let mut rng = rand::rng();
+        (0..num)
+            .map(|_| {
+                let tx = TxHash::random_with(&mut rng);
+                let blob = BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar {
+                    blobs: vec![],
+                    commitments: vec![],
+                    proofs: vec![],
+                });
+                (tx, blob)
+            })
+            .collect()
+    }
+
+    fn eip7594_single_blob_sidecar() -> (BlobTransactionSidecarVariant, B256, BlobAndProofV2) {
+        let blob = Blob::default();
+        let commitment = Bytes48::default();
+        let cell_proofs = vec![Bytes48::default(); CELLS_PER_EXT_BLOB];
+
+        let versioned_hash = kzg_to_versioned_hash(commitment.as_slice());
+
+        let expected =
+            BlobAndProofV2 { blob: Box::new(Blob::default()), proofs: cell_proofs.clone() };
+        let sidecar = BlobTransactionSidecarEip7594::new(vec![blob], vec![commitment], cell_proofs);
+
+        (BlobTransactionSidecarVariant::Eip7594(sidecar), versioned_hash, expected)
+    }
+
+    #[test]
+    fn disk_insert_all_get_all() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(10);
+        let all_hashes = blobs.iter().map(|(tx, _)| *tx).collect::<Vec<_>>();
+        store.insert_all(blobs.clone()).unwrap();
+
+        // all cached
+        for (tx, blob) in &blobs {
+            assert!(store.is_cached(tx));
+            let b = store.get(*tx).unwrap().map(Arc::unwrap_or_clone).unwrap();
+            assert_eq!(b, *blob);
+        }
+
+        let all = store.get_all(all_hashes.clone()).unwrap();
+        for (tx, blob) in all {
+            assert!(blobs.contains(&(tx, Arc::unwrap_or_clone(blob))), "missing blob {tx:?}");
+        }
+
+        assert!(store.contains(all_hashes[0]).unwrap());
+        store.delete_all(all_hashes.clone()).unwrap();
+        assert!(store.inner.txs_to_delete.read().contains(&all_hashes[0]));
+        store.clear_cache();
+        store.cleanup();
+
+        assert!(store.get(blobs[0].0).unwrap().is_none());
+
+        let all = store.get_all(all_hashes.clone()).unwrap();
+        assert!(all.is_empty());
+
+        assert!(!store.contains(all_hashes[0]).unwrap());
+        assert!(store.get_exact(all_hashes).is_err());
+
+        assert_eq!(store.data_size_hint(), Some(0));
+        assert_eq!(store.inner.size_tracker.num_blobs.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn disk_insert_and_retrieve() {
+        let (store, _dir) = tmp_store();
+
+        let (tx, blob) = rng_blobs(1).into_iter().next().unwrap();
+        store.insert(tx, blob.clone()).unwrap();
+
+        assert!(store.is_cached(&tx));
+        let retrieved_blob = store.get(tx).unwrap().map(Arc::unwrap_or_clone).unwrap();
+        assert_eq!(retrieved_blob, blob);
+    }
+
+    #[test]
+    fn disk_delete_blob() {
+        let (store, _dir) = tmp_store();
+
+        let (tx, blob) = rng_blobs(1).into_iter().next().unwrap();
+        store.insert(tx, blob).unwrap();
+        assert!(store.is_cached(&tx));
+
+        store.delete(tx).unwrap();
+        assert!(store.inner.txs_to_delete.read().contains(&tx));
+        store.cleanup();
+
+        let result = store.get(tx).unwrap();
+        assert_eq!(
+            result,
+            Some(Arc::new(BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar {
+                blobs: vec![],
+                commitments: vec![],
+                proofs: vec![]
+            })))
+        );
+    }
+
+    #[test]
+    fn disk_insert_all_and_delete_all() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(5);
+        let txs = blobs.iter().map(|(tx, _)| *tx).collect::<Vec<_>>();
+        store.insert_all(blobs.clone()).unwrap();
+
+        for (tx, _) in &blobs {
+            assert!(store.is_cached(tx));
+        }
+
+        store.delete_all(txs.clone()).unwrap();
+        store.cleanup();
+
+        for tx in txs {
+            let result = store.get(tx).unwrap();
+            assert_eq!(
+                result,
+                Some(Arc::new(BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar {
+                    blobs: vec![],
+                    commitments: vec![],
+                    proofs: vec![]
+                })))
+            );
+        }
+    }
+
+    #[test]
+    fn disk_get_all_blobs() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(3);
+        let txs = blobs.iter().map(|(tx, _)| *tx).collect::<Vec<_>>();
+        store.insert_all(blobs.clone()).unwrap();
+
+        let retrieved_blobs = store.get_all(txs.clone()).unwrap();
+        for (tx, blob) in retrieved_blobs {
+            assert!(blobs.contains(&(tx, Arc::unwrap_or_clone(blob))));
+        }
+
+        store.delete_all(txs).unwrap();
+        store.cleanup();
+    }
+
+    #[test]
+    fn disk_get_exact_blobs_success() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(3);
+        let txs = blobs.iter().map(|(tx, _)| *tx).collect::<Vec<_>>();
+        store.insert_all(blobs.clone()).unwrap();
+
+        let retrieved_blobs = store.get_exact(txs).unwrap();
+        for (retrieved_blob, (_, original_blob)) in retrieved_blobs.into_iter().zip(blobs) {
+            assert_eq!(Arc::unwrap_or_clone(retrieved_blob), original_blob);
+        }
+    }
+
+    #[test]
+    fn disk_get_exact_blobs_failure() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(2);
+        let txs = blobs.iter().map(|(tx, _)| *tx).collect::<Vec<_>>();
+        store.insert_all(blobs).unwrap();
+
+        // Try to get a blob that was never inserted
+        let missing_tx = TxHash::random();
+        let result = store.get_exact(vec![txs[0], missing_tx]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn disk_data_size_hint() {
+        let (store, _dir) = tmp_store();
+        assert_eq!(store.data_size_hint(), Some(0));
+
+        let blobs = rng_blobs(2);
+        store.insert_all(blobs).unwrap();
+        assert!(store.data_size_hint().unwrap() > 0);
+    }
+
+    #[test]
+    fn disk_cleanup_stat() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(3);
+        let txs = blobs.iter().map(|(tx, _)| *tx).collect::<Vec<_>>();
+        store.insert_all(blobs).unwrap();
+
+        store.delete_all(txs).unwrap();
+        let stat = store.cleanup();
+        assert_eq!(stat.delete_succeed, 3);
+        assert_eq!(stat.delete_failed, 0);
+    }
+
+    #[test]
+    fn disk_get_blobs_v3_returns_partial_results() {
+        let (store, _dir) = tmp_store();
+
+        let (sidecar, versioned_hash, expected) = eip7594_single_blob_sidecar();
+        store.insert(TxHash::random(), sidecar).unwrap();
+
+        assert_ne!(versioned_hash, B256::ZERO);
+
+        let request = vec![versioned_hash, B256::ZERO];
+        let v2 = store.get_by_versioned_hashes_v2(&request).unwrap();
+        assert!(v2.is_none(), "v2 must return null if any requested blob is missing");
+
+        let v3 = store.get_by_versioned_hashes_v3(&request).unwrap();
+        assert_eq!(v3, vec![Some(expected), None]);
+    }
+
+    #[test]
+    fn disk_get_blobs_v4_returns_requested_cells() {
+        let (store, _dir) = tmp_store();
+
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(TxHash::random(), sidecar).unwrap();
+
+        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let request = vec![versioned_hash, B256::ZERO];
+
+        let v4 = store.get_by_versioned_hashes_v4(&request, indices_bitarray).unwrap();
+        assert_eq!(v4.len(), request.len());
+        assert!(v4[1].is_none());
+
+        let cells_and_proofs = v4[0].as_ref().unwrap();
+        assert_eq!(cells_and_proofs.blob_cells.len(), 2);
+        assert_eq!(cells_and_proofs.proofs.len(), 2);
+        assert!(cells_and_proofs.blob_cells.iter().all(Option::is_some));
+        assert_eq!(cells_and_proofs.proofs, vec![Some(Bytes48::default()); 2]);
+    }
+
+    #[test]
+    fn disk_get_blobs_v3_can_fallback_to_disk() {
+        let (store, _dir) = tmp_store();
+
+        let (sidecar, versioned_hash, expected) = eip7594_single_blob_sidecar();
+        store.insert(TxHash::random(), sidecar).unwrap();
+        store.clear_cache();
+
+        let v3 = store.get_by_versioned_hashes_v3(&[versioned_hash]).unwrap();
+        assert_eq!(v3, vec![Some(expected)]);
+    }
+
+    #[test]
+    fn disk_get_blobs_v4_can_fallback_to_disk() {
+        let (store, _dir) = tmp_store();
+
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(TxHash::random(), sidecar).unwrap();
+        store.clear_cache();
+
+        let v4 = store.get_by_versioned_hashes_v4(&[versioned_hash], B128::from(1u128)).unwrap();
+        let cells_and_proofs = v4[0].as_ref().unwrap();
+        assert_eq!(cells_and_proofs.blob_cells.len(), 1);
+        assert_eq!(cells_and_proofs.proofs, vec![Some(Bytes48::default())]);
+    }
+
+    #[test]
+    fn disk_double_cleanup_no_failure() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(5);
+        let all_hashes: Vec<_> = blobs.iter().map(|(tx, _)| *tx).collect();
+        store.insert_all(blobs).unwrap();
+        store.clear_cache();
+
+        // Schedule blobs for deletion
+        store.delete_all(all_hashes.clone()).unwrap();
+
+        // First cleanup: files exist, all should succeed
+        let stat1 = store.cleanup();
+        assert_eq!(stat1.delete_succeed, 5);
+        assert_eq!(stat1.delete_failed, 0);
+
+        // Manually re-enqueue the same hashes to simulate a concurrent cleanup race
+        store.inner.txs_to_delete.write().extend(all_hashes);
+
+        // Second cleanup: files already deleted, should still report success (NotFound)
+        let stat2 = store.cleanup();
+        assert_eq!(stat2.delete_succeed, 5);
+        assert_eq!(stat2.delete_failed, 0);
+    }
+}

--- a/patches/reth-transaction-pool/src/blobstore/mem.rs
+++ b/patches/reth-transaction-pool/src/blobstore/mem.rs
@@ -1,0 +1,318 @@
+use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobStoreSize};
+use alloy_eips::{
+    eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant},
+};
+use alloy_primitives::{map::B256Map, B128, B256};
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+/// An in-memory blob store.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct InMemoryBlobStore {
+    inner: Arc<InMemoryBlobStoreInner>,
+}
+
+impl InMemoryBlobStore {
+    /// Look up EIP-7594 blobs by their versioned hashes.
+    ///
+    /// This returns a result vector with the **same length and order** as the input
+    /// `versioned_hashes`. Each element is `Some(BlobAndProofV2)` if the blob is available, or
+    /// `None` if it is missing or an older sidecar version.
+    fn get_by_versioned_hashes_eip7594(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Vec<Option<BlobAndProofV2>> {
+        let mut result = vec![None; versioned_hashes.len()];
+        let mut missing_count = result.len();
+        for (_tx_hash, blob_sidecar) in self.inner.store.read().iter() {
+            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
+                for (hash_idx, match_result) in
+                    blob_sidecar.match_versioned_hashes(versioned_hashes)
+                {
+                    let slot = &mut result[hash_idx];
+                    if slot.is_none() {
+                        missing_count -= 1;
+                    }
+                    *slot = Some(match_result);
+                }
+            }
+
+            // Return early if all blobs are found.
+            if missing_count == 0 {
+                // since versioned_hashes may have duplicates, we double check here
+                if result.iter().all(|blob| blob.is_some()) {
+                    break;
+                }
+            }
+        }
+        result
+    }
+
+    /// Look up EIP-7594 blob cells by their versioned hashes.
+    fn get_by_versioned_hashes_cells_eip7594(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        let cell_mask = BlobCellMask::new(indices_bitarray);
+        let mut result = vec![None; versioned_hashes.len()];
+        let mut missing_count = result.len();
+        let blob_sidecars = self.inner.store.read().values().cloned().collect::<Vec<_>>();
+        for blob_sidecar in blob_sidecars {
+            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
+                for (hash_idx, match_result) in blob_sidecar
+                    .match_versioned_hashes_cells(versioned_hashes, cell_mask)
+                    .map_err(|err| BlobStoreError::Other(Box::new(err)))?
+                {
+                    let slot = &mut result[hash_idx];
+                    if slot.is_none() {
+                        missing_count -= 1;
+                    }
+                    *slot = Some(match_result);
+                }
+            }
+
+            if missing_count == 0 && result.iter().all(Option::is_some) {
+                break;
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Default)]
+struct InMemoryBlobStoreInner {
+    /// Storage for all blob data.
+    store: RwLock<B256Map<Arc<BlobTransactionSidecarVariant>>>,
+    size_tracker: BlobStoreSize,
+}
+
+impl PartialEq for InMemoryBlobStoreInner {
+    fn eq(&self, other: &Self) -> bool {
+        self.store.read().eq(&*other.store.read())
+    }
+}
+
+impl BlobStore for InMemoryBlobStore {
+    fn insert(&self, tx: B256, data: BlobTransactionSidecarVariant) -> Result<(), BlobStoreError> {
+        let mut store = self.inner.store.write();
+        self.inner.size_tracker.add_size(insert_size(&mut store, tx, data));
+        self.inner.size_tracker.update_len(store.len());
+        Ok(())
+    }
+
+    fn insert_all(
+        &self,
+        txs: Vec<(B256, BlobTransactionSidecarVariant)>,
+    ) -> Result<(), BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(())
+        }
+        let mut store = self.inner.store.write();
+        let mut total_add = 0;
+        for (tx, data) in txs {
+            let add = insert_size(&mut store, tx, data);
+            total_add += add;
+        }
+        self.inner.size_tracker.add_size(total_add);
+        self.inner.size_tracker.update_len(store.len());
+        Ok(())
+    }
+
+    fn delete(&self, tx: B256) -> Result<(), BlobStoreError> {
+        let mut store = self.inner.store.write();
+        let sub = remove_size(&mut store, &tx);
+        self.inner.size_tracker.sub_size(sub);
+        self.inner.size_tracker.update_len(store.len());
+        Ok(())
+    }
+
+    fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(())
+        }
+        let mut store = self.inner.store.write();
+        let mut total_sub = 0;
+        for tx in txs {
+            total_sub += remove_size(&mut store, &tx);
+        }
+        self.inner.size_tracker.sub_size(total_sub);
+        self.inner.size_tracker.update_len(store.len());
+        Ok(())
+    }
+
+    fn cleanup(&self) -> BlobStoreCleanupStat {
+        BlobStoreCleanupStat::default()
+    }
+
+    // Retrieves the decoded blob data for the given transaction hash.
+    fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        Ok(self.inner.store.read().get(&tx).cloned())
+    }
+
+    fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
+        Ok(self.inner.store.read().contains_key(&tx))
+    }
+
+    fn get_all(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
+        let store = self.inner.store.read();
+        Ok(txs.into_iter().filter_map(|tx| store.get(&tx).map(|item| (tx, item.clone()))).collect())
+    }
+
+    fn get_exact(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let store = self.inner.store.read();
+        txs.into_iter()
+            .map(|tx| store.get(&tx).cloned().ok_or(BlobStoreError::MissingSidecar(tx)))
+            .collect()
+    }
+
+    fn get_by_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
+        let mut result = vec![None; versioned_hashes.len()];
+        for (_tx_hash, blob_sidecar) in self.inner.store.read().iter() {
+            if let Some(blob_sidecar) = blob_sidecar.as_eip4844() {
+                for (hash_idx, match_result) in
+                    blob_sidecar.match_versioned_hashes(versioned_hashes)
+                {
+                    result[hash_idx] = Some(match_result);
+                }
+            }
+
+            // Return early if all blobs are found.
+            if result.iter().all(|blob| blob.is_some()) {
+                break;
+            }
+        }
+        Ok(result)
+    }
+
+    fn get_by_versioned_hashes_v2(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
+        let result = self.get_by_versioned_hashes_eip7594(versioned_hashes);
+        if result.iter().all(|blob| blob.is_some()) {
+            Ok(Some(result.into_iter().map(Option::unwrap).collect()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_by_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
+        Ok(self.get_by_versioned_hashes_eip7594(versioned_hashes))
+    }
+
+    fn get_by_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, indices_bitarray)
+    }
+
+    fn data_size_hint(&self) -> Option<usize> {
+        Some(self.inner.size_tracker.data_size())
+    }
+
+    fn blobs_len(&self) -> usize {
+        self.inner.size_tracker.blobs_len()
+    }
+}
+
+/// Removes the given blob from the store and returns the size of the blob that was removed.
+#[inline]
+fn remove_size(store: &mut B256Map<Arc<BlobTransactionSidecarVariant>>, tx: &B256) -> usize {
+    store.remove(tx).map(|rem| rem.size()).unwrap_or_default()
+}
+
+/// Inserts the given blob into the store and returns the size of the blob that was added.
+///
+/// We don't need to handle the size updates for replacements because transactions are unique.
+#[inline]
+fn insert_size(
+    store: &mut B256Map<Arc<BlobTransactionSidecarVariant>>,
+    tx: B256,
+    blob: BlobTransactionSidecarVariant,
+) -> usize {
+    let add = blob.size();
+    store.insert(tx, Arc::new(blob));
+    add
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eips::{
+        eip4844::{kzg_to_versioned_hash, Blob, BlobAndProofV2, Bytes48},
+        eip7594::{
+            BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant, CELLS_PER_EXT_BLOB,
+        },
+    };
+
+    fn eip7594_single_blob_sidecar() -> (BlobTransactionSidecarVariant, B256, BlobAndProofV2) {
+        let blob = Blob::default();
+        let commitment = Bytes48::default();
+        let cell_proofs = vec![Bytes48::default(); CELLS_PER_EXT_BLOB];
+
+        let versioned_hash = kzg_to_versioned_hash(commitment.as_slice());
+
+        let expected =
+            BlobAndProofV2 { blob: Box::new(Blob::default()), proofs: cell_proofs.clone() };
+        let sidecar = BlobTransactionSidecarEip7594::new(vec![blob], vec![commitment], cell_proofs);
+
+        (BlobTransactionSidecarVariant::Eip7594(sidecar), versioned_hash, expected)
+    }
+
+    #[test]
+    fn mem_get_blobs_v3_returns_partial_results() {
+        let store = InMemoryBlobStore::default();
+
+        let (sidecar, versioned_hash, expected) = eip7594_single_blob_sidecar();
+        store.insert(B256::random(), sidecar).unwrap();
+
+        assert_ne!(versioned_hash, B256::ZERO);
+
+        let request = vec![versioned_hash, B256::ZERO];
+        let v2 = store.get_by_versioned_hashes_v2(&request).unwrap();
+        assert!(v2.is_none(), "v2 must return null if any requested blob is missing");
+
+        let v3 = store.get_by_versioned_hashes_v3(&request).unwrap();
+        assert_eq!(v3, vec![Some(expected), None]);
+    }
+
+    #[test]
+    fn mem_get_blobs_v4_returns_requested_cells() {
+        let store = InMemoryBlobStore::default();
+
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(B256::random(), sidecar).unwrap();
+
+        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let request = vec![versioned_hash, B256::ZERO];
+
+        let v4 = store.get_by_versioned_hashes_v4(&request, indices_bitarray).unwrap();
+        assert_eq!(v4.len(), request.len());
+        assert!(v4[1].is_none());
+
+        let cells_and_proofs = v4[0].as_ref().unwrap();
+        assert_eq!(cells_and_proofs.blob_cells.len(), 2);
+        assert_eq!(cells_and_proofs.proofs.len(), 2);
+        assert!(cells_and_proofs.blob_cells.iter().all(Option::is_some));
+        assert_eq!(cells_and_proofs.proofs, vec![Some(Bytes48::default()); 2]);
+    }
+}

--- a/patches/reth-transaction-pool/src/blobstore/mod.rs
+++ b/patches/reth-transaction-pool/src/blobstore/mod.rs
@@ -1,0 +1,216 @@
+//! Storage for blob data of EIP4844 transactions.
+
+use alloy_eips::{
+    eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
+    eip7594::BlobTransactionSidecarVariant,
+};
+use alloy_primitives::{B128, B256};
+pub use converter::BlobSidecarConverter;
+pub use disk::{DiskFileBlobStore, DiskFileBlobStoreConfig, OpenDiskFileBlobStore};
+pub use mem::InMemoryBlobStore;
+pub use noop::NoopBlobStore;
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+pub use tracker::{BlobStoreCanonTracker, BlobStoreUpdates};
+
+mod converter;
+pub mod disk;
+mod mem;
+mod noop;
+mod tracker;
+
+/// A blob store that can be used to store blob data of EIP4844 transactions.
+///
+/// This type is responsible for keeping track of blob data until it is no longer needed (after
+/// finalization).
+///
+/// Note: this is Clone because it is expected to be wrapped in an Arc.
+pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
+    /// Inserts the blob sidecar into the store
+    fn insert(&self, tx: B256, data: BlobTransactionSidecarVariant) -> Result<(), BlobStoreError>;
+
+    /// Inserts multiple blob sidecars into the store
+    fn insert_all(
+        &self,
+        txs: Vec<(B256, BlobTransactionSidecarVariant)>,
+    ) -> Result<(), BlobStoreError>;
+
+    /// Deletes the blob sidecar from the store
+    fn delete(&self, tx: B256) -> Result<(), BlobStoreError>;
+
+    /// Deletes multiple blob sidecars from the store
+    fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError>;
+
+    /// A maintenance function that can be called periodically to clean up the blob store, returns
+    /// the number of successfully deleted blobs and the number of failed deletions.
+    ///
+    /// This is intended to be called in the background to clean up any old or unused data, in case
+    /// the store uses deferred cleanup: [`DiskFileBlobStore`]
+    fn cleanup(&self) -> BlobStoreCleanupStat;
+
+    /// Retrieves the decoded blob data for the given transaction hash.
+    fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+
+    /// Checks if the given transaction hash is in the blob store.
+    fn contains(&self, tx: B256) -> Result<bool, BlobStoreError>;
+
+    /// Retrieves all decoded blob data for the given transaction hashes.
+    ///
+    /// This only returns the blobs that were found in the store.
+    /// If there's no blob it will not be returned.
+    ///
+    /// Note: this is not guaranteed to return the blobs in the same order as the input.
+    fn get_all(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError>;
+
+    /// Returns the exact [`BlobTransactionSidecarVariant`] for the given transaction hashes in the
+    /// exact order they were requested.
+    ///
+    /// Returns an error if any of the blobs are not found in the blob store.
+    fn get_exact(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+
+    /// Return the [`BlobAndProofV1`]s for a list of blob versioned hashes.
+    fn get_by_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError>;
+
+    /// Return the [`BlobAndProofV2`]s for a list of blob versioned hashes.
+    /// Blobs and proofs are returned only if they are present for _all_ requested
+    /// versioned hashes.
+    ///
+    /// This differs from [`BlobStore::get_by_versioned_hashes_v1`] in that it also returns all the
+    /// cell proofs in [`BlobAndProofV2`] supported by the EIP-7594 blob sidecar variant.
+    ///
+    /// The response also differs from [`BlobStore::get_by_versioned_hashes_v1`] in that this
+    /// returns `None` if any of the requested versioned hashes are not present in the blob store:
+    /// e.g. where v1 would return `[A, None, C]` v2 would return `None`. See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#engine_getblobsv2>
+    fn get_by_versioned_hashes_v2(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError>;
+
+    /// Return the [`BlobAndProofV2`]s for a list of blob versioned hashes.
+    ///
+    /// The response is always the same length as the request. Missing or older-version blobs are
+    /// returned as `None` elements.
+    fn get_by_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError>;
+
+    /// Return the [`BlobCellsAndProofsV1`]s for a list of blob versioned hashes and requested cell
+    /// indices.
+    ///
+    /// The response is always the same length as the request. Missing or older-version blobs are
+    /// returned as `None` elements.
+    fn get_by_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError>;
+
+    /// Data size of all transactions in the blob store.
+    fn data_size_hint(&self) -> Option<usize>;
+
+    /// How many blobs are in the blob store.
+    fn blobs_len(&self) -> usize;
+}
+
+/// Error variants that can occur when interacting with a blob store.
+#[derive(Debug, thiserror::Error)]
+pub enum BlobStoreError {
+    /// Thrown if the blob sidecar is not found for a given transaction hash but was required.
+    #[error("blob sidecar not found for transaction {0:?}")]
+    MissingSidecar(B256),
+    /// Failed to decode the stored blob data.
+    #[error("failed to decode blob data: {0}")]
+    DecodeError(#[from] alloy_rlp::Error),
+    /// Other implementation specific error.
+    #[error(transparent)]
+    Other(Box<dyn core::error::Error + Send + Sync>),
+}
+
+/// Keeps track of the size of the blob store.
+#[derive(Debug, Default)]
+pub(crate) struct BlobStoreSize {
+    data_size: AtomicUsize,
+    num_blobs: AtomicUsize,
+}
+
+impl BlobStoreSize {
+    #[inline]
+    pub(crate) fn add_size(&self, add: usize) {
+        self.data_size.fetch_add(add, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn sub_size(&self, sub: usize) {
+        let _ = self.data_size.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.saturating_sub(sub))
+        });
+    }
+
+    #[inline]
+    pub(crate) fn update_len(&self, len: usize) {
+        self.num_blobs.store(len, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn inc_len(&self, add: usize) {
+        self.num_blobs.fetch_add(add, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn sub_len(&self, sub: usize) {
+        let _ = self.num_blobs.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.saturating_sub(sub))
+        });
+    }
+
+    #[inline]
+    pub(crate) fn data_size(&self) -> usize {
+        self.data_size.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub(crate) fn blobs_len(&self) -> usize {
+        self.num_blobs.load(Ordering::Relaxed)
+    }
+}
+
+impl PartialEq for BlobStoreSize {
+    fn eq(&self, other: &Self) -> bool {
+        self.data_size.load(Ordering::Relaxed) == other.data_size.load(Ordering::Relaxed) &&
+            self.num_blobs.load(Ordering::Relaxed) == other.num_blobs.load(Ordering::Relaxed)
+    }
+}
+
+/// Statistics for the cleanup operation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BlobStoreCleanupStat {
+    /// the number of successfully deleted blobs
+    pub delete_succeed: usize,
+    /// the number of failed deletions
+    pub delete_failed: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[expect(dead_code)]
+    struct DynStore {
+        store: Box<dyn BlobStore>,
+    }
+}

--- a/patches/reth-transaction-pool/src/blobstore/noop.rs
+++ b/patches/reth-transaction-pool/src/blobstore/noop.rs
@@ -1,0 +1,103 @@
+use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError};
+use alloy_eips::{
+    eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
+    eip7594::BlobTransactionSidecarVariant,
+};
+use alloy_primitives::{B128, B256};
+use std::sync::Arc;
+
+/// A blobstore implementation that does nothing
+#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct NoopBlobStore;
+
+impl BlobStore for NoopBlobStore {
+    fn insert(
+        &self,
+        _tx: B256,
+        _data: BlobTransactionSidecarVariant,
+    ) -> Result<(), BlobStoreError> {
+        Ok(())
+    }
+
+    fn insert_all(
+        &self,
+        _txs: Vec<(B256, BlobTransactionSidecarVariant)>,
+    ) -> Result<(), BlobStoreError> {
+        Ok(())
+    }
+
+    fn delete(&self, _tx: B256) -> Result<(), BlobStoreError> {
+        Ok(())
+    }
+
+    fn delete_all(&self, _txs: Vec<B256>) -> Result<(), BlobStoreError> {
+        Ok(())
+    }
+
+    fn cleanup(&self) -> BlobStoreCleanupStat {
+        BlobStoreCleanupStat::default()
+    }
+
+    fn get(&self, _tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        Ok(None)
+    }
+
+    fn contains(&self, _tx: B256) -> Result<bool, BlobStoreError> {
+        Ok(false)
+    }
+
+    fn get_all(
+        &self,
+        _txs: Vec<B256>,
+    ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
+        Ok(vec![])
+    }
+
+    fn get_exact(
+        &self,
+        txs: Vec<B256>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(vec![])
+        }
+        Err(BlobStoreError::MissingSidecar(txs[0]))
+    }
+
+    fn get_by_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
+        Ok(vec![None; versioned_hashes.len()])
+    }
+
+    fn get_by_versioned_hashes_v2(
+        &self,
+        _versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
+        Ok(None)
+    }
+
+    fn get_by_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
+        Ok(vec![None; versioned_hashes.len()])
+    }
+
+    fn get_by_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        _indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        Ok(vec![None; versioned_hashes.len()])
+    }
+
+    fn data_size_hint(&self) -> Option<usize> {
+        Some(0)
+    }
+
+    fn blobs_len(&self) -> usize {
+        0
+    }
+}

--- a/patches/reth-transaction-pool/src/blobstore/tracker.rs
+++ b/patches/reth-transaction-pool/src/blobstore/tracker.rs
@@ -1,0 +1,189 @@
+//! Support for maintaining the blob pool.
+
+use alloy_consensus::Typed2718;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{BlockNumber, B256};
+use reth_execution_types::ChainBlocks;
+use reth_primitives_traits::{Block, BlockBody, SignedTransaction};
+use std::collections::BTreeMap;
+
+/// The type that is used to track canonical blob transactions.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct BlobStoreCanonTracker {
+    /// Keeps track of the blob transactions included in blocks.
+    blob_txs_in_blocks: BTreeMap<BlockNumber, Vec<B256>>,
+}
+
+impl BlobStoreCanonTracker {
+    /// Adds a block to the blob store maintenance.
+    pub fn add_block(
+        &mut self,
+        block_number: BlockNumber,
+        blob_txs: impl IntoIterator<Item = B256>,
+    ) {
+        self.blob_txs_in_blocks.insert(block_number, blob_txs.into_iter().collect());
+    }
+
+    /// Adds all blocks to the tracked list of blocks.
+    ///
+    /// Replaces any previously tracked blocks with the set of transactions.
+    pub fn add_blocks(
+        &mut self,
+        blocks: impl IntoIterator<Item = (BlockNumber, impl IntoIterator<Item = B256>)>,
+    ) {
+        for (block_number, blob_txs) in blocks {
+            self.add_block(block_number, blob_txs);
+        }
+    }
+
+    /// Adds all blob transactions from the given chain to the tracker.
+    ///
+    /// Note: In case this is a chain that's part of a reorg, this replaces previously tracked
+    /// blocks.
+    pub fn add_new_chain_blocks<B>(&mut self, blocks: &ChainBlocks<'_, B>)
+    where
+        B: Block<Body: BlockBody<Transaction: SignedTransaction>>,
+    {
+        let blob_txs = blocks.iter().map(|(num, block)| {
+            let iter = block
+                .body()
+                .transactions()
+                .iter()
+                .filter(|tx| tx.is_eip4844())
+                .map(|tx| tx.trie_hash());
+            (*num, iter)
+        });
+        self.add_blocks(blob_txs);
+    }
+
+    /// Invoked when a block is finalized.
+    ///
+    /// This returns all blob transactions that were included in blocks that are now finalized.
+    pub fn on_finalized_block(&mut self, finalized_block: BlockNumber) -> BlobStoreUpdates {
+        let mut finalized = Vec::new();
+        while let Some(entry) = self.blob_txs_in_blocks.first_entry() {
+            if *entry.key() <= finalized_block {
+                finalized.extend(entry.remove_entry().1);
+            } else {
+                break
+            }
+        }
+
+        if finalized.is_empty() {
+            BlobStoreUpdates::None
+        } else {
+            BlobStoreUpdates::Finalized(finalized)
+        }
+    }
+}
+
+/// Updates that should be applied to the blob store.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BlobStoreUpdates {
+    /// No updates.
+    None,
+    /// Delete the given finalized transactions from the blob store.
+    Finalized(Vec<B256>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{Header, Signed};
+    use alloy_primitives::Signature;
+    use reth_ethereum_primitives::Transaction;
+    use reth_execution_types::Chain;
+    use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
+
+    #[test]
+    fn test_finalized_tracker() {
+        let mut tracker = BlobStoreCanonTracker::default();
+
+        let block1 = vec![B256::random()];
+        let block2 = vec![B256::random()];
+        let block3 = vec![B256::random()];
+        tracker.add_block(1, block1.clone());
+        tracker.add_block(2, block2.clone());
+        tracker.add_block(3, block3.clone());
+
+        assert_eq!(tracker.on_finalized_block(0), BlobStoreUpdates::None);
+        assert_eq!(tracker.on_finalized_block(1), BlobStoreUpdates::Finalized(block1));
+        assert_eq!(
+            tracker.on_finalized_block(3),
+            BlobStoreUpdates::Finalized(block2.into_iter().chain(block3).collect::<Vec<_>>())
+        );
+    }
+
+    #[test]
+    fn test_add_new_chain_blocks() {
+        let mut tracker = BlobStoreCanonTracker::default();
+        // Create sample transactions
+        let tx1_signed = Signed::new_unhashed(
+            Transaction::Eip4844(Default::default()),
+            Signature::test_signature(),
+        ); // EIP-4844 transaction
+        let tx2_signed = Signed::new_unhashed(
+            Transaction::Eip4844(Default::default()),
+            Signature::test_signature(),
+        ); // EIP-4844 transaction
+
+        let tx1_hash = *tx1_signed.hash();
+        let tx2_hash = *tx2_signed.hash();
+        // Creating a first block with EIP-4844 transactions
+        let block1 = RecoveredBlock::new_sealed(
+            SealedBlock::from_sealed_parts(
+                SealedHeader::new(Header { number: 10, ..Default::default() }, B256::random()),
+                alloy_consensus::BlockBody {
+                    transactions: vec![
+                        tx1_signed.into(),
+                        tx2_signed.into(),
+                        // Another transaction that is not EIP-4844
+                        Signed::new_unhashed(
+                            Transaction::Eip7702(Default::default()),
+                            Signature::test_signature(),
+                        )
+                        .into(),
+                    ],
+                    ..Default::default()
+                },
+            ),
+            Default::default(),
+        );
+
+        // Creating a second block with EIP-1559 and EIP-2930 transactions
+        // Note: This block does not contain any EIP-4844 transactions
+        let block2 = RecoveredBlock::new_sealed(
+            SealedBlock::from_sealed_parts(
+                SealedHeader::new(Header { number: 11, ..Default::default() }, B256::random()),
+                alloy_consensus::BlockBody {
+                    transactions: vec![
+                        Signed::new_unhashed(
+                            Transaction::Eip1559(Default::default()),
+                            Signature::test_signature(),
+                        )
+                        .into(),
+                        Signed::new_unhashed(
+                            Transaction::Eip2930(Default::default()),
+                            Signature::test_signature(),
+                        )
+                        .into(),
+                    ],
+                    ..Default::default()
+                },
+            ),
+            Default::default(),
+        );
+
+        // Extract blocks from the chain
+        let chain: Chain = Chain::new(vec![block1, block2], Default::default(), BTreeMap::new());
+        let blocks = chain.into_inner().0;
+
+        // Add new chain blocks to the tracker
+        tracker.add_new_chain_blocks(&blocks);
+
+        // Tx1 and tx2 should be in the block containing EIP-4844 transactions
+        assert_eq!(tracker.blob_txs_in_blocks.get(&10).unwrap(), &vec![tx1_hash, tx2_hash]);
+        // No transactions should be in the block containing non-EIP-4844 transactions
+        assert!(tracker.blob_txs_in_blocks.get(&11).unwrap().is_empty());
+    }
+}

--- a/patches/reth-transaction-pool/src/config.rs
+++ b/patches/reth-transaction-pool/src/config.rs
@@ -1,0 +1,398 @@
+use crate::{
+    maintain::MAX_QUEUED_TRANSACTION_LIFETIME,
+    pool::{NEW_TX_LISTENER_BUFFER_SIZE, PENDING_TX_LISTENER_BUFFER_SIZE},
+    PoolSize, TransactionOrigin,
+};
+use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
+use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
+use alloy_primitives::{map::AddressSet, Address};
+use std::{ops::Mul, time::Duration};
+
+/// Guarantees max transactions for one sender, compatible with geth/erigon
+pub const TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;
+
+/// The default maximum allowed number of transactions in the given subpool.
+pub const TXPOOL_SUBPOOL_MAX_TXS_DEFAULT: usize = 10_000;
+
+/// The default maximum allowed size of the given subpool.
+pub const TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT: usize = 20;
+
+/// The default additional validation tasks size.
+pub const DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS: usize = 1;
+
+/// Default price bump (in %) for the transaction pool underpriced check.
+pub const DEFAULT_PRICE_BUMP: u128 = 10;
+
+/// Replace blob price bump (in %) for the transaction pool underpriced check.
+///
+/// This enforces that a blob transaction requires a 100% price bump to be replaced
+pub const REPLACE_BLOB_PRICE_BUMP: u128 = 100;
+
+/// Default maximum new transactions for broadcasting.
+pub const MAX_NEW_PENDING_TXS_NOTIFICATIONS: usize = 200;
+
+/// Default maximum allowed in flight delegated transactions per account.
+pub const DEFAULT_MAX_INFLIGHT_DELEGATED_SLOTS: usize = 1;
+
+/// Configuration options for the Transaction pool.
+#[derive(Debug, Clone)]
+pub struct PoolConfig {
+    /// Max number of transaction in the pending sub-pool
+    pub pending_limit: SubPoolLimit,
+    /// Max number of transaction in the basefee sub-pool
+    pub basefee_limit: SubPoolLimit,
+    /// Max number of transaction in the queued sub-pool
+    pub queued_limit: SubPoolLimit,
+    /// Max number of transactions in the blob sub-pool
+    pub blob_limit: SubPoolLimit,
+    /// Blob cache size
+    pub blob_cache_size: Option<u32>,
+    /// Max number of executable transaction slots guaranteed per account
+    pub max_account_slots: usize,
+    /// Price bump (in %) for the transaction pool underpriced check.
+    pub price_bumps: PriceBumpConfig,
+    /// Minimum base fee required by the protocol.
+    pub minimal_protocol_basefee: u64,
+    /// Minimum priority fee required for transaction acceptance into the pool.
+    pub minimum_priority_fee: Option<u128>,
+    /// The max gas limit for transactions in the pool
+    pub gas_limit: u64,
+    /// How to handle locally received transactions:
+    /// [`TransactionOrigin::Local`](TransactionOrigin).
+    pub local_transactions_config: LocalTransactionConfig,
+    /// Bound on number of pending transactions from `reth_network::TransactionsManager` to buffer.
+    pub pending_tx_listener_buffer_size: usize,
+    /// Bound on number of new transactions from `reth_network::TransactionsManager` to buffer.
+    pub new_tx_listener_buffer_size: usize,
+    /// How many new pending transactions to buffer and send iterators in progress.
+    pub max_new_pending_txs_notifications: usize,
+    /// Maximum lifetime for transactions in the pool
+    pub max_queued_lifetime: Duration,
+    /// The maximum allowed inflight transactions a delegated sender can have.
+    ///
+    /// This restricts how many executable transaction a delegated sender can stack.
+    pub max_inflight_delegated_slot_limit: usize,
+}
+
+impl PoolConfig {
+    /// Sets the minimal protocol base fee to 0, effectively disabling checks that enforce that a
+    /// transaction's fee must be higher than the [`MIN_PROTOCOL_BASE_FEE`] which is the lowest
+    /// value the ethereum EIP-1559 base fee can reach.
+    pub const fn with_disabled_protocol_base_fee(self) -> Self {
+        self.with_protocol_base_fee(0)
+    }
+
+    /// Configures the minimal protocol base fee that should be enforced.
+    ///
+    /// Ethereum's EIP-1559 base fee can't drop below [`MIN_PROTOCOL_BASE_FEE`] hence this is
+    /// enforced by default in the pool.
+    pub const fn with_protocol_base_fee(mut self, protocol_base_fee: u64) -> Self {
+        self.minimal_protocol_basefee = protocol_base_fee;
+        self
+    }
+
+    /// Configures how many slots are available for a delegated sender.
+    pub const fn with_max_inflight_delegated_slots(
+        mut self,
+        max_inflight_delegation_limit: usize,
+    ) -> Self {
+        self.max_inflight_delegated_slot_limit = max_inflight_delegation_limit;
+        self
+    }
+
+    /// Returns whether the size and amount constraints in any sub-pools are exceeded.
+    #[inline]
+    pub const fn is_exceeded(&self, pool_size: PoolSize) -> bool {
+        self.blob_limit.is_exceeded(pool_size.blob, pool_size.blob_size) ||
+            self.pending_limit.is_exceeded(pool_size.pending, pool_size.pending_size) ||
+            self.basefee_limit.is_exceeded(pool_size.basefee, pool_size.basefee_size) ||
+            self.queued_limit.is_exceeded(pool_size.queued, pool_size.queued_size)
+    }
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            pending_limit: Default::default(),
+            basefee_limit: Default::default(),
+            queued_limit: Default::default(),
+            blob_limit: Default::default(),
+            blob_cache_size: None,
+            max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+            price_bumps: Default::default(),
+            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
+            minimum_priority_fee: None,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            local_transactions_config: Default::default(),
+            pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
+            new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,
+            max_new_pending_txs_notifications: MAX_NEW_PENDING_TXS_NOTIFICATIONS,
+            max_queued_lifetime: MAX_QUEUED_TRANSACTION_LIFETIME,
+            max_inflight_delegated_slot_limit: DEFAULT_MAX_INFLIGHT_DELEGATED_SLOTS,
+        }
+    }
+}
+
+/// Size limits for a sub-pool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubPoolLimit {
+    /// Maximum amount of transaction in the pool.
+    pub max_txs: usize,
+    /// Maximum combined size (in bytes) of transactions in the pool.
+    pub max_size: usize,
+}
+
+impl SubPoolLimit {
+    /// Creates a new instance with the given limits.
+    pub const fn new(max_txs: usize, max_size: usize) -> Self {
+        Self { max_txs, max_size }
+    }
+
+    /// Creates an unlimited [`SubPoolLimit`]
+    pub const fn max() -> Self {
+        Self::new(usize::MAX, usize::MAX)
+    }
+
+    /// Returns whether the size or amount constraint is violated.
+    #[inline]
+    pub const fn is_exceeded(&self, txs: usize, size: usize) -> bool {
+        self.max_txs < txs || self.max_size < size
+    }
+
+    /// Returns how many transactions exceed the configured limit.
+    pub const fn tx_excess(&self, txs: usize) -> Option<usize> {
+        txs.checked_sub(self.max_txs)
+    }
+}
+
+impl Mul<usize> for SubPoolLimit {
+    type Output = Self;
+
+    fn mul(self, rhs: usize) -> Self::Output {
+        let Self { max_txs, max_size } = self;
+        Self { max_txs: max_txs * rhs, max_size: max_size * rhs }
+    }
+}
+
+impl Default for SubPoolLimit {
+    fn default() -> Self {
+        // either 10k transactions or 20MB
+        Self {
+            max_txs: TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+            max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT * 1024 * 1024,
+        }
+    }
+}
+
+/// Price bump config (in %) for the transaction pool underpriced check.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct PriceBumpConfig {
+    /// Default price bump (in %) for the transaction pool underpriced check.
+    pub default_price_bump: u128,
+    /// Replace blob price bump (in %) for the transaction pool underpriced check.
+    pub replace_blob_tx_price_bump: u128,
+}
+
+impl PriceBumpConfig {
+    /// Returns the price bump required to replace the given transaction type.
+    #[inline]
+    pub const fn price_bump(&self, tx_type: u8) -> u128 {
+        if tx_type == EIP4844_TX_TYPE_ID {
+            return self.replace_blob_tx_price_bump
+        }
+        self.default_price_bump
+    }
+}
+
+impl Default for PriceBumpConfig {
+    fn default() -> Self {
+        Self {
+            default_price_bump: DEFAULT_PRICE_BUMP,
+            replace_blob_tx_price_bump: REPLACE_BLOB_PRICE_BUMP,
+        }
+    }
+}
+
+/// Configuration options for the locally received transactions:
+/// [`TransactionOrigin::Local`](TransactionOrigin)
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct LocalTransactionConfig {
+    /// Apply no exemptions to the locally received transactions.
+    ///
+    /// This includes:
+    ///   - available slots are limited to the configured `max_account_slots` of [`PoolConfig`]
+    ///   - no price exemptions
+    ///   - no eviction exemptions
+    pub no_exemptions: bool,
+    /// Addresses that will be considered as local. Above exemptions apply.
+    pub local_addresses: AddressSet,
+    /// Flag indicating whether local transactions should be propagated.
+    pub propagate_local_transactions: bool,
+}
+
+impl Default for LocalTransactionConfig {
+    fn default() -> Self {
+        Self {
+            no_exemptions: false,
+            local_addresses: AddressSet::default(),
+            propagate_local_transactions: true,
+        }
+    }
+}
+
+impl LocalTransactionConfig {
+    /// Returns whether local transactions are not exempt from the configured limits.
+    #[inline]
+    pub const fn no_local_exemptions(&self) -> bool {
+        self.no_exemptions
+    }
+
+    /// Returns whether the local addresses vector contains the given address.
+    #[inline]
+    pub fn contains_local_address(&self, address: &Address) -> bool {
+        self.local_addresses.contains(address)
+    }
+
+    /// Returns whether the particular transaction should be considered local.
+    ///
+    /// This always returns false if the local exemptions are disabled.
+    #[inline]
+    pub fn is_local(&self, origin: TransactionOrigin, sender: &Address) -> bool {
+        if self.no_local_exemptions() {
+            return false
+        }
+        origin.is_local() || self.contains_local_address(sender)
+    }
+
+    /// Sets toggle to propagate transactions received locally by this client (e.g
+    /// transactions from `eth_sendTransaction` to this nodes' RPC server)
+    ///
+    /// If set to false, only transactions received by network peers (via
+    /// p2p) will be marked as propagated in the local transaction pool and returned on a
+    /// `GetPooledTransactions` p2p request
+    pub const fn set_propagate_local_transactions(mut self, propagate_local_txs: bool) -> Self {
+        self.propagate_local_transactions = propagate_local_txs;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pool_size_sanity() {
+        let pool_size = PoolSize {
+            pending: 0,
+            pending_size: 0,
+            basefee: 0,
+            basefee_size: 0,
+            queued: 0,
+            queued_size: 0,
+            blob: 0,
+            blob_size: 0,
+            ..Default::default()
+        };
+
+        // the current size is zero so this should not exceed any limits
+        let config = PoolConfig::default();
+        assert!(!config.is_exceeded(pool_size));
+
+        // set them to be above the limits
+        let pool_size = PoolSize {
+            pending: config.pending_limit.max_txs + 1,
+            pending_size: config.pending_limit.max_size + 1,
+            basefee: config.basefee_limit.max_txs + 1,
+            basefee_size: config.basefee_limit.max_size + 1,
+            queued: config.queued_limit.max_txs + 1,
+            queued_size: config.queued_limit.max_size + 1,
+            blob: config.blob_limit.max_txs + 1,
+            blob_size: config.blob_limit.max_size + 1,
+            ..Default::default()
+        };
+
+        // now this should be above the limits
+        assert!(config.is_exceeded(pool_size));
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = LocalTransactionConfig::default();
+
+        assert!(!config.no_exemptions);
+        assert!(config.local_addresses.is_empty());
+        assert!(config.propagate_local_transactions);
+    }
+
+    #[test]
+    fn test_no_local_exemptions() {
+        let config = LocalTransactionConfig { no_exemptions: true, ..Default::default() };
+        assert!(config.no_local_exemptions());
+    }
+
+    #[test]
+    fn test_contains_local_address() {
+        let address = Address::new([1; 20]);
+        let mut local_addresses = AddressSet::default();
+        local_addresses.insert(address);
+
+        let config = LocalTransactionConfig { local_addresses, ..Default::default() };
+
+        // Should contain the inserted address
+        assert!(config.contains_local_address(&address));
+
+        // Should not contain another random address
+        assert!(!config.contains_local_address(&Address::new([2; 20])));
+    }
+
+    #[test]
+    fn test_is_local_with_no_exemptions() {
+        let address = Address::new([1; 20]);
+        let config = LocalTransactionConfig {
+            no_exemptions: true,
+            local_addresses: AddressSet::default(),
+            ..Default::default()
+        };
+
+        // Should return false as no exemptions is set to true
+        assert!(!config.is_local(TransactionOrigin::Local, &address));
+    }
+
+    #[test]
+    fn test_is_local_without_no_exemptions() {
+        let address = Address::new([1; 20]);
+        let mut local_addresses = AddressSet::default();
+        local_addresses.insert(address);
+
+        let config =
+            LocalTransactionConfig { no_exemptions: false, local_addresses, ..Default::default() };
+
+        // Should return true as the transaction origin is local
+        assert!(config.is_local(TransactionOrigin::Local, &Address::new([2; 20])));
+        assert!(config.is_local(TransactionOrigin::Local, &address));
+
+        // Should return true as the address is in the local_addresses set
+        assert!(config.is_local(TransactionOrigin::External, &address));
+        // Should return false as the address is not in the local_addresses set
+        assert!(!config.is_local(TransactionOrigin::External, &Address::new([2; 20])));
+    }
+
+    #[test]
+    fn test_set_propagate_local_transactions() {
+        let config = LocalTransactionConfig::default();
+        assert!(config.propagate_local_transactions);
+
+        let new_config = config.set_propagate_local_transactions(false);
+        assert!(!new_config.propagate_local_transactions);
+    }
+
+    #[test]
+    fn scale_pool_limit() {
+        let limit = SubPoolLimit::default();
+        let double = limit * 2;
+        assert_eq!(
+            double,
+            SubPoolLimit { max_txs: limit.max_txs * 2, max_size: limit.max_size * 2 }
+        )
+    }
+}

--- a/patches/reth-transaction-pool/src/error.rs
+++ b/patches/reth-transaction-pool/src/error.rs
@@ -1,0 +1,539 @@
+//! Transaction pool errors
+
+use std::any::Any;
+
+use alloy_eips::eip4844::BlobTransactionValidationError;
+use alloy_primitives::{Address, TxHash, U256};
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
+
+/// Transaction pool result type.
+pub type PoolResult<T> = Result<T, PoolError>;
+
+/// A trait for additional errors that can be thrown by the transaction pool.
+///
+/// For example during validation
+/// [`TransactionValidator::validate_transaction`](crate::validate::TransactionValidator::validate_transaction)
+pub trait PoolTransactionError: core::error::Error + Send + Sync {
+    /// Returns `true` if the error was caused by a transaction that is considered bad in the
+    /// context of the transaction pool and warrants peer penalization.
+    ///
+    /// See [`PoolError::is_bad_transaction`].
+    fn is_bad_transaction(&self) -> bool;
+
+    /// Returns a reference to `self` as a `&dyn Any`, enabling downcasting.
+    fn as_any(&self) -> &dyn Any;
+}
+
+// Needed for `#[error(transparent)]`
+impl core::error::Error for Box<dyn PoolTransactionError> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        (**self).source()
+    }
+}
+
+/// Transaction pool error.
+#[derive(Debug, thiserror::Error)]
+#[error("[{hash}]: {kind}")]
+pub struct PoolError {
+    /// The transaction hash that caused the error.
+    pub hash: TxHash,
+    /// The error kind.
+    pub kind: PoolErrorKind,
+}
+
+/// Transaction pool error kind.
+#[derive(Debug, thiserror::Error)]
+pub enum PoolErrorKind {
+    /// Same transaction already imported
+    #[error("already imported")]
+    AlreadyImported,
+    /// Thrown if a replacement transaction's gas price is below the already imported transaction
+    #[error("insufficient gas price to replace existing transaction")]
+    ReplacementUnderpriced,
+    /// The fee cap of the transaction is below the minimum fee cap determined by the protocol
+    #[error("transaction feeCap {0} below chain minimum")]
+    FeeCapBelowMinimumProtocolFeeCap(u128),
+    /// Thrown when the number of unique transactions of a sender exceeded the slot capacity.
+    #[error("rejected due to {0} being identified as a spammer")]
+    SpammerExceededCapacity(Address),
+    /// Thrown when a new transaction is added to the pool, but then immediately discarded to
+    /// respect the size limits of the pool.
+    #[error("transaction discarded outright due to pool size constraints")]
+    DiscardedOnInsert,
+    /// Thrown when the transaction is considered invalid.
+    #[error(transparent)]
+    InvalidTransaction(#[from] InvalidPoolTransactionError),
+    /// Thrown if the mutual exclusivity constraint (blob vs normal transaction) is violated.
+    #[error("transaction type {1} conflicts with existing transaction for {0}")]
+    ExistingConflictingTransactionType(Address, u8),
+    /// Any other error that occurred while inserting/validating a transaction. e.g. IO database
+    /// error
+    #[error(transparent)]
+    Other(#[from] Box<dyn core::error::Error + Send + Sync>),
+}
+
+// === impl PoolError ===
+
+impl PoolError {
+    /// Creates a new pool error.
+    pub fn new(hash: TxHash, kind: impl Into<PoolErrorKind>) -> Self {
+        Self { hash, kind: kind.into() }
+    }
+
+    /// Creates a new pool error with the `Other` kind.
+    pub fn other(
+        hash: TxHash,
+        error: impl Into<Box<dyn core::error::Error + Send + Sync>>,
+    ) -> Self {
+        Self { hash, kind: PoolErrorKind::Other(error.into()) }
+    }
+
+    /// Returns `true` if the error was caused by a transaction that is considered bad in the
+    /// context of the transaction pool and warrants peer penalization.
+    ///
+    /// Not all error variants are caused by the incorrect composition of the transaction (See also
+    /// [`InvalidPoolTransactionError`]) and can be caused by the current state of the transaction
+    /// pool. For example the transaction pool is already full or the error was caused by an
+    /// internal error, such as database errors.
+    ///
+    /// This function returns true only if the transaction will never make it into the pool because
+    /// its composition is invalid and the original sender should have detected this as well. This
+    /// is used to determine whether the original sender should be penalized for sending an
+    /// erroneous transaction.
+    #[inline]
+    pub fn is_bad_transaction(&self) -> bool {
+        #[expect(clippy::match_same_arms)]
+        match &self.kind {
+            PoolErrorKind::AlreadyImported => {
+                // already imported but not bad
+                false
+            }
+            PoolErrorKind::ReplacementUnderpriced => {
+                // already imported but not bad
+                false
+            }
+            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => {
+                // fee cap of the tx below the technical minimum determined by the protocol, see
+                // [MINIMUM_PROTOCOL_FEE_CAP](alloy_primitives::constants::MIN_PROTOCOL_BASE_FEE)
+                // although this transaction will always be invalid, we do not want to penalize the
+                // sender because this check simply could not be implemented by the client
+                false
+            }
+            PoolErrorKind::SpammerExceededCapacity(_) => {
+                // the sender exceeded the slot capacity, we should not penalize the peer for
+                // sending the tx because we don't know if all the transactions are sent from the
+                // same peer, there's also a chance that old transactions haven't been cleared yet
+                // (pool lags behind) and old transaction still occupy a slot in the pool
+                false
+            }
+            PoolErrorKind::DiscardedOnInsert => {
+                // valid tx but dropped due to size constraints
+                false
+            }
+            PoolErrorKind::InvalidTransaction(err) => {
+                // transaction rejected because it violates constraints
+                err.is_bad_transaction()
+            }
+            PoolErrorKind::Other(_) => {
+                // internal error unrelated to the transaction
+                false
+            }
+            PoolErrorKind::ExistingConflictingTransactionType(_, _) => {
+                // this is not a protocol error but an implementation error since the pool enforces
+                // exclusivity (blob vs normal tx) for all senders
+                false
+            }
+        }
+    }
+
+    /// Returns `true` if this is a blob sidecar error that should NOT be cached as a bad import.
+    ///
+    /// The transaction hash may be valid — the issue is peer-specific (e.g. malformed sidecar
+    /// data), so we penalize the peer but allow re-fetching from other peers.
+    #[inline]
+    pub const fn is_bad_blob_sidecar(&self) -> bool {
+        match &self.kind {
+            PoolErrorKind::InvalidTransaction(err) => err.is_bad_blob_sidecar(),
+            _ => false,
+        }
+    }
+}
+
+/// Represents all errors that can happen when validating transactions for the pool for EIP-4844
+/// transactions
+#[derive(Debug, thiserror::Error)]
+pub enum Eip4844PoolTransactionError {
+    /// Thrown if we're unable to find the blob for a transaction that was previously extracted
+    #[error("blob sidecar not found for EIP4844 transaction")]
+    MissingEip4844BlobSidecar,
+    /// Thrown if an EIP-4844 transaction without any blobs arrives
+    #[error("blobless blob transaction")]
+    NoEip4844Blobs,
+    /// Thrown if an EIP-4844 transaction arrives with too many blobs
+    #[error("too many blobs in transaction: have {have}, permitted {permitted}")]
+    TooManyEip4844Blobs {
+        /// Number of blobs the transaction has
+        have: u64,
+        /// Number of maximum blobs the transaction can have
+        permitted: u64,
+    },
+    /// Thrown if validating the blob sidecar for the transaction failed.
+    #[error(transparent)]
+    InvalidEip4844Blob(BlobTransactionValidationError),
+    /// EIP-4844 transactions are only accepted if they're gapless, meaning the previous nonce of
+    /// the transaction (`tx.nonce -1`) must either be in the pool or match the on chain nonce of
+    /// the sender.
+    ///
+    /// This error is thrown on validation if a valid blob transaction arrives with a nonce that
+    /// would introduce gap in the nonce sequence.
+    #[error("nonce too high")]
+    Eip4844NonceGap,
+    /// Thrown if blob transaction has an EIP-7594 style sidecar before Osaka.
+    #[error("unexpected eip-7594 sidecar before osaka")]
+    UnexpectedEip7594SidecarBeforeOsaka,
+    /// Thrown if blob transaction has an EIP-4844 style sidecar after Osaka.
+    #[error("unexpected eip-4844 sidecar after osaka")]
+    UnexpectedEip4844SidecarAfterOsaka,
+    /// Thrown if blob transaction has an EIP-7594 style sidecar but EIP-7594 support is disabled.
+    #[error("eip-7594 sidecar disallowed")]
+    Eip7594SidecarDisallowed,
+}
+
+/// Represents all errors that can happen when validating transactions for the pool for EIP-7702
+/// transactions
+#[derive(Debug, thiserror::Error)]
+pub enum Eip7702PoolTransactionError {
+    /// Thrown if the transaction has no items in its authorization list
+    #[error("no items in authorization list for EIP7702 transaction")]
+    MissingEip7702AuthorizationList,
+    /// Returned when a transaction with a nonce
+    /// gap is received from accounts with a deployed delegation or pending delegation.
+    #[error("gapped-nonce tx from delegated accounts")]
+    OutOfOrderTxFromDelegated,
+    /// Returned when the maximum number of in-flight
+    /// transactions is reached for specific accounts.
+    #[error("in-flight transaction limit reached for delegated accounts")]
+    InflightTxLimitReached,
+    /// Returned if a transaction has an authorization
+    /// signed by an address which already has in-flight transactions known to the
+    /// pool.
+    #[error("authority already reserved")]
+    AuthorityReserved,
+}
+
+/// Represents errors that can happen when validating transactions for the pool
+///
+/// See [`TransactionValidator`](crate::TransactionValidator).
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidPoolTransactionError {
+    /// Hard consensus errors
+    #[error(transparent)]
+    Consensus(#[from] InvalidTransactionError),
+    /// Thrown when a new transaction is added to the pool, but then immediately discarded to
+    /// respect the size limits of the pool.
+    #[error("transaction's gas limit {0} exceeds block's gas limit {1}")]
+    ExceedsGasLimit(u64, u64),
+    /// Thrown when a transaction's gas limit exceeds the configured maximum per-transaction limit.
+    #[error("transaction's gas limit {0} exceeds maximum per-transaction gas limit {1}")]
+    MaxTxGasLimitExceeded(u64, u64),
+    /// Thrown when a new transaction is added to the pool, but then immediately discarded to
+    /// respect the tx fee exceeds the configured cap
+    #[error("tx fee ({max_tx_fee_wei} wei) exceeds the configured cap ({tx_fee_cap_wei} wei)")]
+    ExceedsFeeCap {
+        /// max fee in wei of new tx submitted to the pool (e.g. 0.11534 ETH)
+        max_tx_fee_wei: u128,
+        /// configured tx fee cap in wei (e.g. 1.0 ETH)
+        tx_fee_cap_wei: u128,
+    },
+    /// Thrown when a new transaction is added to the pool, but then immediately discarded to
+    /// respect the `max_init_code_size`.
+    #[error("transaction's input size {0} exceeds max_init_code_size {1}")]
+    ExceedsMaxInitCodeSize(usize, usize),
+    /// Thrown if the input data of a transaction is greater
+    /// than some meaningful limit a user might use. This is not a consensus error
+    /// making the transaction invalid, rather a DOS protection.
+    #[error("oversized data: transaction size {size}, limit {limit}")]
+    OversizedData {
+        /// Size of the transaction/input data that exceeded the limit.
+        size: usize,
+        /// Configured limit that was exceeded.
+        limit: usize,
+    },
+    /// Thrown if the transaction's fee is below the minimum fee
+    #[error("transaction underpriced")]
+    Underpriced,
+    /// Thrown if the transaction's would require an account to be overdrawn
+    #[error("transaction overdraws from account, balance: {balance}, cost: {cost}")]
+    Overdraft {
+        /// Cost transaction is allowed to consume. See `reth_transaction_pool::PoolTransaction`.
+        cost: U256,
+        /// Balance of account.
+        balance: U256,
+    },
+    /// EIP-2681 error thrown if the nonce is higher or equal than `U64::max`
+    /// `<https://eips.ethereum.org/EIPS/eip-2681>`
+    #[error("nonce exceeds u64 limit")]
+    Eip2681,
+    /// EIP-4844 related errors
+    #[error(transparent)]
+    Eip4844(#[from] Eip4844PoolTransactionError),
+    /// EIP-7702 related errors
+    #[error(transparent)]
+    Eip7702(#[from] Eip7702PoolTransactionError),
+    /// Any other error that occurred while inserting/validating that is transaction specific
+    #[error(transparent)]
+    Other(Box<dyn PoolTransactionError>),
+    /// The transaction is specified to use less gas than required to start the
+    /// invocation.
+    #[error("intrinsic gas too low")]
+    IntrinsicGasTooLow,
+    /// The transaction priority fee is below the minimum required priority fee.
+    #[error("transaction priority fee below minimum required priority fee {minimum_priority_fee}")]
+    PriorityFeeBelowMinimum {
+        /// Minimum required priority fee.
+        minimum_priority_fee: u128,
+    },
+}
+
+// === impl InvalidPoolTransactionError ===
+
+impl InvalidPoolTransactionError {
+    /// Returns a new [`InvalidPoolTransactionError::Other`] instance with the given
+    /// [`PoolTransactionError`].
+    pub fn other<E: PoolTransactionError + 'static>(err: E) -> Self {
+        Self::Other(Box::new(err))
+    }
+
+    /// Returns `true` if the error was caused by a transaction that is considered bad in the
+    /// context of the transaction pool and warrants peer penalization.
+    ///
+    /// See [`PoolError::is_bad_transaction`].
+    #[expect(clippy::match_same_arms)]
+    #[inline]
+    fn is_bad_transaction(&self) -> bool {
+        match self {
+            Self::Consensus(err) => {
+                // transaction considered invalid by the consensus rules
+                // We do not consider the following errors to be erroneous transactions, since they
+                // depend on dynamic environmental conditions and should not be assumed to have been
+                // intentionally caused by the sender
+                match err {
+                    InvalidTransactionError::InsufficientFunds { .. } |
+                    InvalidTransactionError::NonceNotConsistent { .. } => {
+                        // transaction could just have arrived late/early
+                        false
+                    }
+                    InvalidTransactionError::GasTooLow |
+                    InvalidTransactionError::GasTooHigh |
+                    InvalidTransactionError::TipAboveFeeCap => {
+                        // these are technically not invalid
+                        false
+                    }
+                    InvalidTransactionError::FeeCapTooLow => {
+                        // dynamic, but not used during validation
+                        false
+                    }
+                    InvalidTransactionError::Eip2930Disabled |
+                    InvalidTransactionError::Eip1559Disabled |
+                    InvalidTransactionError::Eip4844Disabled |
+                    InvalidTransactionError::Eip7702Disabled => {
+                        // settings
+                        false
+                    }
+                    InvalidTransactionError::OldLegacyChainId |
+                    InvalidTransactionError::ChainIdMismatch |
+                    InvalidTransactionError::GasUintOverflow |
+                    InvalidTransactionError::TxTypeNotSupported |
+                    InvalidTransactionError::SignerAccountHasBytecode |
+                    InvalidTransactionError::GasLimitTooHigh => true,
+                }
+            }
+            Self::ExceedsGasLimit(_, _) => true,
+            Self::MaxTxGasLimitExceeded(_, _) => {
+                // local setting
+                false
+            }
+            Self::ExceedsFeeCap { max_tx_fee_wei: _, tx_fee_cap_wei: _ } => {
+                // local setting
+                false
+            }
+            Self::ExceedsMaxInitCodeSize(_, _) => true,
+            Self::OversizedData { .. } => true,
+            Self::Underpriced => {
+                // local setting
+                false
+            }
+            Self::IntrinsicGasTooLow => true,
+            Self::Overdraft { .. } => false,
+            Self::Other(err) => err.is_bad_transaction(),
+            Self::Eip2681 => true,
+            Self::Eip4844(eip4844_err) => {
+                match eip4844_err {
+                    Eip4844PoolTransactionError::MissingEip4844BlobSidecar => {
+                        // this is only reachable when blob transactions are reinjected and we're
+                        // unable to find the previously extracted blob
+                        false
+                    }
+                    Eip4844PoolTransactionError::InvalidEip4844Blob(_) => {
+                        // This is only reachable when the blob is invalid
+                        true
+                    }
+                    Eip4844PoolTransactionError::Eip4844NonceGap => {
+                        // it is possible that the pool sees `nonce n` before `nonce n-1` and this
+                        // is only thrown for valid(good) blob transactions
+                        false
+                    }
+                    Eip4844PoolTransactionError::NoEip4844Blobs => {
+                        // this is a malformed transaction and should not be sent over the network
+                        true
+                    }
+                    Eip4844PoolTransactionError::TooManyEip4844Blobs { .. } => {
+                        // this is a malformed transaction and should not be sent over the network
+                        true
+                    }
+                    Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka |
+                    Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka |
+                    Eip4844PoolTransactionError::Eip7594SidecarDisallowed => {
+                        // for now we do not want to penalize peers for broadcasting different
+                        // sidecars
+                        false
+                    }
+                }
+            }
+            Self::Eip7702(eip7702_err) => match eip7702_err {
+                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => {
+                    // as EIP-7702 specifies, 7702 transactions must have an non-empty authorization
+                    // list so this is a malformed transaction and should not be
+                    // sent over the network
+                    true
+                }
+                Eip7702PoolTransactionError::OutOfOrderTxFromDelegated => false,
+                Eip7702PoolTransactionError::InflightTxLimitReached => false,
+                Eip7702PoolTransactionError::AuthorityReserved => false,
+            },
+            Self::PriorityFeeBelowMinimum { .. } => false,
+        }
+    }
+
+    /// Returns `true` if this is a blob sidecar error (e.g. invalid proof, missing sidecar).
+    ///
+    /// These errors indicate the sidecar data from a specific peer was bad, but the transaction
+    /// hash itself may be valid when fetched from another peer.
+    #[inline]
+    pub const fn is_bad_blob_sidecar(&self) -> bool {
+        matches!(
+            self,
+            Self::Eip4844(
+                Eip4844PoolTransactionError::MissingEip4844BlobSidecar |
+                    Eip4844PoolTransactionError::InvalidEip4844Blob(_) |
+                    Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka |
+                    Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka |
+                    Eip4844PoolTransactionError::Eip7594SidecarDisallowed
+            )
+        )
+    }
+
+    /// Returns true if this is a [`Self::Consensus`] variant.
+    pub const fn as_consensus(&self) -> Option<&InvalidTransactionError> {
+        match self {
+            Self::Consensus(err) => Some(err),
+            _ => None,
+        }
+    }
+
+    /// Returns true if this is [`InvalidTransactionError::NonceNotConsistent`] and the
+    /// transaction's nonce is lower than the state's.
+    pub fn is_nonce_too_low(&self) -> bool {
+        match self {
+            Self::Consensus(err) => err.is_nonce_too_low(),
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if an import failed due to an oversized transaction
+    pub const fn is_oversized(&self) -> bool {
+        matches!(self, Self::OversizedData { .. })
+    }
+
+    /// Returns `true` if an import failed due to nonce gap.
+    pub const fn is_nonce_gap(&self) -> bool {
+        matches!(self, Self::Consensus(InvalidTransactionError::NonceNotConsistent { .. })) ||
+            matches!(self, Self::Eip4844(Eip4844PoolTransactionError::Eip4844NonceGap))
+    }
+
+    /// Returns the arbitrary error if it is [`InvalidPoolTransactionError::Other`]
+    pub fn as_other(&self) -> Option<&dyn PoolTransactionError> {
+        match self {
+            Self::Other(err) => Some(&**err),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the [`InvalidPoolTransactionError::Other`] value if this type is a
+    /// [`InvalidPoolTransactionError::Other`] of that type. Returns None otherwise.
+    pub fn downcast_other_ref<T: core::error::Error + 'static>(&self) -> Option<&T> {
+        let other = self.as_other()?;
+        other.as_any().downcast_ref()
+    }
+
+    /// Returns true if the this type is a [`InvalidPoolTransactionError::Other`] of that error
+    /// type. Returns false otherwise.
+    pub fn is_other<T: core::error::Error + 'static>(&self) -> bool {
+        self.as_other().map(|err| err.as_any().is::<T>()).unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(thiserror::Error, Debug)]
+    #[error("err")]
+    struct E;
+
+    impl PoolTransactionError for E {
+        fn is_bad_transaction(&self) -> bool {
+            false
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn other_downcast() {
+        let err = InvalidPoolTransactionError::Other(Box::new(E));
+        assert!(err.is_other::<E>());
+
+        assert!(err.downcast_other_ref::<E>().is_some());
+    }
+
+    #[test]
+    fn bad_blob_sidecar_detection() {
+        let err = PoolError::new(
+            TxHash::ZERO,
+            InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::InvalidEip4844Blob(
+                BlobTransactionValidationError::InvalidProof,
+            )),
+        );
+
+        assert!(err.is_bad_blob_sidecar());
+
+        let err = PoolError::new(
+            TxHash::ZERO,
+            InvalidPoolTransactionError::Eip4844(
+                Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
+            ),
+        );
+
+        assert!(err.is_bad_blob_sidecar());
+
+        let err = PoolError::new(
+            TxHash::ZERO,
+            InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::NoEip4844Blobs),
+        );
+
+        assert!(!err.is_bad_blob_sidecar());
+    }
+}

--- a/patches/reth-transaction-pool/src/identifier.rs
+++ b/patches/reth-transaction-pool/src/identifier.rs
@@ -1,0 +1,278 @@
+//! Identifier types for transactions and senders.
+use alloy_primitives::{map::AddressMap, Address};
+use rustc_hash::FxHashMap;
+
+/// An internal mapping of addresses.
+///
+/// This assigns a _unique_ [`SenderId`] for a new [`Address`].
+/// It has capacity for 2^64 unique addresses.
+#[derive(Debug, Default)]
+pub struct SenderIdentifiers {
+    /// The identifier to use next.
+    id: u64,
+    /// Assigned [`SenderId`] for an [`Address`].
+    address_to_id: AddressMap<SenderId>,
+    /// Reverse mapping of [`SenderId`] to [`Address`].
+    sender_to_address: FxHashMap<SenderId, Address>,
+}
+
+impl SenderIdentifiers {
+    /// Returns the address for the given identifier.
+    pub fn address(&self, id: &SenderId) -> Option<&Address> {
+        self.sender_to_address.get(id)
+    }
+
+    /// Returns the [`SenderId`] that belongs to the given address, if it exists
+    pub fn sender_id(&self, addr: &Address) -> Option<SenderId> {
+        self.address_to_id.get(addr).copied()
+    }
+
+    /// Returns the existing [`SenderId`] or assigns a new one if it's missing
+    pub fn sender_id_or_create(&mut self, addr: Address) -> SenderId {
+        self.sender_id(&addr).unwrap_or_else(|| {
+            let id = self.next_id();
+            self.address_to_id.insert(addr, id);
+            self.sender_to_address.insert(id, addr);
+            id
+        })
+    }
+
+    /// Returns the existing [`SenderId`] or assigns a new one if it's missing
+    pub fn sender_ids_or_create(
+        &mut self,
+        addrs: impl IntoIterator<Item = Address>,
+    ) -> Vec<SenderId> {
+        addrs.into_iter().map(|addr| self.sender_id_or_create(addr)).collect()
+    }
+
+    /// Returns the current identifier and increments the counter.
+    fn next_id(&mut self) -> SenderId {
+        let id = self.id;
+        self.id = self.id.wrapping_add(1);
+        id.into()
+    }
+}
+
+/// A _unique_ identifier for a sender of an address.
+///
+/// This is the identifier of an internal `address` mapping that is valid in the context of this
+/// program.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct SenderId(u64);
+
+impl SenderId {
+    /// Returns a `Bound` for [`TransactionId`] starting with nonce `0`
+    pub const fn start_bound(self) -> std::ops::Bound<TransactionId> {
+        std::ops::Bound::Included(TransactionId::new(self, 0))
+    }
+
+    /// Returns a `Range` for [`TransactionId`] starting with nonce `0` and ending with nonce
+    /// `u64::MAX`
+    pub const fn range(self) -> std::ops::RangeInclusive<TransactionId> {
+        TransactionId::new(self, 0)..=TransactionId::new(self, u64::MAX)
+    }
+
+    /// Converts the sender to a [`TransactionId`] with the given nonce.
+    pub const fn into_transaction_id(self, nonce: u64) -> TransactionId {
+        TransactionId::new(self, nonce)
+    }
+}
+
+impl From<u64> for SenderId {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// A unique identifier of a transaction of a Sender.
+///
+/// This serves as an identifier for dependencies of a transaction:
+/// A transaction with a nonce higher than the current state nonce depends on `tx.nonce - 1`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TransactionId {
+    /// Sender of this transaction
+    pub sender: SenderId,
+    /// Nonce of this transaction
+    pub nonce: u64,
+}
+
+impl TransactionId {
+    /// Create a new identifier pair
+    pub const fn new(sender: SenderId, nonce: u64) -> Self {
+        Self { sender, nonce }
+    }
+
+    /// Returns the [`TransactionId`] this transaction depends on.
+    ///
+    /// This returns `transaction_nonce - 1` if `transaction_nonce` is higher than the
+    /// `on_chain_nonce`
+    pub fn ancestor(transaction_nonce: u64, on_chain_nonce: u64, sender: SenderId) -> Option<Self> {
+        // SAFETY: transaction_nonce > on_chain_nonce ⇒ transaction_nonce >= 1
+        (transaction_nonce > on_chain_nonce).then(|| Self::new(sender, transaction_nonce - 1))
+    }
+
+    /// Returns the [`TransactionId`] that would come before this transaction.
+    pub fn unchecked_ancestor(&self) -> Option<Self> {
+        // SAFETY: self.nonce != 0 ⇒ self.nonce >= 1
+        (self.nonce != 0).then(|| Self::new(self.sender, self.nonce - 1))
+    }
+
+    /// Returns the [`TransactionId`] that directly follows this transaction: `self.nonce + 1`
+    pub const fn descendant(&self) -> Self {
+        Self::new(self.sender, self.next_nonce())
+    }
+
+    /// Returns the nonce that follows immediately after this one.
+    #[inline]
+    pub const fn next_nonce(&self) -> u64 {
+        self.nonce + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn test_transaction_id_new() {
+        let sender = SenderId(1);
+        let tx_id = TransactionId::new(sender, 5);
+        assert_eq!(tx_id.sender, sender);
+        assert_eq!(tx_id.nonce, 5);
+    }
+
+    #[test]
+    fn test_transaction_id_ancestor() {
+        let sender = SenderId(1);
+
+        // Special case with nonce 0 and higher on-chain nonce
+        let tx_id = TransactionId::ancestor(0, 1, sender);
+        assert_eq!(tx_id, None);
+
+        // Special case with nonce 0 and same on-chain nonce
+        let tx_id = TransactionId::ancestor(0, 0, sender);
+        assert_eq!(tx_id, None);
+
+        // Ancestor is the previous nonce if the transaction nonce is higher than the on-chain nonce
+        let tx_id = TransactionId::ancestor(5, 0, sender);
+        assert_eq!(tx_id, Some(TransactionId::new(sender, 4)));
+
+        // No ancestor if the transaction nonce is the same as the on-chain nonce
+        let tx_id = TransactionId::ancestor(5, 5, sender);
+        assert_eq!(tx_id, None);
+
+        // No ancestor if the transaction nonce is lower than the on-chain nonce
+        let tx_id = TransactionId::ancestor(5, 15, sender);
+        assert_eq!(tx_id, None);
+    }
+
+    #[test]
+    fn test_transaction_id_unchecked_ancestor() {
+        let sender = SenderId(1);
+
+        // Ancestor is the previous nonce if transaction nonce is higher than 0
+        let tx_id = TransactionId::new(sender, 5);
+        assert_eq!(tx_id.unchecked_ancestor(), Some(TransactionId::new(sender, 4)));
+
+        // No ancestor if transaction nonce is 0
+        let tx_id = TransactionId::new(sender, 0);
+        assert_eq!(tx_id.unchecked_ancestor(), None);
+    }
+
+    #[test]
+    fn test_transaction_id_descendant() {
+        let sender = SenderId(1);
+        let tx_id = TransactionId::new(sender, 5);
+        let descendant = tx_id.descendant();
+        assert_eq!(descendant, TransactionId::new(sender, 6));
+    }
+
+    #[test]
+    fn test_transaction_id_next_nonce() {
+        let sender = SenderId(1);
+        let tx_id = TransactionId::new(sender, 5);
+        assert_eq!(tx_id.next_nonce(), 6);
+    }
+
+    #[test]
+    fn test_transaction_id_ord_eq_sender() {
+        let tx1 = TransactionId::new(100u64.into(), 0u64);
+        let tx2 = TransactionId::new(100u64.into(), 1u64);
+        assert!(tx2 > tx1);
+        let set = BTreeSet::from([tx1, tx2]);
+        assert_eq!(set.into_iter().collect::<Vec<_>>(), vec![tx1, tx2]);
+    }
+
+    #[test]
+    fn test_transaction_id_ord() {
+        let tx1 = TransactionId::new(99u64.into(), 0u64);
+        let tx2 = TransactionId::new(100u64.into(), 1u64);
+        assert!(tx2 > tx1);
+        let set = BTreeSet::from([tx1, tx2]);
+        assert_eq!(set.into_iter().collect::<Vec<_>>(), vec![tx1, tx2]);
+    }
+
+    #[test]
+    fn test_address_retrieval() {
+        let mut identifiers = SenderIdentifiers::default();
+        let address = Address::new([1; 20]);
+        let id = identifiers.sender_id_or_create(address);
+        assert_eq!(identifiers.address(&id), Some(&address));
+    }
+
+    #[test]
+    fn test_sender_id_retrieval() {
+        let mut identifiers = SenderIdentifiers::default();
+        let address = Address::new([1; 20]);
+        let id = identifiers.sender_id_or_create(address);
+        assert_eq!(identifiers.sender_id(&address), Some(id));
+    }
+
+    #[test]
+    fn test_sender_id_or_create_existing() {
+        let mut identifiers = SenderIdentifiers::default();
+        let address = Address::new([1; 20]);
+        let id1 = identifiers.sender_id_or_create(address);
+        let id2 = identifiers.sender_id_or_create(address);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_sender_id_or_create_new() {
+        let mut identifiers = SenderIdentifiers::default();
+        let address1 = Address::new([1; 20]);
+        let address2 = Address::new([2; 20]);
+        let id1 = identifiers.sender_id_or_create(address1);
+        let id2 = identifiers.sender_id_or_create(address2);
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_next_id_wrapping() {
+        let mut identifiers = SenderIdentifiers { id: u64::MAX, ..Default::default() };
+
+        // The current ID is `u64::MAX`, the next ID should wrap around to 0.
+        let id1 = identifiers.next_id();
+        assert_eq!(id1, SenderId(u64::MAX));
+
+        // The next ID should now be 0 because of wrapping.
+        let id2 = identifiers.next_id();
+        assert_eq!(id2, SenderId(0));
+
+        // And then 1, continuing incrementing.
+        let id3 = identifiers.next_id();
+        assert_eq!(id3, SenderId(1));
+    }
+
+    #[test]
+    fn test_sender_id_start_bound() {
+        let sender = SenderId(1);
+        let start_bound = sender.start_bound();
+        if let std::ops::Bound::Included(tx_id) = start_bound {
+            assert_eq!(tx_id, TransactionId::new(sender, 0));
+        } else {
+            panic!("Expected included bound");
+        }
+    }
+}

--- a/patches/reth-transaction-pool/src/lib.rs
+++ b/patches/reth-transaction-pool/src/lib.rs
@@ -1,0 +1,861 @@
+//! Reth's transaction pool implementation.
+//!
+//! This crate provides a generic transaction pool implementation.
+//!
+//! ## Functionality
+//!
+//! The transaction pool is responsible for
+//!
+//!    - recording incoming transactions
+//!    - providing existing transactions
+//!    - ordering and providing the best transactions for block production
+//!    - monitoring memory footprint and enforce pool size limits
+//!    - storing blob data for transactions in a separate blobstore on insertion
+//!
+//! ## Transaction Flow: From Network/RPC to Pool
+//!
+//! Transactions enter the pool through two main paths:
+//!
+//! ### 1. Network Path (P2P)
+//!
+//! ```text
+//! Network Peer
+//!     ↓
+//! Transactions or NewPooledTransactionHashes message
+//!     ↓
+//! TransactionsManager (crates/net/network/src/transactions/mod.rs)
+//!     │
+//!     ├─→ For Transactions message:
+//!     │   ├─→ Validates message format
+//!     │   ├─→ Checks if transaction already known
+//!     │   ├─→ Marks peer as having seen the transaction
+//!     │   └─→ Queues for import
+//!     │
+//!     └─→ For NewPooledTransactionHashes message:
+//!         ├─→ Filters out already known transactions
+//!         ├─→ Queues unknown hashes for fetching
+//!         ├─→ Sends GetPooledTransactions request
+//!         ├─→ Receives PooledTransactions response
+//!         └─→ Queues fetched transactions for import
+//!             ↓
+//! pool.add_external_transactions() [Origin: External]
+//!     ↓
+//! Transaction Validation & Pool Addition
+//! ```
+//!
+//! ### 2. RPC Path (Local submission)
+//!
+//! ```text
+//! eth_sendRawTransaction RPC call
+//!     ├─→ Decodes raw bytes
+//!     └─→ Recovers sender
+//!         ↓
+//! pool.add_transaction() [Origin: Local]
+//!     ↓
+//! Transaction Validation & Pool Addition
+//! ```
+//!
+//! ### Transaction Origins
+//!
+//! - **Local**: Transactions submitted via RPC (trusted, may have different fee requirements)
+//! - **External**: Transactions from network peers (untrusted, subject to stricter validation)
+//! - **Private**: Local transactions that should not be propagated to the network
+//!
+//! ## Validation Process
+//!
+//! ### Stateless Checks
+//!
+//! Ethereum transactions undergo several stateless checks:
+//!
+//! - **Transaction Type**: Fork-dependent support (Legacy always, EIP-2930/1559/4844/7702 need
+//!   activation)
+//! - **Size**: Input data ≤ 128KB (default)
+//! - **Gas**: Limit ≤ block gas limit
+//! - **Fees**: Priority fee ≤ max fee; local tx fee cap; external minimum priority fee
+//! - **Chain ID**: Must match current chain
+//! - **Intrinsic Gas**: Sufficient for data and access lists
+//! - **Blobs** (EIP-4844): Valid count, KZG proofs
+//!
+//! ### Stateful Checks
+//!
+//! 1. **Sender**: No bytecode (unless EIP-7702 delegated in Prague)
+//! 2. **Nonce**: ≥ account nonce
+//! 3. **Balance**: Covers value + (`gas_limit` × `max_fee_per_gas`)
+//!
+//! ### Common Errors
+//!
+//! - [`NonceNotConsistent`](reth_primitives_traits::transaction::error::InvalidTransactionError::NonceNotConsistent): Nonce too low
+//! - [`InsufficientFunds`](reth_primitives_traits::transaction::error::InvalidTransactionError::InsufficientFunds): Insufficient balance
+//! - [`ExceedsGasLimit`](crate::error::InvalidPoolTransactionError::ExceedsGasLimit): Gas limit too
+//!   high
+//! - [`SignerAccountHasBytecode`](reth_primitives_traits::transaction::error::InvalidTransactionError::SignerAccountHasBytecode): EOA has code
+//! - [`Underpriced`](crate::error::InvalidPoolTransactionError::Underpriced): Fee too low
+//! - [`ReplacementUnderpriced`](crate::error::PoolErrorKind::ReplacementUnderpriced): Replacement
+//!   transaction fee too low
+//! - Blob errors:
+//!   - [`MissingEip4844BlobSidecar`](crate::error::Eip4844PoolTransactionError::MissingEip4844BlobSidecar): Missing sidecar
+//!   - [`InvalidEip4844Blob`](crate::error::Eip4844PoolTransactionError::InvalidEip4844Blob):
+//!     Invalid blob proofs
+//!   - [`NoEip4844Blobs`](crate::error::Eip4844PoolTransactionError::NoEip4844Blobs): EIP-4844
+//!     transaction without blobs
+//!   - [`TooManyEip4844Blobs`](crate::error::Eip4844PoolTransactionError::TooManyEip4844Blobs): Too
+//!     many blobs
+//!
+//! ## Subpool Design
+//!
+//! The pool maintains four distinct subpools, each serving a specific purpose
+//!
+//! ### Subpools
+//!
+//! 1. **Pending**: Ready for inclusion (no gaps, sufficient balance/fees)
+//! 2. **Queued**: Future transactions (nonce gaps or insufficient balance)
+//! 3. **`BaseFee`**: Valid but below current base fee
+//! 4. **Blob**: EIP-4844 transactions not pending due to insufficient base fee or blob fee
+//!
+//! ### State Transitions
+//!
+//! Transactions move between subpools based on state changes:
+//!
+//! ```text
+//! Queued ─────────→ BaseFee/Blob ────────→ Pending
+//!   ↑                      ↑                       │
+//!   │                      │                       │
+//!   └────────────────────┴─────────────────────┘
+//!         (demotions due to state changes)
+//! ```
+//!
+//! **Promotions**: Nonce gaps filled, balance/fee improvements
+//! **Demotions**: Nonce gaps created, balance/fee degradation
+//!
+//! ## Pool Maintenance
+//!
+//! 1. **Block Updates**: Removes mined txs, updates accounts/fees, triggers movements
+//! 2. **Size Enforcement**: Discards worst transactions when limits exceeded
+//! 3. **Propagation**: External (always), Local (configurable), Private (never)
+//!
+//! ## Assumptions
+//!
+//! ### Transaction type
+//!
+//! The pool expects certain ethereum related information from the generic transaction type of the
+//! pool ([`PoolTransaction`]), this includes gas price, base fee (EIP-1559 transactions), nonce
+//! etc. It makes no assumptions about the encoding format, but the transaction type must report its
+//! size so pool size limits (memory) can be enforced.
+//!
+//! ### Transaction ordering
+//!
+//! The pending pool contains transactions that can be mined on the current state.
+//! The order in which they're returned are determined by a `Priority` value returned by the
+//! `TransactionOrdering` type this pool is configured with.
+//!
+//! This is only used in the _pending_ pool to yield the best transactions for block production. The
+//! _base pool_ is ordered by base fee, and the _queued pool_ by current distance.
+//!
+//! ### Validation
+//!
+//! The pool itself does not validate incoming transactions, instead this should be provided by
+//! implementing `TransactionsValidator`. Only transactions that the validator returns as valid are
+//! included in the pool. It is assumed that transaction that are in the pool are either valid on
+//! the current state or could become valid after certain state changes. Transactions that can never
+//! become valid (e.g. nonce lower than current on chain nonce) will never be added to the pool and
+//! instead are discarded right away.
+//!
+//! ### State Changes
+//!
+//! New blocks trigger pool updates via changesets (see Pool Maintenance).
+//!
+//! ## Implementation details
+//!
+//! The `TransactionPool` trait exposes all externally used functionality of the pool, such as
+//! inserting, querying specific transactions by hash or retrieving the best transactions.
+//! In addition, it enables the registration of event listeners that are notified of state changes.
+//! Events are communicated via channels.
+//!
+//! ### Architecture
+//!
+//! The final `TransactionPool` is made up of two layers:
+//!
+//! The lowest layer is the actual pool implementations that manages (validated) transactions:
+//! [`TxPool`](crate::pool::txpool::TxPool). This is contained in a higher level pool type that
+//! guards the low level pool and handles additional listeners or metrics: [`PoolInner`].
+//!
+//! The transaction pool will be used by separate consumers (RPC, P2P), to make sharing easier, the
+//! [`Pool`] type is just an `Arc` wrapper around `PoolInner`. This is the usable type that provides
+//! the `TransactionPool` interface.
+//!
+//!
+//! ## Blob Transactions
+//!
+//! Blob transaction can be quite large hence they are stored in a separate blobstore. The pool is
+//! responsible for inserting blob data for new transactions into the blobstore.
+//! See also [`ValidTransaction`](validate::ValidTransaction)
+//!
+//!
+//! ## Examples
+//!
+//! Listen for new transactions and print them:
+//!
+//! ```
+//! use reth_chainspec::MAINNET;
+//! use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+//! use reth_tasks::Runtime;
+//! use reth_chainspec::ChainSpecProvider;
+//! use reth_transaction_pool::{TransactionValidationTaskExecutor, Pool, TransactionPool};
+//! use reth_transaction_pool::blobstore::InMemoryBlobStore;
+//! use reth_chainspec::EthereumHardforks;
+//! use reth_evm::ConfigureEvm;
+//! use alloy_consensus::Header;
+//! async fn t<C, Evm>(client: C, evm_config: Evm)
+//! where
+//!     C: ChainSpecProvider<ChainSpec: EthereumHardforks> + StateProviderFactory + BlockReaderIdExt<Header = Header> + Clone + 'static,
+//!     Evm: ConfigureEvm<Primitives: reth_primitives_traits::NodePrimitives<BlockHeader = Header>> + 'static,
+//! {
+//!     let blob_store = InMemoryBlobStore::default();
+//!     let runtime = Runtime::test();
+//!     let pool = Pool::eth_pool(
+//!         TransactionValidationTaskExecutor::eth(client, evm_config, blob_store.clone(), runtime),
+//!         blob_store,
+//!         Default::default(),
+//!     );
+//!   let mut transactions = pool.pending_transactions_listener();
+//!   tokio::task::spawn( async move {
+//!      while let Some(tx) = transactions.recv().await {
+//!          println!("New transaction: {:?}", tx);
+//!      }
+//!   });
+//!
+//!   // do something useful with the pool, like RPC integration
+//!
+//! # }
+//! ```
+//!
+//! Spawn maintenance task to keep the pool updated
+//!
+//! ```
+//! use futures_util::Stream;
+//! use reth_chain_state::CanonStateNotification;
+//! use reth_chainspec::{MAINNET, ChainSpecProvider, ChainSpec};
+//! use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+//! use reth_tasks::Runtime;
+//! use reth_transaction_pool::{TransactionValidationTaskExecutor, Pool};
+//! use reth_transaction_pool::blobstore::InMemoryBlobStore;
+//! use reth_transaction_pool::maintain::{maintain_transaction_pool_future};
+//! use reth_evm::ConfigureEvm;
+//! use reth_ethereum_primitives::EthPrimitives;
+//! use alloy_consensus::Header;
+//!
+//!  async fn t<C, St, Evm>(client: C, stream: St, evm_config: Evm)
+//!    where C: StateProviderFactory + BlockReaderIdExt<Header = Header> + ChainSpecProvider<ChainSpec = ChainSpec> + Clone + 'static,
+//!     St: Stream<Item = CanonStateNotification<EthPrimitives>> + Send + Unpin + 'static,
+//!     Evm: ConfigureEvm<Primitives = EthPrimitives> + 'static,
+//!     {
+//!     let blob_store = InMemoryBlobStore::default();
+//!     let runtime = Runtime::test();
+//!     let pool = Pool::eth_pool(
+//!         TransactionValidationTaskExecutor::eth(client.clone(), evm_config, blob_store.clone(), runtime.clone()),
+//!         blob_store,
+//!         Default::default(),
+//!     );
+//!
+//!   // spawn a task that listens for new blocks and updates the pool's transactions, mined transactions etc..
+//!   tokio::task::spawn(maintain_transaction_pool_future(client, pool, stream, runtime.clone(), Default::default()));
+//!
+//! # }
+//! ```
+//!
+//! ## Feature Flags
+//!
+//! - `serde` (default): Enable serde support
+//! - `test-utils`: Export utilities for testing
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+pub use imbl::OrdMap;
+
+pub use crate::{
+    batcher::{BatchTxProcessor, BatchTxRequest},
+    blobstore::{BlobStore, BlobStoreError},
+    config::{
+        LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit,
+        DEFAULT_MAX_INFLIGHT_DELEGATED_SLOTS, DEFAULT_PRICE_BUMP,
+        DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS, MAX_NEW_PENDING_TXS_NOTIFICATIONS,
+        REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+        TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+    },
+    error::PoolResult,
+    ordering::{CoinbaseTipOrdering, Priority, TransactionOrdering},
+    pool::{
+        blob_tx_priority, fee_delta, state::SubPool, AddedTransactionOutcome,
+        AllTransactionsEvents, FullTransactionEvent, NewTransactionEvent, TransactionEvent,
+        TransactionEvents, TransactionListenerKind,
+    },
+    traits::*,
+    validate::{
+        EthTransactionValidator, TransactionValidationOutcome, TransactionValidationTaskExecutor,
+        TransactionValidator, ValidPoolTransaction,
+    },
+};
+use crate::{identifier::TransactionId, pool::PoolInner};
+use alloy_eips::{
+    eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
+    eip7594::BlobTransactionSidecarVariant,
+};
+use alloy_primitives::{map::AddressSet, Address, TxHash, B128, B256, U256};
+use aquamarine as _;
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_eth_wire_types::HandleMempoolData;
+use reth_evm::ConfigureEvm;
+use reth_evm_ethereum::EthEvmConfig;
+use reth_execution_types::ChangedAccount;
+use reth_primitives_traits::{HeaderTy, Recovered};
+use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+use std::sync::Arc;
+use tokio::sync::mpsc::Receiver;
+use tracing::{instrument, trace};
+
+pub mod error;
+pub mod maintain;
+pub mod metrics;
+pub mod noop;
+pub mod pool;
+pub mod validate;
+
+pub mod batcher;
+pub mod blobstore;
+mod config;
+pub mod identifier;
+mod ordering;
+mod traits;
+
+#[cfg(any(test, feature = "test-utils"))]
+/// Common test helpers for mocking a pool
+pub mod test_utils;
+
+/// Type alias for default ethereum transaction pool
+pub type EthTransactionPool<Client, S, Evm = EthEvmConfig, T = EthPooledTransaction> = Pool<
+    TransactionValidationTaskExecutor<EthTransactionValidator<Client, T, Evm>>,
+    CoinbaseTipOrdering<T>,
+    S,
+>;
+
+/// A shareable, generic, customizable `TransactionPool` implementation.
+#[derive(Debug)]
+pub struct Pool<V, T: TransactionOrdering, S> {
+    /// Arc'ed instance of the pool internals
+    pool: Arc<PoolInner<V, T, S>>,
+}
+
+// === impl Pool ===
+
+impl<V, T, S> Pool<V, T, S>
+where
+    V: TransactionValidator,
+    T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
+    S: BlobStore,
+{
+    /// Create a new transaction pool instance.
+    pub fn new(validator: V, ordering: T, blob_store: S, config: PoolConfig) -> Self {
+        Self { pool: Arc::new(PoolInner::new(validator, ordering, blob_store, config)) }
+    }
+
+    /// Returns the wrapped pool internals.
+    pub fn inner(&self) -> &PoolInner<V, T, S> {
+        &self.pool
+    }
+
+    /// Get the config the pool was configured with.
+    pub fn config(&self) -> &PoolConfig {
+        self.inner().config()
+    }
+
+    /// Get the validator reference.
+    pub fn validator(&self) -> &V {
+        self.inner().validator()
+    }
+
+    /// Validates the given transaction
+    async fn validate(
+        &self,
+        origin: TransactionOrigin,
+        transaction: V::Transaction,
+    ) -> TransactionValidationOutcome<V::Transaction> {
+        self.pool.validator().validate_transaction(origin, transaction).await
+    }
+
+    /// Number of transactions in the entire pool
+    pub fn len(&self) -> usize {
+        self.pool.len()
+    }
+
+    /// Whether the pool is empty
+    pub fn is_empty(&self) -> bool {
+        self.pool.is_empty()
+    }
+
+    /// Returns whether or not the pool is over its configured size and transaction count limits.
+    pub fn is_exceeded(&self) -> bool {
+        self.pool.is_exceeded()
+    }
+
+    /// Returns the configured blob store.
+    pub fn blob_store(&self) -> &S {
+        self.pool.blob_store()
+    }
+}
+
+impl<Client, S, Evm> EthTransactionPool<Client, S, Evm>
+where
+    Client: ChainSpecProvider<ChainSpec: EthereumHardforks>
+        + StateProviderFactory
+        + Clone
+        + BlockReaderIdExt<Header = HeaderTy<Evm::Primitives>>
+        + 'static,
+    S: BlobStore,
+    Evm: ConfigureEvm + 'static,
+{
+    /// Returns a new [`Pool`] that uses the default [`TransactionValidationTaskExecutor`] when
+    /// validating [`EthPooledTransaction`]s and ords via [`CoinbaseTipOrdering`]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reth_chainspec::MAINNET;
+    /// use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+    /// use reth_tasks::Runtime;
+    /// use reth_chainspec::ChainSpecProvider;
+    /// use reth_transaction_pool::{
+    ///     blobstore::InMemoryBlobStore, Pool, TransactionValidationTaskExecutor,
+    /// };
+    /// use reth_chainspec::EthereumHardforks;
+    /// use reth_evm::ConfigureEvm;
+    /// use alloy_consensus::Header;
+    /// # fn t<C, Evm>(client: C, evm_config: Evm, runtime: Runtime)
+    /// # where
+    /// #     C: ChainSpecProvider<ChainSpec: EthereumHardforks> + StateProviderFactory + BlockReaderIdExt<Header = Header> + Clone + 'static,
+    /// #     Evm: ConfigureEvm<Primitives: reth_primitives_traits::NodePrimitives<BlockHeader = Header>> + 'static,
+    /// # {
+    /// let blob_store = InMemoryBlobStore::default();
+    /// let pool = Pool::eth_pool(
+    ///     TransactionValidationTaskExecutor::eth(
+    ///         client,
+    ///         evm_config,
+    ///         blob_store.clone(),
+    ///         runtime,
+    ///     ),
+    ///     blob_store,
+    ///     Default::default(),
+    /// );
+    /// # }
+    /// ```
+    pub fn eth_pool(
+        validator: TransactionValidationTaskExecutor<
+            EthTransactionValidator<Client, EthPooledTransaction, Evm>,
+        >,
+        blob_store: S,
+        config: PoolConfig,
+    ) -> Self {
+        Self::new(validator, CoinbaseTipOrdering::default(), blob_store, config)
+    }
+}
+
+/// implements the `TransactionPool` interface for various transaction pool API consumers.
+impl<V, T, S> TransactionPool for Pool<V, T, S>
+where
+    V: TransactionValidator,
+    <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
+    S: BlobStore,
+{
+    type Transaction = T::Transaction;
+
+    fn pool_size(&self) -> PoolSize {
+        self.pool.size()
+    }
+
+    fn block_info(&self) -> BlockInfo {
+        self.pool.block_info()
+    }
+
+    async fn add_transaction_and_subscribe(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> PoolResult<TransactionEvents> {
+        let tx = self.validate(origin, transaction).await;
+        self.pool.add_transaction_and_subscribe(origin, tx)
+    }
+
+    async fn add_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> PoolResult<AddedTransactionOutcome> {
+        let tx = self.validate(origin, transaction).await;
+        let mut results = self.pool.add_transactions(origin, std::iter::once(tx));
+        results.pop().expect("result length is the same as the input")
+    }
+
+    async fn add_transactions(
+        &self,
+        origin: TransactionOrigin,
+        transactions: Vec<Self::Transaction>,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        if transactions.is_empty() {
+            return Vec::new()
+        }
+        let validated = self
+            .pool
+            .validator()
+            .validate_transactions(transactions.into_iter().map(|tx| (origin, tx)))
+            .await;
+        self.pool.add_transactions(origin, validated)
+    }
+
+    async fn add_transactions_with_origins(
+        &self,
+        transactions: Vec<(TransactionOrigin, Self::Transaction)>,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        if transactions.is_empty() {
+            return Vec::new()
+        }
+        let origins: Vec<_> = transactions.iter().map(|(origin, _)| *origin).collect();
+        let validated = self.pool.validator().validate_transactions(transactions).await;
+        self.pool.add_transactions_with_origins(origins.into_iter().zip(validated))
+    }
+
+    fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents> {
+        self.pool.add_transaction_event_listener(tx_hash)
+    }
+
+    fn all_transactions_event_listener(&self) -> AllTransactionsEvents<Self::Transaction> {
+        self.pool.add_all_transactions_event_listener()
+    }
+
+    fn pending_transactions_listener_for(&self, kind: TransactionListenerKind) -> Receiver<TxHash> {
+        self.pool.add_pending_listener(kind)
+    }
+
+    fn blob_transaction_sidecars_listener(&self) -> Receiver<NewBlobSidecar> {
+        self.pool.add_blob_sidecar_listener()
+    }
+
+    fn new_transactions_listener_for(
+        &self,
+        kind: TransactionListenerKind,
+    ) -> Receiver<NewTransactionEvent<Self::Transaction>> {
+        self.pool.add_new_transaction_listener(kind)
+    }
+
+    fn pooled_transaction_hashes(&self) -> Vec<TxHash> {
+        self.pool.pooled_transactions_hashes()
+    }
+
+    fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash> {
+        self.pool.pooled_transactions_hashes_max(max)
+    }
+
+    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.pooled_transactions()
+    }
+
+    fn pooled_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.pooled_transactions_max(max)
+    }
+
+    fn get_pooled_transaction_elements(
+        &self,
+        tx_hashes: Vec<TxHash>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled> {
+        self.pool.get_pooled_transaction_elements(tx_hashes, limit)
+    }
+
+    fn append_pooled_transaction_elements(
+        &self,
+        tx_hashes: &[TxHash],
+        limit: GetPooledTransactionLimit,
+        out: &mut Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>,
+    ) {
+        self.pool.append_pooled_transaction_elements(tx_hashes, limit, out)
+    }
+
+    fn get_pooled_transaction_element(
+        &self,
+        tx_hash: TxHash,
+    ) -> Option<Recovered<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
+    {
+        self.pool.get_pooled_transaction_element(tx_hash)
+    }
+
+    fn best_transactions(
+        &self,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        Box::new(self.pool.best_transactions())
+    }
+
+    fn best_transactions_with_attributes(
+        &self,
+        best_transactions_attributes: BestTransactionsAttributes,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        self.pool.best_transactions_with_attributes(best_transactions_attributes)
+    }
+
+    fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.pending_transactions()
+    }
+
+    fn get_pending_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_pending_transaction_by_sender_and_nonce(sender, nonce)
+    }
+
+    fn pending_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.pending_transactions_max(max)
+    }
+
+    fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.queued_transactions()
+    }
+
+    fn pending_and_queued_txn_count(&self) -> (usize, usize) {
+        let data = self.pool.get_pool_data();
+        let pending = data.pending_transactions_count();
+        let queued = data.queued_transactions_count();
+        (pending, queued)
+    }
+
+    fn all_transactions(&self) -> AllPoolTransactions<Self::Transaction> {
+        self.pool.all_transactions()
+    }
+
+    fn all_transaction_hashes(&self) -> Vec<TxHash> {
+        self.pool.all_transaction_hashes()
+    }
+
+    fn remove_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.remove_transactions(hashes)
+    }
+
+    fn remove_transactions_and_descendants(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.remove_transactions_and_descendants(hashes)
+    }
+
+    fn remove_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.remove_transactions_by_sender(sender)
+    }
+
+    fn prune_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.prune_transactions(hashes)
+    }
+
+    fn retain_unknown<A>(&self, announcement: &mut A)
+    where
+        A: HandleMempoolData,
+    {
+        self.pool.retain_unknown(announcement)
+    }
+
+    fn get(&self, tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner().get(tx_hash)
+    }
+
+    fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner().get_all(txs)
+    }
+
+    fn on_propagated(&self, txs: PropagatedTransactions) {
+        self.inner().on_propagated(txs)
+    }
+
+    fn get_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_transactions_by_sender(sender)
+    }
+
+    fn get_pending_transactions_with_predicate(
+        &self,
+        predicate: impl FnMut(&ValidPoolTransaction<Self::Transaction>) -> bool,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.pending_transactions_with_predicate(predicate)
+    }
+
+    fn get_pending_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_pending_transactions_by_sender(sender)
+    }
+
+    fn get_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_queued_transactions_by_sender(sender)
+    }
+
+    fn get_highest_transaction_by_sender(
+        &self,
+        sender: Address,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_highest_transaction_by_sender(sender)
+    }
+
+    fn get_highest_consecutive_transaction_by_sender(
+        &self,
+        sender: Address,
+        on_chain_nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_highest_consecutive_transaction_by_sender(sender, on_chain_nonce)
+    }
+
+    fn get_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        let sender_id = self.pool.sender_id(&sender)?;
+        let transaction_id = TransactionId::new(sender_id, nonce);
+
+        self.inner().get_pool_data().all().get(&transaction_id).map(|tx| tx.transaction.clone())
+    }
+
+    fn get_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_transactions_by_origin(origin)
+    }
+
+    /// Returns all pending transactions filtered by [`TransactionOrigin`]
+    fn get_pending_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_pending_transactions_by_origin(origin)
+    }
+
+    fn unique_senders(&self) -> AddressSet {
+        self.pool.unique_senders()
+    }
+
+    fn get_blob(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        self.pool.blob_store().get(tx_hash)
+    }
+
+    fn get_all_blobs(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<(TxHash, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
+        self.pool.blob_store().get_all(tx_hashes)
+    }
+
+    fn get_all_blobs_exact(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        self.pool.blob_store().get_exact(tx_hashes)
+    }
+
+    fn get_blobs_for_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
+        self.pool.blob_store().get_by_versioned_hashes_v1(versioned_hashes)
+    }
+
+    fn get_blobs_for_versioned_hashes_v2(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
+        self.pool.blob_store().get_by_versioned_hashes_v2(versioned_hashes)
+    }
+
+    fn get_blobs_for_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
+        self.pool.blob_store().get_by_versioned_hashes_v3(versioned_hashes)
+    }
+
+    fn get_blobs_for_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        self.pool.blob_store().get_by_versioned_hashes_v4(versioned_hashes, indices_bitarray)
+    }
+}
+
+impl<V, T, S> TransactionPoolExt for Pool<V, T, S>
+where
+    V: TransactionValidator,
+    <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
+    S: BlobStore,
+{
+    type Block = V::Block;
+
+    #[instrument(skip(self), target = "txpool")]
+    fn set_block_info(&self, info: BlockInfo) {
+        trace!(target: "txpool", "updating pool block info");
+        self.pool.set_block_info(info)
+    }
+
+    fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_, Self::Block>) {
+        self.pool.on_canonical_state_change(update);
+    }
+
+    fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
+        self.pool.update_accounts(accounts);
+    }
+
+    fn delete_blob(&self, tx: TxHash) {
+        self.pool.delete_blob(tx)
+    }
+
+    fn delete_blobs(&self, txs: Vec<TxHash>) {
+        self.pool.delete_blobs(txs)
+    }
+
+    fn cleanup_blobs(&self) {
+        self.pool.cleanup_blobs()
+    }
+}
+
+impl<V, T: TransactionOrdering, S> Clone for Pool<V, T, S> {
+    fn clone(&self) -> Self {
+        Self { pool: Arc::clone(&self.pool) }
+    }
+}

--- a/patches/reth-transaction-pool/src/lib.rs
+++ b/patches/reth-transaction-pool/src/lib.rs
@@ -275,6 +275,14 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// This crate is a near-verbatim vendored copy of upstream `reth-transaction-pool`, which
+// keeps the `unnameable-types` lint disabled (see reth's root Cargo.toml:
+// `# rust.unnameable-types = "warn"`). Upstream ships several `pub` types in private
+// modules that are reachable through the public API but not nameable (e.g.
+// `pool::update::UpdateOutcome`, `validate::task::ValidationJobSender`). The Mantle
+// workspace enables that lint fork-wide, so allow it here to stay aligned with upstream
+// rather than diverging the vendored source.
+#![allow(unnameable_types)]
 
 pub use imbl::OrdMap;
 

--- a/patches/reth-transaction-pool/src/maintain.rs
+++ b/patches/reth-transaction-pool/src/maintain.rs
@@ -1,0 +1,967 @@
+//! Support for maintaining the state of the transaction pool
+
+use crate::{
+    blobstore::{BlobSidecarConverter, BlobStoreCanonTracker, BlobStoreUpdates},
+    error::PoolError,
+    metrics::MaintainPoolMetrics,
+    traits::{CanonicalStateUpdate, EthPoolTransaction, TransactionPool, TransactionPoolExt},
+    AllPoolTransactions, BlobTransactionSidecarVariant, BlockInfo, PoolTransaction, PoolUpdateKind,
+    TransactionOrigin,
+};
+use alloy_consensus::{transaction::TxHashRef, BlockHeader, Typed2718};
+use alloy_eips::{BlockNumberOrTag, Decodable2718, Encodable2718};
+use alloy_primitives::{
+    map::{AddressSet, HashSet},
+    Address, BlockHash, BlockNumber, Bytes,
+};
+use alloy_rlp::Encodable;
+use futures_util::{
+    future::{BoxFuture, Fuse, FusedFuture},
+    FutureExt, Stream, StreamExt,
+};
+use reth_chain_state::CanonStateNotification;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_execution_types::ChangedAccount;
+use reth_fs_util::FsPathError;
+use reth_primitives_traits::{
+    transaction::signed::SignedTransaction, NodePrimitives, SealedHeader,
+};
+use reth_storage_api::{errors::provider::ProviderError, BlockReaderIdExt, StateProviderFactory};
+use reth_tasks::Runtime;
+use serde::{Deserialize, Serialize};
+use std::{
+    borrow::Borrow,
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tokio::{
+    sync::oneshot,
+    time::{self, Duration},
+};
+use tracing::{debug, error, info, trace, warn};
+
+/// Maximum amount of time non-executable transaction are queued.
+pub const MAX_QUEUED_TRANSACTION_LIFETIME: Duration = Duration::from_secs(3 * 60 * 60);
+
+/// Additional settings for maintaining the transaction pool
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaintainPoolConfig {
+    /// Maximum (reorg) depth we handle when updating the transaction pool: `new.number -
+    /// last_seen.number`
+    ///
+    /// Default: 64 (2 epochs)
+    pub max_update_depth: u64,
+    /// Maximum number of accounts to reload from state at once when updating the transaction pool.
+    ///
+    /// Default: 100
+    pub max_reload_accounts: usize,
+
+    /// Maximum amount of time non-executable, non local transactions are queued.
+    /// Default: 3 hours
+    pub max_tx_lifetime: Duration,
+
+    /// Apply no exemptions to the locally received transactions.
+    ///
+    /// This includes:
+    ///   - no price exemptions
+    ///   - no eviction exemptions
+    pub no_local_exemptions: bool,
+}
+
+impl Default for MaintainPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_update_depth: 64,
+            max_reload_accounts: 100,
+            max_tx_lifetime: MAX_QUEUED_TRANSACTION_LIFETIME,
+            no_local_exemptions: false,
+        }
+    }
+}
+
+/// Settings for local transaction backup task
+#[derive(Debug, Clone, Default)]
+pub struct LocalTransactionBackupConfig {
+    /// Path to transactions backup file
+    pub transactions_path: Option<PathBuf>,
+}
+
+impl LocalTransactionBackupConfig {
+    /// Receive path to transactions backup and return initialized config
+    pub const fn with_local_txs_backup(transactions_path: PathBuf) -> Self {
+        Self { transactions_path: Some(transactions_path) }
+    }
+}
+
+/// Returns a spawnable future for maintaining the state of the transaction pool.
+pub fn maintain_transaction_pool_future<N, Client, P, St>(
+    client: Client,
+    pool: P,
+    events: St,
+    task_spawner: Runtime,
+    config: MaintainPoolConfig,
+) -> BoxFuture<'static, ()>
+where
+    N: NodePrimitives,
+    Client: StateProviderFactory
+        + BlockReaderIdExt<Header = N::BlockHeader>
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = N::BlockHeader> + EthereumHardforks>
+        + Clone
+        + 'static,
+    P: TransactionPoolExt<Transaction: PoolTransaction<Consensus = N::SignedTx>, Block = N::Block>
+        + 'static,
+    St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
+{
+    async move {
+        maintain_transaction_pool(client, pool, events, task_spawner, config).await;
+    }
+    .boxed()
+}
+
+/// Maintains the state of the transaction pool by handling new blocks and reorgs.
+///
+/// This listens for any new blocks and reorgs and updates the transaction pool's state accordingly
+pub async fn maintain_transaction_pool<N, Client, P, St>(
+    client: Client,
+    pool: P,
+    mut events: St,
+    task_spawner: Runtime,
+    config: MaintainPoolConfig,
+) where
+    N: NodePrimitives,
+    Client: StateProviderFactory
+        + BlockReaderIdExt<Header = N::BlockHeader>
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = N::BlockHeader> + EthereumHardforks>
+        + Clone
+        + 'static,
+    P: TransactionPoolExt<Transaction: PoolTransaction<Consensus = N::SignedTx>, Block = N::Block>
+        + 'static,
+    St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
+{
+    let metrics = MaintainPoolMetrics::default();
+    let MaintainPoolConfig { max_update_depth, max_reload_accounts, .. } = config;
+    // ensure the pool points to latest state
+    if let Ok(Some(latest)) = client.header_by_number_or_tag(BlockNumberOrTag::Latest) {
+        let latest = SealedHeader::seal_slow(latest);
+        let chain_spec = client.chain_spec();
+        let info = BlockInfo {
+            block_gas_limit: latest.gas_limit(),
+            last_seen_block_hash: latest.hash(),
+            last_seen_block_number: latest.number(),
+            pending_basefee: chain_spec
+                .next_block_base_fee(latest.header(), latest.timestamp())
+                .unwrap_or_default(),
+            pending_blob_fee: latest
+                .maybe_next_block_blob_fee(chain_spec.blob_params_at_timestamp(latest.timestamp())),
+        };
+        pool.set_block_info(info);
+    }
+
+    // keeps track of mined blob transaction so we can clean finalized transactions
+    let mut blob_store_tracker = BlobStoreCanonTracker::default();
+
+    // keeps track of the latest finalized block
+    let mut last_finalized_block =
+        FinalizedBlockTracker::new(client.finalized_block_number().ok().flatten());
+
+    // keeps track of any dirty accounts that we know of are out of sync with the pool
+    let mut dirty_addresses = HashSet::default();
+
+    // keeps track of the state of the pool wrt to blocks
+    let mut maintained_state = MaintainedPoolState::InSync;
+
+    // the future that reloads accounts from state
+    let mut reload_accounts_fut = Fuse::terminated();
+
+    // eviction interval for stale non local txs
+    let mut stale_eviction_interval = time::interval(config.max_tx_lifetime);
+
+    // toggle for the first notification
+    let mut first_event = true;
+
+    // The update loop that waits for new blocks and reorgs and performs pool updated
+    // Listen for new chain events and derive the update action for the pool
+    loop {
+        trace!(target: "txpool", state=?maintained_state, "awaiting new block or reorg");
+
+        metrics.set_dirty_accounts_len(dirty_addresses.len());
+        let pool_info = pool.block_info();
+
+        // after performing a pool update after a new block we have some time to properly update
+        // dirty accounts and correct if the pool drifted from current state, for example after
+        // restart or a pipeline run
+        if maintained_state.is_drifted() {
+            metrics.inc_drift();
+            // assuming all senders are dirty
+            dirty_addresses = pool.unique_senders();
+            // make sure we toggle the state back to in sync
+            maintained_state = MaintainedPoolState::InSync;
+        }
+
+        // if we have accounts that are out of sync with the pool, we reload them in chunks
+        if !dirty_addresses.is_empty() && reload_accounts_fut.is_terminated() {
+            let (tx, rx) = oneshot::channel();
+            let c = client.clone();
+            let at = pool_info.last_seen_block_hash;
+            let fut = if dirty_addresses.len() > max_reload_accounts {
+                // need to chunk accounts to reload
+                let accs_to_reload =
+                    dirty_addresses.iter().copied().take(max_reload_accounts).collect::<Vec<_>>();
+                for acc in &accs_to_reload {
+                    // make sure we remove them from the dirty set
+                    dirty_addresses.remove(acc);
+                }
+                async move {
+                    let res = load_accounts(c, at, accs_to_reload);
+                    let _ = tx.send(res);
+                }
+                .boxed()
+            } else {
+                // can fetch all dirty accounts at once
+                let accs_to_reload = std::mem::take(&mut dirty_addresses);
+                async move {
+                    let res = load_accounts(c, at, accs_to_reload);
+                    let _ = tx.send(res);
+                }
+                .boxed()
+            };
+            reload_accounts_fut = rx.fuse();
+            task_spawner.spawn_blocking_task(fut);
+        }
+
+        // check if we have a new finalized block
+        if let Some(finalized) =
+            last_finalized_block.update(client.finalized_block_number().ok().flatten()) &&
+            let BlobStoreUpdates::Finalized(blobs) =
+                blob_store_tracker.on_finalized_block(finalized)
+        {
+            metrics.inc_deleted_tracked_blobs(blobs.len());
+            // remove all finalized blobs from the blob store
+            pool.delete_blobs(blobs);
+            // and also do periodic cleanup
+            let pool = pool.clone();
+            task_spawner.spawn_blocking_task(async move {
+                debug!(target: "txpool", finalized_block = %finalized, "cleaning up blob store");
+                pool.cleanup_blobs();
+            });
+        }
+
+        // outcomes of the futures we are waiting on
+        let mut event = None;
+        let mut reloaded = None;
+
+        // select of account reloads and new canonical state updates which should arrive at the rate
+        // of the block time
+        tokio::select! {
+            res = &mut reload_accounts_fut =>  {
+                reloaded = Some(res);
+            }
+            ev = events.next() =>  {
+                 if ev.is_none() {
+                    // the stream ended, we are done
+                    break;
+                }
+                event = ev;
+                // on receiving the first event on start up, mark the pool as drifted to explicitly
+                // trigger revalidation and clear out outdated txs.
+                if first_event {
+                    maintained_state = MaintainedPoolState::Drifted;
+                    first_event = false
+                }
+            }
+            _ = stale_eviction_interval.tick() => {
+                let queued = pool
+                    .queued_transactions();
+                let mut stale_blobs = Vec::new();
+                let now = std::time::Instant::now();
+                let stale_txs: Vec<_> = queued
+                    .into_iter()
+                    .filter(|tx| {
+                        // filter stale transactions based on config
+                        (tx.origin.is_external() || config.no_local_exemptions) && now - tx.timestamp > config.max_tx_lifetime
+                    })
+                    .map(|tx| {
+                        if tx.is_eip4844() {
+                            stale_blobs.push(*tx.hash());
+                        }
+                        *tx.hash()
+                    })
+                    .collect();
+                debug!(target: "txpool", count=%stale_txs.len(), "removing stale transactions");
+                pool.remove_transactions(stale_txs);
+                pool.delete_blobs(stale_blobs);
+            }
+        }
+        // handle the result of the account reload
+        match reloaded {
+            Some(Ok(Ok(LoadedAccounts { accounts, failed_to_load }))) => {
+                // reloaded accounts successfully
+                // extend accounts we failed to load from database
+                dirty_addresses.extend(failed_to_load);
+                // update the pool with the loaded accounts
+                pool.update_accounts(accounts);
+            }
+            Some(Ok(Err(res))) => {
+                // Failed to load accounts from state
+                let (accs, err) = *res;
+                debug!(target: "txpool", %err, "failed to load accounts");
+                dirty_addresses.extend(accs);
+            }
+            Some(Err(_)) => {
+                // failed to receive the accounts, sender dropped, only possible if task panicked
+                maintained_state = MaintainedPoolState::Drifted;
+            }
+            None => {}
+        }
+
+        // handle the new block or reorg
+        let Some(event) = event else { continue };
+        match event {
+            CanonStateNotification::Reorg { old, new } => {
+                let (old_blocks, old_state) = old.inner();
+                let (new_blocks, new_state) = new.inner();
+                let new_tip = new_blocks.tip();
+                let new_first = new_blocks.first();
+                let old_first = old_blocks.first();
+
+                // check if the reorg is not canonical with the pool's block
+                if !(old_first.parent_hash() == pool_info.last_seen_block_hash ||
+                    new_first.parent_hash() == pool_info.last_seen_block_hash)
+                {
+                    // the new block points to a higher block than the oldest block in the old chain
+                    maintained_state = MaintainedPoolState::Drifted;
+                }
+
+                let chain_spec = client.chain_spec();
+
+                // fees for the next block: `new_tip+1`
+                let pending_block_base_fee = chain_spec
+                    .next_block_base_fee(new_tip.header(), new_tip.timestamp())
+                    .unwrap_or_default();
+                let pending_block_blob_fee = new_tip.header().maybe_next_block_blob_fee(
+                    chain_spec.blob_params_at_timestamp(new_tip.timestamp()),
+                );
+
+                // we know all changed account in the new chain
+                let new_changed_accounts: HashSet<_> =
+                    new_state.changed_accounts().map(ChangedAccountEntry).collect();
+
+                // find all accounts that were changed in the old chain but _not_ in the new chain
+                let missing_changed_acc = old_state
+                    .accounts_iter()
+                    .map(|(a, _)| a)
+                    .filter(|addr| !new_changed_accounts.contains(addr));
+
+                // for these we need to fetch the nonce+balance from the db at the new tip
+                let mut changed_accounts =
+                    match load_accounts(client.clone(), new_tip.hash(), missing_changed_acc) {
+                        Ok(LoadedAccounts { accounts, failed_to_load }) => {
+                            // extend accounts we failed to load from database
+                            dirty_addresses.extend(failed_to_load);
+
+                            accounts
+                        }
+                        Err(err) => {
+                            let (addresses, err) = *err;
+                            debug!(
+                                target: "txpool",
+                                %err,
+                                "failed to load missing changed accounts at new tip: {:?}",
+                                new_tip.hash()
+                            );
+                            dirty_addresses.extend(addresses);
+                            vec![]
+                        }
+                    };
+
+                // also include all accounts from new chain
+                // we can use extend here because they are unique
+                changed_accounts.extend(new_changed_accounts.into_iter().map(|entry| entry.0));
+
+                // all transactions mined in the new chain
+                let new_mined_transactions: HashSet<_> = new_blocks.transaction_hashes().collect();
+
+                // update the pool then re-inject the pruned transactions
+                // find all transactions that were mined in the old chain but not in the new chain
+                let pruned_old_transactions = old_blocks
+                    .transactions_ecrecovered()
+                    .filter(|tx| !new_mined_transactions.contains(tx.tx_hash()))
+                    .filter_map(|tx| {
+                        if tx.is_eip4844() {
+                            // reorged blobs no longer include the blob, which is necessary for
+                            // validating the transaction. Even though the transaction could have
+                            // been validated previously, we still need the blob in order to
+                            // accurately set the transaction's
+                            // encoded-length which is propagated over the network.
+                            pool.get_blob(*tx.tx_hash())
+                                .ok()
+                                .flatten()
+                                .map(Arc::unwrap_or_clone)
+                                .and_then(|sidecar| {
+                                    <P as TransactionPool>::Transaction::try_from_eip4844(
+                                        tx, sidecar,
+                                    )
+                                })
+                        } else {
+                            <P as TransactionPool>::Transaction::try_from_consensus(tx).ok()
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                // update the pool first
+                let update = CanonicalStateUpdate {
+                    new_tip: new_tip.sealed_block(),
+                    pending_block_base_fee,
+                    pending_block_blob_fee,
+                    changed_accounts,
+                    // all transactions mined in the new chain need to be removed from the pool
+                    mined_transactions: new_blocks.transaction_hashes().collect(),
+                    update_kind: PoolUpdateKind::Reorg,
+                };
+                pool.on_canonical_state_change(update);
+
+                // all transactions that were mined in the old chain but not in the new chain need
+                // to be re-injected
+                //
+                // Note: we no longer know if the tx was local or external
+                // Because the transactions are not finalized, the corresponding blobs are still in
+                // blob store (if we previously received them from the network)
+                metrics.inc_reinserted_transactions(pruned_old_transactions.len());
+                let _ = pool.add_external_transactions(pruned_old_transactions).await;
+
+                // keep track of new mined blob transactions
+                blob_store_tracker.add_new_chain_blocks(&new_blocks);
+            }
+            CanonStateNotification::Commit { new } => {
+                let (blocks, state) = new.inner();
+                let tip = blocks.tip();
+                let chain_spec = client.chain_spec();
+
+                // fees for the next block: `tip+1`
+                let pending_block_base_fee = chain_spec
+                    .next_block_base_fee(tip.header(), tip.timestamp())
+                    .unwrap_or_default();
+                let pending_block_blob_fee = tip.header().maybe_next_block_blob_fee(
+                    chain_spec.blob_params_at_timestamp(tip.timestamp()),
+                );
+
+                let first_block = blocks.first();
+                trace!(
+                    target: "txpool",
+                    first = first_block.number(),
+                    tip = tip.number(),
+                    pool_block = pool_info.last_seen_block_number,
+                    "update pool on new commit"
+                );
+
+                // check if the depth is too large and should be skipped, this could happen after
+                // initial sync or long re-sync
+                let depth = tip.number().abs_diff(pool_info.last_seen_block_number);
+                if depth > max_update_depth {
+                    maintained_state = MaintainedPoolState::Drifted;
+                    debug!(target: "txpool", ?depth, "skipping deep canonical update");
+                    let info = BlockInfo {
+                        block_gas_limit: tip.header().gas_limit(),
+                        last_seen_block_hash: tip.hash(),
+                        last_seen_block_number: tip.number(),
+                        pending_basefee: pending_block_base_fee,
+                        pending_blob_fee: pending_block_blob_fee,
+                    };
+                    pool.set_block_info(info);
+
+                    // keep track of mined blob transactions
+                    blob_store_tracker.add_new_chain_blocks(&blocks);
+
+                    continue
+                }
+
+                let mut changed_accounts = Vec::with_capacity(state.state().len());
+                for acc in state.changed_accounts() {
+                    // we can always clear the dirty flag for this account
+                    dirty_addresses.remove(&acc.address);
+                    changed_accounts.push(acc);
+                }
+
+                let mined_transactions = blocks.transaction_hashes().collect();
+
+                // check if the range of the commit is canonical with the pool's block
+                if first_block.parent_hash() != pool_info.last_seen_block_hash {
+                    // we received a new canonical chain commit but the commit is not canonical with
+                    // the pool's block, this could happen after initial sync or
+                    // long re-sync
+                    maintained_state = MaintainedPoolState::Drifted;
+                }
+
+                // Canonical update
+                let update = CanonicalStateUpdate {
+                    new_tip: tip.sealed_block(),
+                    pending_block_base_fee,
+                    pending_block_blob_fee,
+                    changed_accounts,
+                    mined_transactions,
+                    update_kind: PoolUpdateKind::Commit,
+                };
+                pool.on_canonical_state_change(update);
+
+                // keep track of mined blob transactions
+                blob_store_tracker.add_new_chain_blocks(&blocks);
+
+                // If Osaka activates in 2 slots we need to convert blobs to new format.
+                if !chain_spec.is_osaka_active_at_timestamp(tip.timestamp()) &&
+                    !chain_spec.is_osaka_active_at_timestamp(tip.timestamp().saturating_add(12)) &&
+                    chain_spec.is_osaka_active_at_timestamp(tip.timestamp().saturating_add(24))
+                {
+                    let pool = pool.clone();
+                    let spawner = task_spawner.clone();
+                    let client = client.clone();
+                    task_spawner.spawn_task(async move {
+                        // Start converting not eaerlier than 4 seconds into current slot to ensure
+                        // that our pool only contains valid transactions for the next block (as
+                        // it's not Osaka yet).
+                        tokio::time::sleep(Duration::from_secs(4)).await;
+
+                        let mut interval = tokio::time::interval(Duration::from_secs(1));
+                        loop {
+                            // Loop and replace blob transactions until we reach Osaka transition
+                            // block after which no legacy blobs are going to be accepted.
+                            let last_iteration =
+                                client.latest_header().ok().flatten().is_none_or(|header| {
+                                    client
+                                        .chain_spec()
+                                        .is_osaka_active_at_timestamp(header.timestamp())
+                                });
+
+                            let AllPoolTransactions { pending, queued } = pool.all_transactions();
+                            for tx in pending.into_iter().chain(queued).filter(|tx| tx.is_eip4844())
+                            {
+                                let tx_hash = *tx.hash();
+
+                                // Fetch sidecar from the pool
+                                let Ok(Some(sidecar)) = pool.get_blob(tx_hash) else {
+                                    continue;
+                                };
+                                // Ensure it is a legacy blob
+                                if !sidecar.is_eip4844() {
+                                    continue;
+                                }
+                                // Remove transaction and sidecar from the pool, both are in memory
+                                // now
+                                let Some(tx) = pool.remove_transactions(vec![tx_hash]).pop() else {
+                                    continue;
+                                };
+                                pool.delete_blob(tx_hash);
+
+                                let BlobTransactionSidecarVariant::Eip4844(sidecar) =
+                                    Arc::unwrap_or_clone(sidecar)
+                                else {
+                                    continue;
+                                };
+
+                                let converter = BlobSidecarConverter::new();
+                                let pool = pool.clone();
+                                spawner.spawn_task(async move {
+                                    // Convert sidecar to EIP-7594 format
+                                    let Some(sidecar) = converter.convert(sidecar).await else {
+                                        return;
+                                    };
+
+                                    // Re-insert transaction with the new sidecar
+                                    let origin = tx.origin;
+                                    let Some(tx) = EthPoolTransaction::try_from_eip4844(
+                                        tx.to_consensus(),
+                                        sidecar.into(),
+                                    ) else {
+                                        return;
+                                    };
+                                    let _ = pool.add_transaction(origin, tx).await;
+                                });
+                            }
+
+                            if last_iteration {
+                                break;
+                            }
+
+                            interval.tick().await;
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+struct FinalizedBlockTracker {
+    last_finalized_block: Option<BlockNumber>,
+}
+
+impl FinalizedBlockTracker {
+    const fn new(last_finalized_block: Option<BlockNumber>) -> Self {
+        Self { last_finalized_block }
+    }
+
+    /// Updates the tracked finalized block and returns the new finalized block if it changed
+    fn update(&mut self, finalized_block: Option<BlockNumber>) -> Option<BlockNumber> {
+        let finalized = finalized_block?;
+        self.last_finalized_block.is_none_or(|last| last < finalized).then(|| {
+            self.last_finalized_block = Some(finalized);
+            finalized
+        })
+    }
+}
+
+/// Keeps track of the pool's state, whether the accounts in the pool are in sync with the actual
+/// state.
+#[derive(Debug, PartialEq, Eq)]
+enum MaintainedPoolState {
+    /// Pool is assumed to be in sync with the current state
+    InSync,
+    /// Pool could be out of sync with the state
+    Drifted,
+}
+
+impl MaintainedPoolState {
+    /// Returns `true` if the pool is assumed to be out of sync with the current state.
+    #[inline]
+    const fn is_drifted(&self) -> bool {
+        matches!(self, Self::Drifted)
+    }
+}
+
+/// A unique [`ChangedAccount`] identified by its address that can be used for deduplication
+#[derive(Eq)]
+struct ChangedAccountEntry(ChangedAccount);
+
+impl PartialEq for ChangedAccountEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.address == other.0.address
+    }
+}
+
+impl Hash for ChangedAccountEntry {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.address.hash(state);
+    }
+}
+
+impl Borrow<Address> for ChangedAccountEntry {
+    fn borrow(&self) -> &Address {
+        &self.0.address
+    }
+}
+
+#[derive(Default)]
+struct LoadedAccounts {
+    /// All accounts that were loaded
+    accounts: Vec<ChangedAccount>,
+    /// All accounts that failed to load
+    failed_to_load: Vec<Address>,
+}
+
+/// Loads all accounts at the given state
+///
+/// Returns an error with all given addresses if the state is not available.
+///
+/// Note: this expects _unique_ addresses
+fn load_accounts<Client, I>(
+    client: Client,
+    at: BlockHash,
+    addresses: I,
+) -> Result<LoadedAccounts, Box<(AddressSet, ProviderError)>>
+where
+    I: IntoIterator<Item = Address>,
+    Client: StateProviderFactory,
+{
+    let addresses = addresses.into_iter();
+    let mut res = LoadedAccounts::default();
+    let state = match client.history_by_block_hash(at) {
+        Ok(state) => state,
+        Err(err) => return Err(Box::new((addresses.collect(), err))),
+    };
+    for addr in addresses {
+        if let Ok(maybe_acc) = state.basic_account(&addr) {
+            let acc = maybe_acc
+                .map(|acc| ChangedAccount { address: addr, nonce: acc.nonce, balance: acc.balance })
+                .unwrap_or_else(|| ChangedAccount::empty(addr));
+            res.accounts.push(acc)
+        } else {
+            // failed to load account.
+            res.failed_to_load.push(addr);
+        }
+    }
+    Ok(res)
+}
+
+/// Loads transactions from a file, decodes them from the JSON or RLP format, and
+/// inserts them into the transaction pool on node boot up.
+/// The file is removed after the transactions have been successfully processed.
+async fn load_and_reinsert_transactions<P>(
+    pool: P,
+    file_path: &Path,
+) -> Result<(), TransactionsBackupError>
+where
+    P: TransactionPool<Transaction: PoolTransaction<Consensus: SignedTransaction>>,
+{
+    if !file_path.exists() {
+        return Ok(())
+    }
+
+    debug!(target: "txpool", txs_file =?file_path, "Check local persistent storage for saved transactions");
+    let data = reth_fs_util::read(file_path)?;
+
+    if data.is_empty() {
+        return Ok(())
+    }
+
+    let pool_transactions: Vec<(TransactionOrigin, <P as TransactionPool>::Transaction)> =
+        if let Ok(tx_backups) = serde_json::from_slice::<Vec<TxBackup>>(&data) {
+            tx_backups
+                .into_iter()
+                .filter_map(|backup| {
+                    let tx_signed =
+                        <P::Transaction as PoolTransaction>::Consensus::decode_2718_exact(
+                            backup.rlp.as_ref(),
+                        )
+                        .ok()?;
+                    let recovered = tx_signed.try_into_recovered().ok()?;
+                    let pool_tx =
+                        <P::Transaction as PoolTransaction>::try_from_consensus(recovered).ok()?;
+
+                    Some((backup.origin, pool_tx))
+                })
+                .collect()
+        } else {
+            let txs_signed: Vec<<P::Transaction as PoolTransaction>::Consensus> =
+                alloy_rlp::Decodable::decode(&mut data.as_slice())?;
+
+            txs_signed
+                .into_iter()
+                .filter_map(|tx| tx.try_into_recovered().ok())
+                .filter_map(|tx| {
+                    <P::Transaction as PoolTransaction>::try_from_consensus(tx)
+                        .ok()
+                        .map(|pool_tx| (TransactionOrigin::Local, pool_tx))
+                })
+                .collect()
+        };
+
+    let inserted = futures_util::future::join_all(
+        pool_transactions.into_iter().map(|(origin, tx)| pool.add_transaction(origin, tx)),
+    )
+    .await;
+
+    info!(target: "txpool", txs_file =?file_path, num_txs=%inserted.len(), "Successfully reinserted local transactions from file");
+    reth_fs_util::remove_file(file_path)?;
+    Ok(())
+}
+
+fn save_local_txs_backup<P>(pool: P, file_path: &Path)
+where
+    P: TransactionPool<Transaction: PoolTransaction<Consensus: Encodable>>,
+{
+    let local_transactions = pool.get_local_transactions();
+    if local_transactions.is_empty() {
+        trace!(target: "txpool", "no local transactions to save");
+        return
+    }
+
+    let local_transactions = local_transactions
+        .into_iter()
+        .map(|tx| {
+            let consensus_tx = tx.to_consensus().into_inner();
+            let rlp_data = consensus_tx.encoded_2718();
+
+            TxBackup { rlp: rlp_data.into(), origin: tx.origin }
+        })
+        .collect::<Vec<_>>();
+
+    let json_data = match serde_json::to_string(&local_transactions) {
+        Ok(data) => data,
+        Err(err) => {
+            warn!(target: "txpool", %err, txs_file=?file_path, "failed to serialize local transactions to json");
+            return
+        }
+    };
+
+    info!(target: "txpool", txs_file =?file_path, num_txs=%local_transactions.len(), "Saving current local transactions");
+    let parent_dir = file_path.parent().map(std::fs::create_dir_all).transpose();
+
+    match parent_dir.map(|_| reth_fs_util::write(file_path, json_data)) {
+        Ok(_) => {
+            info!(target: "txpool", txs_file=?file_path, "Wrote local transactions to file");
+        }
+        Err(err) => {
+            warn!(target: "txpool", %err, txs_file=?file_path, "Failed to write local transactions to file");
+        }
+    }
+}
+
+/// A transaction backup that is saved as json to a file for
+/// reinsertion into the pool
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TxBackup {
+    /// Encoded transaction
+    pub rlp: Bytes,
+    /// The origin of the transaction
+    pub origin: TransactionOrigin,
+}
+
+/// Errors possible during txs backup load and decode
+#[derive(thiserror::Error, Debug)]
+pub enum TransactionsBackupError {
+    /// Error during RLP decoding of transactions
+    #[error("failed to apply transactions backup. Encountered RLP decode error: {0}")]
+    Decode(#[from] alloy_rlp::Error),
+    /// Error during json decoding of transactions
+    #[error("failed to apply transactions backup. Encountered JSON decode error: {0}")]
+    Json(#[from] serde_json::Error),
+    /// Error during file upload
+    #[error("failed to apply transactions backup. Encountered file error: {0}")]
+    FsPath(#[from] FsPathError),
+    /// Error adding transactions to the transaction pool
+    #[error("failed to insert transactions to the transactions pool. Encountered pool error: {0}")]
+    Pool(#[from] PoolError),
+}
+
+/// Task which manages saving local transactions to the persistent file in case of shutdown.
+/// Reloads the transactions from the file on the boot up and inserts them into the pool.
+pub async fn backup_local_transactions_task<P>(
+    shutdown: reth_tasks::shutdown::GracefulShutdown,
+    pool: P,
+    config: LocalTransactionBackupConfig,
+) where
+    P: TransactionPool<Transaction: PoolTransaction<Consensus: SignedTransaction>> + Clone,
+{
+    let Some(transactions_path) = config.transactions_path else {
+        // nothing to do
+        return
+    };
+
+    if let Err(err) = load_and_reinsert_transactions(pool.clone(), &transactions_path).await {
+        error!(target: "txpool", "{}", err)
+    }
+
+    let graceful_guard = shutdown.await;
+
+    // write transactions to disk
+    save_local_txs_backup(pool, &transactions_path);
+
+    drop(graceful_guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
+        CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionOrigin,
+    };
+    use alloy_eips::eip2718::Decodable2718;
+    use alloy_primitives::{hex, U256};
+    use reth_ethereum_primitives::PooledTransactionVariant;
+    use reth_evm_ethereum::EthEvmConfig;
+    use reth_fs_util as fs;
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+    use reth_tasks::Runtime;
+
+    #[test]
+    fn changed_acc_entry() {
+        let changed_acc = ChangedAccountEntry(ChangedAccount::empty(Address::random()));
+        let mut copy = changed_acc.0;
+        copy.nonce = 10;
+        assert!(changed_acc.eq(&ChangedAccountEntry(copy)));
+    }
+
+    const EXTENSION: &str = "json";
+    const FILENAME: &str = "test_transactions_backup";
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_save_local_txs_backup() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let transactions_path = temp_dir.path().join(FILENAME).with_extension(EXTENSION);
+        let tx_bytes = hex!(
+            "02f87201830655c2808505ef61f08482565f94388c818ca8b9251b393131c08a736a67ccb192978801049e39c4b5b1f580c001a01764ace353514e8abdfb92446de356b260e3c1225b73fc4c8876a6258d12a129a04f02294aa61ca7676061cd99f29275491218b4754b46a0248e5e42bc5091f507"
+        );
+        let tx = PooledTransactionVariant::decode_2718(&mut &tx_bytes[..]).unwrap();
+        let provider = MockEthProvider::default().with_genesis_block();
+        let transaction = EthPooledTransaction::from_pooled(tx.try_into_recovered().unwrap());
+        let tx_to_cmp = transaction.clone();
+        let sender = hex!("1f9090aaE28b8a3dCeaDf281B0F12828e676c326").into();
+        provider.add_account(sender, ExtendedAccount::new(42, U256::MAX));
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+            .build(blob_store.clone());
+
+        let txpool = Pool::new(
+            validator,
+            CoinbaseTipOrdering::default(),
+            blob_store.clone(),
+            Default::default(),
+        );
+
+        txpool.add_transaction(TransactionOrigin::Local, transaction.clone()).await.unwrap();
+
+        let rt = Runtime::test();
+        let config = LocalTransactionBackupConfig::with_local_txs_backup(transactions_path.clone());
+        rt.spawn_critical_with_graceful_shutdown_signal("test task", |shutdown| {
+            backup_local_transactions_task(shutdown, txpool.clone(), config)
+        });
+
+        let mut txns = txpool.get_local_transactions();
+        let tx_on_finish = txns.pop().expect("there should be 1 transaction");
+
+        assert_eq!(*tx_to_cmp.hash(), *tx_on_finish.hash());
+
+        rt.graceful_shutdown();
+
+        let data = fs::read(transactions_path).unwrap();
+
+        let txs: Vec<TxBackup> = serde_json::from_slice::<Vec<TxBackup>>(&data).unwrap();
+        assert_eq!(txs.len(), 1);
+
+        temp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_update_with_higher_finalized_block() {
+        let mut tracker = FinalizedBlockTracker::new(Some(10));
+        assert_eq!(tracker.update(Some(15)), Some(15));
+        assert_eq!(tracker.last_finalized_block, Some(15));
+    }
+
+    #[test]
+    fn test_update_with_lower_finalized_block() {
+        let mut tracker = FinalizedBlockTracker::new(Some(20));
+        assert_eq!(tracker.update(Some(15)), None);
+        // finalized block should NOT go backwards
+        assert_eq!(tracker.last_finalized_block, Some(20));
+    }
+
+    #[test]
+    fn test_update_with_equal_finalized_block() {
+        let mut tracker = FinalizedBlockTracker::new(Some(20));
+        assert_eq!(tracker.update(Some(20)), None);
+        assert_eq!(tracker.last_finalized_block, Some(20));
+    }
+
+    #[test]
+    fn test_update_with_no_last_finalized_block() {
+        let mut tracker = FinalizedBlockTracker::new(None);
+        assert_eq!(tracker.update(Some(10)), Some(10));
+        assert_eq!(tracker.last_finalized_block, Some(10));
+    }
+
+    #[test]
+    fn test_update_with_no_new_finalized_block() {
+        let mut tracker = FinalizedBlockTracker::new(Some(10));
+        assert_eq!(tracker.update(None), None);
+        assert_eq!(tracker.last_finalized_block, Some(10));
+    }
+
+    #[test]
+    fn test_update_with_no_finalized_blocks() {
+        let mut tracker = FinalizedBlockTracker::new(None);
+        assert_eq!(tracker.update(None), None);
+        assert_eq!(tracker.last_finalized_block, None);
+    }
+}

--- a/patches/reth-transaction-pool/src/metrics.rs
+++ b/patches/reth-transaction-pool/src/metrics.rs
@@ -1,0 +1,156 @@
+//! Transaction pool metrics.
+
+use reth_metrics::{
+    metrics::{Counter, Gauge, Histogram},
+    Metrics,
+};
+
+/// Transaction pool metrics
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool")]
+pub struct TxPoolMetrics {
+    /// Number of transactions inserted in the pool
+    pub inserted_transactions: Counter,
+    /// Number of invalid transactions
+    pub invalid_transactions: Counter,
+    /// Number of removed transactions from the pool
+    pub removed_transactions: Counter,
+
+    /// Number of transactions in the pending sub-pool
+    pub pending_pool_transactions: Gauge,
+    /// Total amount of memory used by the transactions in the pending sub-pool in bytes
+    pub pending_pool_size_bytes: Gauge,
+
+    /// Number of transactions in the basefee sub-pool
+    pub basefee_pool_transactions: Gauge,
+    /// Total amount of memory used by the transactions in the basefee sub-pool in bytes
+    pub basefee_pool_size_bytes: Gauge,
+
+    /// Number of transactions in the queued sub-pool
+    pub queued_pool_transactions: Gauge,
+    /// Total amount of memory used by the transactions in the queued sub-pool in bytes
+    pub queued_pool_size_bytes: Gauge,
+
+    /// Number of transactions in the blob sub-pool
+    pub blob_pool_transactions: Gauge,
+    /// Total amount of memory used by the transactions in the blob sub-pool in bytes
+    pub blob_pool_size_bytes: Gauge,
+
+    /// Number of all transactions of all sub-pools: pending + basefee + queued + blob
+    pub total_transactions: Gauge,
+    /// Number of all legacy transactions in the pool
+    pub total_legacy_transactions: Gauge,
+    /// Number of all EIP-2930 transactions in the pool
+    pub total_eip2930_transactions: Gauge,
+    /// Number of all EIP-1559 transactions in the pool
+    pub total_eip1559_transactions: Gauge,
+    /// Number of all EIP-4844 transactions in the pool
+    pub total_eip4844_transactions: Gauge,
+    /// Number of all EIP-7702 transactions in the pool
+    pub total_eip7702_transactions: Gauge,
+    /// Number of all other transactions in the pool
+    pub total_other_transactions: Gauge,
+
+    /// How often the pool was updated after the canonical state changed
+    pub performed_state_updates: Counter,
+
+    /// Counter for the number of pending transactions evicted
+    pub pending_transactions_evicted: Counter,
+    /// Counter for the number of basefee transactions evicted
+    pub basefee_transactions_evicted: Counter,
+    /// Counter for the number of blob transactions evicted
+    pub blob_transactions_evicted: Counter,
+    /// Counter for the number of queued transactions evicted
+    pub queued_transactions_evicted: Counter,
+}
+
+/// Transaction pool blobstore metrics
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool")]
+pub struct BlobStoreMetrics {
+    /// Number of failed inserts into the blobstore
+    pub blobstore_failed_inserts: Counter,
+    /// Number of failed deletes into the blobstore
+    pub blobstore_failed_deletes: Counter,
+    /// The number of bytes the blobs in the blobstore take up
+    pub blobstore_byte_size: Gauge,
+    /// How many blobs are currently in the blobstore
+    pub blobstore_entries: Gauge,
+}
+
+/// Transaction pool maintenance metrics
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool")]
+pub struct MaintainPoolMetrics {
+    /// Gauge indicating the number of addresses with pending updates in the pool,
+    /// requiring their account information to be fetched.
+    pub dirty_accounts: Gauge,
+    /// Counter for the number of times the pool state diverged from the canonical blockchain
+    /// state.
+    pub drift_count: Counter,
+    /// Counter for the number of transactions reinserted into the pool following a blockchain
+    /// reorganization (reorg).
+    pub reinserted_transactions: Counter,
+    /// Counter for the number of finalized blob transactions that have been removed from tracking.
+    pub deleted_tracked_finalized_blobs: Counter,
+}
+
+impl MaintainPoolMetrics {
+    /// Sets the number of dirty accounts in the pool.
+    #[inline]
+    pub fn set_dirty_accounts_len(&self, count: usize) {
+        self.dirty_accounts.set(count as f64);
+    }
+
+    /// Increments the count of reinserted transactions.
+    #[inline]
+    pub fn inc_reinserted_transactions(&self, count: usize) {
+        self.reinserted_transactions.increment(count as u64);
+    }
+
+    /// Increments the count of deleted tracked finalized blobs.
+    #[inline]
+    pub fn inc_deleted_tracked_blobs(&self, count: usize) {
+        self.deleted_tracked_finalized_blobs.increment(count as u64);
+    }
+
+    /// Increments the drift count by one.
+    #[inline]
+    pub fn inc_drift(&self) {
+        self.drift_count.increment(1);
+    }
+}
+
+/// All Transactions metrics
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool")]
+pub struct AllTransactionsMetrics {
+    /// Number of all transactions by hash in the pool
+    pub all_transactions_by_hash: Gauge,
+    /// Number of all transactions by id in the pool
+    pub all_transactions_by_id: Gauge,
+    /// Number of all transactions by all senders in the pool
+    pub all_transactions_by_all_senders: Gauge,
+    /// Number of blob transactions nonce gaps.
+    pub blob_transactions_nonce_gaps: Counter,
+    /// The current blob base fee
+    pub blob_base_fee: Gauge,
+    /// The current base fee
+    pub base_fee: Gauge,
+}
+
+/// Transaction pool validation metrics
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool")]
+pub struct TxPoolValidationMetrics {
+    /// How long to successfully validate a blob
+    pub blob_validation_duration: Histogram,
+}
+
+/// Transaction pool validator task metrics
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool")]
+pub struct TxPoolValidatorMetrics {
+    /// Number of in-flight validation job sends waiting for channel capacity
+    pub inflight_validation_jobs: Gauge,
+}

--- a/patches/reth-transaction-pool/src/noop.rs
+++ b/patches/reth-transaction-pool/src/noop.rs
@@ -1,0 +1,469 @@
+//! A transaction pool implementation that does nothing.
+//!
+//! This is useful for wiring components together that don't require an actual pool but still need
+//! to be generic over it.
+
+use crate::{
+    blobstore::BlobStoreError,
+    error::{InvalidPoolTransactionError, PoolError},
+    pool::TransactionListenerKind,
+    traits::{BestTransactionsAttributes, GetPooledTransactionLimit, NewBlobSidecar},
+    validate::ValidTransaction,
+    AddedTransactionOutcome, AllPoolTransactions, AllTransactionsEvents, BestTransactions,
+    BlockInfo, EthPoolTransaction, EthPooledTransaction, NewTransactionEvent, PoolResult, PoolSize,
+    PoolTransaction, PropagatedTransactions, TransactionEvents, TransactionOrigin, TransactionPool,
+    TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
+};
+use alloy_eips::{
+    eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M,
+    eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
+    eip7594::BlobTransactionSidecarVariant,
+};
+use alloy_primitives::{map::AddressSet, Address, TxHash, B128, B256, U256};
+use reth_eth_wire_types::HandleMempoolData;
+use reth_primitives_traits::Recovered;
+use std::{marker::PhantomData, sync::Arc};
+use tokio::sync::{mpsc, mpsc::Receiver};
+
+/// A [`TransactionPool`] implementation that does nothing.
+///
+/// All transactions are rejected and no events are emitted.
+/// This type will never hold any transactions and is only useful for wiring components together.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct NoopTransactionPool<T = EthPooledTransaction> {
+    /// Type marker
+    _marker: PhantomData<T>,
+}
+
+impl<T> NoopTransactionPool<T> {
+    /// Creates a new [`NoopTransactionPool`].
+    pub fn new() -> Self {
+        Self { _marker: Default::default() }
+    }
+}
+
+impl Default for NoopTransactionPool<EthPooledTransaction> {
+    fn default() -> Self {
+        Self { _marker: Default::default() }
+    }
+}
+
+impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
+    type Transaction = T;
+
+    fn pool_size(&self) -> PoolSize {
+        Default::default()
+    }
+
+    fn block_info(&self) -> BlockInfo {
+        BlockInfo {
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            last_seen_block_hash: Default::default(),
+            last_seen_block_number: 0,
+            pending_basefee: 0,
+            pending_blob_fee: None,
+        }
+    }
+
+    async fn add_transaction_and_subscribe(
+        &self,
+        _origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> PoolResult<TransactionEvents> {
+        let hash = *transaction.hash();
+        Err(PoolError::other(hash, Box::new(NoopInsertError::new(transaction))))
+    }
+
+    async fn add_transaction(
+        &self,
+        _origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> PoolResult<AddedTransactionOutcome> {
+        let hash = *transaction.hash();
+        Err(PoolError::other(hash, Box::new(NoopInsertError::new(transaction))))
+    }
+
+    async fn add_transactions(
+        &self,
+        _origin: TransactionOrigin,
+        transactions: Vec<Self::Transaction>,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        transactions
+            .into_iter()
+            .map(|transaction| {
+                let hash = *transaction.hash();
+                Err(PoolError::other(hash, Box::new(NoopInsertError::new(transaction))))
+            })
+            .collect()
+    }
+
+    async fn add_transactions_with_origins(
+        &self,
+        transactions: Vec<(TransactionOrigin, Self::Transaction)>,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        transactions
+            .into_iter()
+            .map(|(_, transaction)| {
+                let hash = *transaction.hash();
+                Err(PoolError::other(hash, Box::new(NoopInsertError::new(transaction))))
+            })
+            .collect()
+    }
+
+    fn transaction_event_listener(&self, _tx_hash: TxHash) -> Option<TransactionEvents> {
+        None
+    }
+
+    fn all_transactions_event_listener(&self) -> AllTransactionsEvents<Self::Transaction> {
+        AllTransactionsEvents::new(mpsc::channel(1).1)
+    }
+
+    fn pending_transactions_listener_for(
+        &self,
+        _kind: TransactionListenerKind,
+    ) -> Receiver<TxHash> {
+        mpsc::channel(1).1
+    }
+
+    fn new_transactions_listener(&self) -> Receiver<NewTransactionEvent<Self::Transaction>> {
+        mpsc::channel(1).1
+    }
+
+    fn blob_transaction_sidecars_listener(&self) -> Receiver<NewBlobSidecar> {
+        mpsc::channel(1).1
+    }
+
+    fn new_transactions_listener_for(
+        &self,
+        _kind: TransactionListenerKind,
+    ) -> Receiver<NewTransactionEvent<Self::Transaction>> {
+        mpsc::channel(1).1
+    }
+
+    fn pooled_transaction_hashes(&self) -> Vec<TxHash> {
+        vec![]
+    }
+
+    fn pooled_transaction_hashes_max(&self, _max: usize) -> Vec<TxHash> {
+        vec![]
+    }
+
+    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn pooled_transactions_max(
+        &self,
+        _max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_pooled_transaction_elements(
+        &self,
+        _tx_hashes: Vec<TxHash>,
+        _limit: GetPooledTransactionLimit,
+    ) -> Vec<<Self::Transaction as PoolTransaction>::Pooled> {
+        vec![]
+    }
+
+    fn append_pooled_transaction_elements(
+        &self,
+        _tx_hashes: &[TxHash],
+        _limit: GetPooledTransactionLimit,
+        _out: &mut Vec<<Self::Transaction as PoolTransaction>::Pooled>,
+    ) {
+    }
+
+    fn get_pooled_transaction_element(
+        &self,
+        _tx_hash: TxHash,
+    ) -> Option<Recovered<<Self::Transaction as PoolTransaction>::Pooled>> {
+        None
+    }
+
+    fn best_transactions(
+        &self,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        Box::new(std::iter::empty())
+    }
+
+    fn best_transactions_with_attributes(
+        &self,
+        _: BestTransactionsAttributes,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        Box::new(std::iter::empty())
+    }
+
+    fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn pending_transactions_max(
+        &self,
+        _max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn pending_and_queued_txn_count(&self) -> (usize, usize) {
+        (0, 0)
+    }
+
+    fn all_transactions(&self) -> AllPoolTransactions<Self::Transaction> {
+        AllPoolTransactions::default()
+    }
+
+    fn all_transaction_hashes(&self) -> Vec<TxHash> {
+        vec![]
+    }
+
+    fn remove_transactions(
+        &self,
+        _hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn remove_transactions_and_descendants(
+        &self,
+        _hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn remove_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn prune_transactions(
+        &self,
+        _hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn retain_unknown<A>(&self, _announcement: &mut A)
+    where
+        A: HandleMempoolData,
+    {
+    }
+
+    fn get(&self, _tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        None
+    }
+
+    fn get_all(&self, _txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn on_propagated(&self, _txs: PropagatedTransactions) {}
+
+    fn get_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_pending_transactions_with_predicate(
+        &self,
+        _predicate: impl FnMut(&ValidPoolTransaction<Self::Transaction>) -> bool,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_pending_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_queued_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_highest_transaction_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        None
+    }
+
+    fn get_highest_consecutive_transaction_by_sender(
+        &self,
+        _sender: Address,
+        _on_chain_nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        None
+    }
+
+    fn get_transaction_by_sender_and_nonce(
+        &self,
+        _sender: Address,
+        _nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        None
+    }
+
+    fn get_transactions_by_origin(
+        &self,
+        _origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_pending_transactions_by_origin(
+        &self,
+        _origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn unique_senders(&self) -> AddressSet {
+        Default::default()
+    }
+
+    fn get_blob(
+        &self,
+        _tx_hash: TxHash,
+    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        Ok(None)
+    }
+
+    fn get_all_blobs(
+        &self,
+        _tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<(TxHash, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
+        Ok(vec![])
+    }
+
+    fn get_all_blobs_exact(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        if tx_hashes.is_empty() {
+            return Ok(vec![])
+        }
+        Err(BlobStoreError::MissingSidecar(tx_hashes[0]))
+    }
+
+    fn get_blobs_for_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
+        Ok(vec![None; versioned_hashes.len()])
+    }
+
+    fn get_blobs_for_versioned_hashes_v2(
+        &self,
+        _versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
+        Ok(None)
+    }
+
+    fn get_blobs_for_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
+        Ok(vec![None; versioned_hashes.len()])
+    }
+
+    fn get_blobs_for_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        _indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        Ok(vec![None; versioned_hashes.len()])
+    }
+}
+
+/// A [`TransactionValidator`] that does nothing.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct MockTransactionValidator<T> {
+    propagate_local: bool,
+    return_invalid: bool,
+    _marker: PhantomData<T>,
+}
+
+impl<T: EthPoolTransaction> TransactionValidator for MockTransactionValidator<T> {
+    type Transaction = T;
+    type Block = reth_ethereum_primitives::Block;
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        mut transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        if self.return_invalid {
+            return TransactionValidationOutcome::Invalid(
+                transaction,
+                InvalidPoolTransactionError::Underpriced,
+            );
+        }
+        let maybe_sidecar = transaction.take_blob().maybe_sidecar().cloned();
+        // we return `balance: U256::MAX` to simulate a valid transaction which will never go into
+        // overdraft
+        TransactionValidationOutcome::Valid {
+            balance: U256::MAX,
+            state_nonce: 0,
+            bytecode_hash: None,
+            transaction: ValidTransaction::new(transaction, maybe_sidecar),
+            propagate: match origin {
+                TransactionOrigin::External => true,
+                TransactionOrigin::Local => self.propagate_local,
+                TransactionOrigin::Private => false,
+            },
+            authorities: None,
+        }
+    }
+}
+
+impl<T> MockTransactionValidator<T> {
+    /// Creates a new [`MockTransactionValidator`] that does not allow local transactions to be
+    /// propagated.
+    pub fn no_propagate_local() -> Self {
+        Self { propagate_local: false, return_invalid: false, _marker: Default::default() }
+    }
+    /// Creates a new [`MockTransactionValidator`] that always returns an invalid outcome.
+    pub fn return_invalid() -> Self {
+        Self { propagate_local: false, return_invalid: true, _marker: Default::default() }
+    }
+}
+
+impl<T> Default for MockTransactionValidator<T> {
+    fn default() -> Self {
+        Self { propagate_local: true, return_invalid: false, _marker: Default::default() }
+    }
+}
+
+/// An error that contains the transaction that failed to be inserted into the noop pool.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("can't insert transaction into the noop pool that does nothing")]
+pub struct NoopInsertError<T: EthPoolTransaction = EthPooledTransaction> {
+    tx: T,
+}
+
+impl<T: EthPoolTransaction> NoopInsertError<T> {
+    const fn new(tx: T) -> Self {
+        Self { tx }
+    }
+
+    /// Returns the transaction that failed to be inserted.
+    pub fn into_inner(self) -> T {
+        self.tx
+    }
+}

--- a/patches/reth-transaction-pool/src/ordering.rs
+++ b/patches/reth-transaction-pool/src/ordering.rs
@@ -1,0 +1,115 @@
+use crate::traits::PoolTransaction;
+use std::{cmp::Ordering, fmt::Debug, marker::PhantomData};
+
+/// Priority of the transaction that can be missing.
+///
+/// Transactions with missing priorities are ranked lower.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum Priority<T: Ord + Clone> {
+    /// The value of the priority of the transaction.
+    Value(T),
+    /// Missing priority due to ordering internals.
+    None,
+}
+
+impl<T: Ord + Clone> From<Option<T>> for Priority<T> {
+    fn from(value: Option<T>) -> Self {
+        value.map_or(Self::None, Priority::Value)
+    }
+}
+
+impl<T: Ord + Clone> PartialOrd for Priority<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Ord + Clone> Ord for Priority<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Value(a), Self::Value(b)) => a.cmp(b),
+            // Note: None should be smaller than Value.
+            (Self::Value(_), Self::None) => Ordering::Greater,
+            (Self::None, Self::Value(_)) => Ordering::Less,
+            (Self::None, Self::None) => Ordering::Equal,
+        }
+    }
+}
+
+/// Transaction ordering trait to determine the order of transactions.
+///
+/// Decides how transactions should be ordered within the pool, depending on a `Priority` value.
+///
+/// The returned priority must reflect [total order](https://en.wikipedia.org/wiki/Total_order).
+pub trait TransactionOrdering: Debug + Send + Sync + 'static {
+    /// Priority of a transaction.
+    ///
+    /// Higher is better.
+    type PriorityValue: Ord + Clone + Default + Debug + Send + Sync;
+
+    /// The transaction type to determine the priority of.
+    type Transaction: PoolTransaction;
+
+    /// Returns the priority score for the given transaction.
+    fn priority(
+        &self,
+        transaction: &Self::Transaction,
+        base_fee: u64,
+    ) -> Priority<Self::PriorityValue>;
+}
+
+/// Default ordering for the pool.
+///
+/// The transactions are ordered by their coinbase tip.
+/// The higher the coinbase tip is, the higher the priority of the transaction.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct CoinbaseTipOrdering<T>(PhantomData<T>);
+
+impl<T> TransactionOrdering for CoinbaseTipOrdering<T>
+where
+    T: PoolTransaction + 'static,
+{
+    type PriorityValue = u128;
+    type Transaction = T;
+
+    /// Source: <https://github.com/ethereum/go-ethereum/blob/7f756dc1185d7f1eeeacb1d12341606b7135f9ea/core/txpool/legacypool/list.go#L469-L482>.
+    ///
+    /// NOTE: The implementation is incomplete for missing base fee.
+    fn priority(
+        &self,
+        transaction: &Self::Transaction,
+        base_fee: u64,
+    ) -> Priority<Self::PriorityValue> {
+        transaction.effective_tip_per_gas(base_fee).into()
+    }
+}
+
+impl<T> Default for CoinbaseTipOrdering<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T> Clone for CoinbaseTipOrdering<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_priority_ordering() {
+        let p1 = Priority::Value(3);
+        let p2 = Priority::Value(1);
+        let p3 = Priority::None;
+
+        assert!(p1 > p2); // 3 > 1
+        assert!(p1 > p3); // Value(3) > None
+        assert!(p2 > p3); // Value(1) > None
+        assert_eq!(p3, Priority::None);
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/best.rs
+++ b/patches/reth-transaction-pool/src/pool/best.rs
@@ -1,0 +1,1118 @@
+use crate::{
+    error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
+    identifier::{SenderId, TransactionId},
+    pool::pending::PendingTransaction,
+    PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction,
+};
+use alloy_consensus::Transaction;
+use alloy_primitives::map::AddressSet;
+use core::fmt;
+use imbl::OrdMap;
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
+use std::{
+    collections::{BTreeSet, HashSet, VecDeque},
+    sync::Arc,
+};
+use tokio::sync::broadcast::{error::TryRecvError, Receiver};
+use tracing::debug;
+
+const MAX_NEW_TRANSACTIONS_PER_BATCH: usize = 16;
+
+/// An iterator that returns transactions that can be executed on the current state (*best*
+/// transactions).
+///
+/// This is a wrapper around [`BestTransactions`] that also enforces a specific basefee.
+///
+/// This iterator guarantees that all transactions it returns satisfy both the base fee and blob
+/// fee!
+pub(crate) struct BestTransactionsWithFees<T: TransactionOrdering> {
+    pub(crate) best: BestTransactions<T>,
+    pub(crate) base_fee: u64,
+    pub(crate) base_fee_per_blob_gas: u64,
+}
+
+impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransactionsWithFees<T> {
+    fn mark_invalid(&mut self, tx: &Self::Item, kind: &InvalidPoolTransactionError) {
+        BestTransactions::mark_invalid(&mut self.best, tx, kind)
+    }
+
+    fn no_updates(&mut self) {
+        self.best.no_updates()
+    }
+
+    fn skip_blobs(&mut self) {
+        self.set_skip_blobs(true)
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        self.best.set_skip_blobs(skip_blobs)
+    }
+}
+
+impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
+    type Item = Arc<ValidPoolTransaction<T::Transaction>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // find the next transaction that satisfies the base fee
+        loop {
+            let best = Iterator::next(&mut self.best)?;
+            // If both the base fee and blob fee (if applicable for EIP-4844) are satisfied, return
+            // the transaction
+            if best.transaction.max_fee_per_gas() >= self.base_fee as u128 &&
+                best.transaction
+                    .max_fee_per_blob_gas()
+                    .is_none_or(|fee| fee >= self.base_fee_per_blob_gas as u128)
+            {
+                return Some(best);
+            }
+            crate::traits::BestTransactions::mark_invalid(
+                self,
+                &best,
+                &InvalidPoolTransactionError::Underpriced,
+            );
+        }
+    }
+}
+
+/// An iterator that returns transactions that can be executed on the current state (*best*
+/// transactions).
+///
+/// The [`PendingPool`](crate::pool::pending::PendingPool) contains transactions that *could* all
+/// be executed on the current state, but only yields transactions that are ready to be executed
+/// now. While it contains all gapless transactions of a sender, it _always_ only returns the
+/// transaction with the current on chain nonce.
+#[derive(Debug)]
+pub struct BestTransactions<T: TransactionOrdering> {
+    /// Contains a copy of _all_ transactions of the pending pool at the point in time this
+    /// iterator was created.
+    pub(crate) all: OrdMap<TransactionId, PendingTransaction<T>>,
+    /// Transactions that can be executed right away: these have the expected nonce.
+    ///
+    /// Once an `independent` transaction with the nonce `N` is returned, it unlocks `N+1`, which
+    /// then can be moved from the `all` set to the `independent` set.
+    pub(crate) independent: BTreeSet<PendingTransaction<T>>,
+    /// There might be the case where a yielded transactions is invalid, this will track it.
+    pub(crate) invalid: HashSet<SenderId>,
+    /// Used to receive any new pending transactions that have been added to the pool after this
+    /// iterator was static filtered
+    ///
+    /// These new pending transactions are inserted into this iterator's pool before yielding the
+    /// next value
+    pub(crate) new_transaction_receiver: Option<Receiver<PendingTransaction<T>>>,
+    /// The priority value of most recently yielded transaction.
+    ///
+    /// This is required if new pending transactions are fed in while it yields new values.
+    pub(crate) last_priority: Option<Priority<T::PriorityValue>>,
+    /// Flag to control whether to skip blob transactions (EIP4844).
+    pub(crate) skip_blobs: bool,
+}
+
+impl<T: TransactionOrdering> BestTransactions<T> {
+    /// Mark the transaction and its descendants as invalid.
+    pub(crate) fn mark_invalid(
+        &mut self,
+        tx: &Arc<ValidPoolTransaction<T::Transaction>>,
+        _kind: &InvalidPoolTransactionError,
+    ) {
+        self.invalid.insert(tx.sender_id());
+    }
+
+    /// Returns the ancestor the given transaction, the transaction with `nonce - 1`.
+    ///
+    /// Note: for a transaction with nonce higher than the current on chain nonce this will always
+    /// return an ancestor since all transactions in this pool are gapless.
+    pub(crate) fn ancestor(&self, id: &TransactionId) -> Option<&PendingTransaction<T>> {
+        self.all.get(&id.unchecked_ancestor()?)
+    }
+
+    /// Non-blocking read on the new pending transactions subscription channel
+    fn try_recv(&mut self) -> Option<IncomingTransaction<T>> {
+        loop {
+            match self.new_transaction_receiver.as_mut()?.try_recv() {
+                Ok(tx) => {
+                    if let Some(last_priority) = &self.last_priority &&
+                        &tx.priority > last_priority
+                    {
+                        // we skip transactions if we already yielded a transaction with lower
+                        // priority
+                        return Some(IncomingTransaction::Stash(tx))
+                    }
+                    return Some(IncomingTransaction::Process(tx))
+                }
+                // note TryRecvError::Lagged can be returned here, which is an error that attempts
+                // to correct itself on consecutive try_recv() attempts
+
+                // the cost of ignoring this error is allowing old transactions to get
+                // overwritten after the chan buffer size is met
+                Err(TryRecvError::Lagged(_)) => {
+                    // Handle the case where the receiver lagged too far behind.
+                    // `num_skipped` indicates the number of messages that were skipped.
+                }
+
+                // this case is still better than the existing iterator behavior where no new
+                // pending txs are surfaced to consumers
+                Err(_) => return None,
+            }
+        }
+    }
+
+    /// Removes the currently best independent transaction from the independent set and the total
+    /// set.
+    fn pop_best(&mut self) -> Option<PendingTransaction<T>> {
+        self.independent.pop_last().inspect(|best| {
+            self.all.remove(best.transaction.id());
+        })
+    }
+
+    /// Checks for new transactions that have come into the `PendingPool` after this iterator was
+    /// created and inserts them
+    fn add_new_transactions(&mut self) {
+        for _ in 0..MAX_NEW_TRANSACTIONS_PER_BATCH {
+            if let Some(pending_tx) = self.try_recv() {
+                //  same logic as PendingPool::add_transaction/PendingPool::best_with_unlocked
+
+                match pending_tx {
+                    IncomingTransaction::Process(tx) => {
+                        let tx_id = *tx.transaction.id();
+                        if self.ancestor(&tx_id).is_none() {
+                            self.independent.insert(tx.clone());
+                        }
+                        self.all.insert(tx_id, tx);
+                    }
+                    IncomingTransaction::Stash(tx) => {
+                        let tx_id = *tx.transaction.id();
+                        self.all.insert(tx_id, tx);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Returns the next best transaction and its priority value.
+    #[expect(clippy::type_complexity)]
+    pub fn next_tx_and_priority(
+        &mut self,
+    ) -> Option<(Arc<ValidPoolTransaction<T::Transaction>>, Priority<T::PriorityValue>)> {
+        loop {
+            self.add_new_transactions();
+            // Remove the next independent tx with the highest priority
+            let best = self.pop_best()?;
+            let sender_id = best.transaction.sender_id();
+
+            // skip transactions for which sender was marked as invalid
+            if self.invalid.contains(&sender_id) {
+                debug!(
+                    target: "txpool",
+                    "[{:?}] skipping invalid transaction",
+                    best.transaction.hash()
+                );
+                continue
+            }
+
+            // Insert transactions that just got unlocked.
+            if let Some(unlocked) = self.all.get(&best.unlocks()) {
+                self.independent.insert(unlocked.clone());
+            }
+
+            if self.skip_blobs && best.transaction.is_eip4844() {
+                // blobs should be skipped, marking them as invalid will ensure that no dependent
+                // transactions are returned
+                self.mark_invalid(
+                    &best.transaction,
+                    &InvalidPoolTransactionError::Eip4844(
+                        Eip4844PoolTransactionError::NoEip4844Blobs,
+                    ),
+                )
+            } else {
+                if self.new_transaction_receiver.is_some() {
+                    self.last_priority = Some(best.priority.clone())
+                }
+                return Some((best.transaction, best.priority))
+            }
+        }
+    }
+}
+
+/// Result of attempting to receive a new transaction from the channel during iteration.
+///
+/// This enum determines how a newly received transaction should be handled based on its priority
+/// relative to transactions already yielded by the iterator.
+enum IncomingTransaction<T: TransactionOrdering> {
+    /// Process the transaction normally: add to both `all` map and potentially to `independent`
+    /// set (if it has no ancestor).
+    ///
+    /// This variant is used when the transaction's priority is lower than or equal to the last
+    /// yielded transaction, meaning it can be safely processed without breaking the descending
+    /// priority order.
+    Process(PendingTransaction<T>),
+
+    /// Stash the transaction: add only to the `all` map, but NOT to the `independent` set.
+    ///
+    /// This variant is used when the transaction has a higher priority than the last yielded
+    /// transaction. We cannot yield it immediately (to maintain strict priority ordering), but we
+    /// must still track it so that:
+    /// - Its descendants can find it via `ancestor()` lookups
+    /// - We prevent those descendants from being incorrectly promoted to `independent`
+    ///
+    /// Without stashing, if a child of this transaction arrives later, it would fail to find its
+    /// parent in `all`, be marked as `independent`, and be yielded out of order (before its
+    /// parent), causing nonce gaps.
+    Stash(PendingTransaction<T>),
+}
+
+impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransactions<T> {
+    fn mark_invalid(&mut self, tx: &Self::Item, kind: &InvalidPoolTransactionError) {
+        Self::mark_invalid(self, tx, kind)
+    }
+
+    fn no_updates(&mut self) {
+        self.new_transaction_receiver.take();
+        self.last_priority.take();
+    }
+
+    fn skip_blobs(&mut self) {
+        self.set_skip_blobs(true);
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        self.skip_blobs = skip_blobs;
+    }
+}
+
+impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
+    type Item = Arc<ValidPoolTransaction<T::Transaction>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_tx_and_priority().map(|(tx, _)| tx)
+    }
+}
+
+/// A [`BestTransactions`](crate::traits::BestTransactions) implementation that filters the
+/// transactions of iter with predicate.
+///
+/// Filter out transactions are marked as invalid:
+/// [`BestTransactions::mark_invalid`](crate::traits::BestTransactions::mark_invalid).
+pub struct BestTransactionFilter<I, P> {
+    pub(crate) best: I,
+    pub(crate) predicate: P,
+}
+
+impl<I, P> BestTransactionFilter<I, P> {
+    /// Create a new [`BestTransactionFilter`] with the given predicate.
+    pub const fn new(best: I, predicate: P) -> Self {
+        Self { best, predicate }
+    }
+}
+
+impl<I, P> Iterator for BestTransactionFilter<I, P>
+where
+    I: crate::traits::BestTransactions,
+    P: FnMut(&<I as Iterator>::Item) -> bool,
+{
+    type Item = <I as Iterator>::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let best = self.best.next()?;
+            if (self.predicate)(&best) {
+                return Some(best)
+            }
+            self.best.mark_invalid(
+                &best,
+                &InvalidPoolTransactionError::Consensus(
+                    InvalidTransactionError::TxTypeNotSupported,
+                ),
+            );
+        }
+    }
+}
+
+impl<I, P> crate::traits::BestTransactions for BestTransactionFilter<I, P>
+where
+    I: crate::traits::BestTransactions,
+    P: FnMut(&<I as Iterator>::Item) -> bool + Send,
+{
+    fn mark_invalid(&mut self, tx: &Self::Item, kind: &InvalidPoolTransactionError) {
+        crate::traits::BestTransactions::mark_invalid(&mut self.best, tx, kind)
+    }
+
+    fn no_updates(&mut self) {
+        self.best.no_updates()
+    }
+
+    fn skip_blobs(&mut self) {
+        self.set_skip_blobs(true)
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        self.best.set_skip_blobs(skip_blobs)
+    }
+}
+
+impl<I: fmt::Debug, P> fmt::Debug for BestTransactionFilter<I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BestTransactionFilter").field("best", &self.best).finish()
+    }
+}
+
+/// Wrapper over [`crate::traits::BestTransactions`] that prioritizes transactions of certain
+/// senders capping total gas used by such transactions.
+#[derive(Debug)]
+pub struct BestTransactionsWithPrioritizedSenders<I: Iterator> {
+    /// Inner iterator
+    inner: I,
+    /// A set of senders which transactions should be prioritized
+    prioritized_senders: AddressSet,
+    /// Maximum total gas limit of prioritized transactions
+    max_prioritized_gas: u64,
+    /// Buffer with transactions that are not being prioritized. Those will be the first to be
+    /// included after the prioritized transactions
+    buffer: VecDeque<I::Item>,
+    /// Tracker of total gas limit of prioritized transactions. Once it reaches
+    /// `max_prioritized_gas` no more transactions will be prioritized
+    prioritized_gas: u64,
+}
+
+impl<I: Iterator> BestTransactionsWithPrioritizedSenders<I> {
+    /// Constructs a new [`BestTransactionsWithPrioritizedSenders`].
+    pub fn new(prioritized_senders: AddressSet, max_prioritized_gas: u64, inner: I) -> Self {
+        Self {
+            inner,
+            prioritized_senders,
+            max_prioritized_gas,
+            buffer: Default::default(),
+            prioritized_gas: Default::default(),
+        }
+    }
+}
+
+impl<I, T> Iterator for BestTransactionsWithPrioritizedSenders<I>
+where
+    I: crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T>>>,
+    T: PoolTransaction,
+{
+    type Item = <I as Iterator>::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If we have space, try prioritizing transactions
+        if self.prioritized_gas < self.max_prioritized_gas {
+            for item in &mut self.inner {
+                if self.prioritized_senders.contains(&item.transaction.sender()) &&
+                    self.prioritized_gas + item.transaction.gas_limit() <=
+                        self.max_prioritized_gas
+                {
+                    self.prioritized_gas += item.transaction.gas_limit();
+                    return Some(item)
+                }
+                self.buffer.push_back(item);
+            }
+        }
+
+        if let Some(item) = self.buffer.pop_front() {
+            Some(item)
+        } else {
+            self.inner.next()
+        }
+    }
+}
+
+impl<I, T> crate::traits::BestTransactions for BestTransactionsWithPrioritizedSenders<I>
+where
+    I: crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T>>>,
+    T: PoolTransaction,
+{
+    fn mark_invalid(&mut self, tx: &Self::Item, kind: &InvalidPoolTransactionError) {
+        self.inner.mark_invalid(tx, kind)
+    }
+
+    fn no_updates(&mut self) {
+        self.inner.no_updates()
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        if skip_blobs {
+            self.buffer.retain(|tx| !tx.transaction.is_eip4844())
+        }
+        self.inner.set_skip_blobs(skip_blobs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        pool::pending::PendingPool,
+        test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},
+        BestTransactions, Priority,
+    };
+
+    #[test]
+    fn test_best_iter() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_tx = 10;
+        // insert 10 gapless tx
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best();
+        assert_eq!(best.all.len(), num_tx as usize);
+        assert_eq!(best.independent.len(), 1);
+
+        // check tx are returned in order
+        for nonce in 0..num_tx {
+            assert_eq!(best.independent.len(), 1);
+            let tx = best.next().unwrap();
+            assert_eq!(tx.nonce(), nonce);
+        }
+    }
+
+    #[test]
+    fn test_best_iter_invalid() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_tx = 10;
+        // insert 10 gapless tx
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best();
+
+        // mark the first tx as invalid
+        let invalid = best.independent.iter().next().unwrap();
+        best.mark_invalid(
+            &invalid.transaction.clone(),
+            &InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported),
+        );
+
+        // iterator is empty
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_transactions_iter_invalid() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_tx = 10;
+        // insert 10 gapless tx
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best: Box<
+            dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<MockTransaction>>>,
+        > = Box::new(pool.best());
+
+        let tx = Iterator::next(&mut best).unwrap();
+        crate::traits::BestTransactions::mark_invalid(
+            &mut *best,
+            &tx,
+            &InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported),
+        );
+        assert!(Iterator::next(&mut best).is_none());
+    }
+
+    #[test]
+    fn test_best_with_fees_iter_base_fee_satisfied() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_tx = 5;
+        let base_fee: u64 = 10;
+        let base_fee_per_blob_gas: u64 = 15;
+
+        // Insert transactions with a max_fee_per_gas greater than or equal to the base fee
+        // Without blob fee
+        for nonce in 0..num_tx {
+            let tx = MockTransaction::eip1559()
+                .rng_hash()
+                .with_nonce(nonce)
+                .with_max_fee(base_fee as u128 + 5);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+
+        for nonce in 0..num_tx {
+            let tx = best.next().expect("Transaction should be returned");
+            assert_eq!(tx.nonce(), nonce);
+            assert!(tx.transaction.max_fee_per_gas() >= base_fee as u128);
+        }
+    }
+
+    #[test]
+    fn test_best_with_fees_iter_base_fee_violated() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_tx = 5;
+        let base_fee: u64 = 20;
+        let base_fee_per_blob_gas: u64 = 15;
+
+        // Insert transactions with a max_fee_per_gas less than the base fee
+        for nonce in 0..num_tx {
+            let tx = MockTransaction::eip1559()
+                .rng_hash()
+                .with_nonce(nonce)
+                .with_max_fee(base_fee as u128 - 5);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+
+        // No transaction should be returned since all violate the base fee
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_with_fees_iter_blob_fee_satisfied() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_tx = 5;
+        let base_fee: u64 = 10;
+        let base_fee_per_blob_gas: u64 = 20;
+
+        // Insert transactions with a max_fee_per_blob_gas greater than or equal to the base fee per
+        // blob gas
+        for nonce in 0..num_tx {
+            let tx = MockTransaction::eip4844()
+                .rng_hash()
+                .with_nonce(nonce)
+                .with_max_fee(base_fee as u128 + 5)
+                .with_blob_fee(base_fee_per_blob_gas as u128 + 5);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+
+        // All transactions should be returned in order since they satisfy both base fee and blob
+        // fee
+        for nonce in 0..num_tx {
+            let tx = best.next().expect("Transaction should be returned");
+            assert_eq!(tx.nonce(), nonce);
+            assert!(tx.transaction.max_fee_per_gas() >= base_fee as u128);
+            assert!(
+                tx.transaction.max_fee_per_blob_gas().unwrap() >= base_fee_per_blob_gas as u128
+            );
+        }
+
+        // No more transactions should be returned
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_with_fees_iter_blob_fee_violated() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_tx = 5;
+        let base_fee: u64 = 10;
+        let base_fee_per_blob_gas: u64 = 20;
+
+        // Insert transactions with a max_fee_per_blob_gas less than the base fee per blob gas
+        for nonce in 0..num_tx {
+            let tx = MockTransaction::eip4844()
+                .rng_hash()
+                .with_nonce(nonce)
+                .with_max_fee(base_fee as u128 + 5)
+                .with_blob_fee(base_fee_per_blob_gas as u128 - 5);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+
+        // No transaction should be returned since all violate the blob fee
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_with_fees_iter_mixed_fees() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let base_fee: u64 = 10;
+        let base_fee_per_blob_gas: u64 = 20;
+
+        // Insert transactions with varying max_fee_per_gas and max_fee_per_blob_gas
+        let tx1 =
+            MockTransaction::eip1559().rng_hash().with_nonce(0).with_max_fee(base_fee as u128 + 5);
+        let tx2 = MockTransaction::eip4844()
+            .rng_hash()
+            .with_nonce(1)
+            .with_max_fee(base_fee as u128 + 5)
+            .with_blob_fee(base_fee_per_blob_gas as u128 + 5);
+        let tx3 = MockTransaction::eip4844()
+            .rng_hash()
+            .with_nonce(2)
+            .with_max_fee(base_fee as u128 + 5)
+            .with_blob_fee(base_fee_per_blob_gas as u128 - 5);
+        let tx4 =
+            MockTransaction::eip1559().rng_hash().with_nonce(3).with_max_fee(base_fee as u128 - 5);
+
+        pool.add_transaction(Arc::new(f.validated(tx1.clone())), 0);
+        pool.add_transaction(Arc::new(f.validated(tx2.clone())), 0);
+        pool.add_transaction(Arc::new(f.validated(tx3)), 0);
+        pool.add_transaction(Arc::new(f.validated(tx4)), 0);
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+
+        let expected_order = vec![tx1, tx2];
+        for expected_tx in expected_order {
+            let tx = best.next().expect("Transaction should be returned");
+            assert_eq!(tx.transaction, expected_tx);
+        }
+
+        // No more transactions should be returned
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_add_transaction_with_next_nonce() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add 5 transactions with increasing nonces to the pool
+        let num_tx = 5;
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        // Create a BestTransactions iterator from the pool
+        let mut best = pool.best();
+
+        // Use a broadcast channel for transaction updates
+        let (tx_sender, tx_receiver) =
+            tokio::sync::broadcast::channel::<PendingTransaction<MockOrdering>>(1000);
+        best.new_transaction_receiver = Some(tx_receiver);
+
+        // Create a new transaction with nonce 5 and validate it
+        let new_tx = MockTransaction::eip1559().rng_hash().with_nonce(5);
+        let valid_new_tx = f.validated(new_tx);
+
+        // Send the new transaction through the broadcast channel
+        let pending_tx = PendingTransaction {
+            submission_id: 10,
+            transaction: Arc::new(valid_new_tx.clone()),
+            priority: Priority::Value(1000),
+        };
+        tx_sender.send(pending_tx.clone()).unwrap();
+
+        // Add new transactions to the iterator
+        best.add_new_transactions();
+
+        // Verify that the new transaction has been added to the 'all' map
+        assert_eq!(best.all.len(), 6);
+        assert!(best.all.contains_key(valid_new_tx.id()));
+
+        // Verify that the new transaction has been added to the 'independent' set
+        assert_eq!(best.independent.len(), 2);
+        assert!(best.independent.contains(&pending_tx));
+    }
+
+    #[test]
+    fn test_best_add_transaction_with_ancestor() {
+        // Initialize a new PendingPool with default MockOrdering and MockTransactionFactory
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add 5 transactions with increasing nonces to the pool
+        let num_tx = 5;
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        // Create a BestTransactions iterator from the pool
+        let mut best = pool.best();
+
+        // Use a broadcast channel for transaction updates
+        let (tx_sender, tx_receiver) =
+            tokio::sync::broadcast::channel::<PendingTransaction<MockOrdering>>(1000);
+        best.new_transaction_receiver = Some(tx_receiver);
+
+        // Create a new transaction with nonce 5 and validate it
+        let base_tx1 = MockTransaction::eip1559().rng_hash().with_nonce(5);
+        let valid_new_tx1 = f.validated(base_tx1.clone());
+
+        // Send the new transaction through the broadcast channel
+        let pending_tx1 = PendingTransaction {
+            submission_id: 10,
+            transaction: Arc::new(valid_new_tx1.clone()),
+            priority: Priority::Value(1000),
+        };
+        tx_sender.send(pending_tx1.clone()).unwrap();
+
+        // Add new transactions to the iterator
+        best.add_new_transactions();
+
+        // Verify that the new transaction has been added to the 'all' map
+        assert_eq!(best.all.len(), 6);
+        assert!(best.all.contains_key(valid_new_tx1.id()));
+
+        // Verify that the new transaction has been added to the 'independent' set
+        assert_eq!(best.independent.len(), 2);
+        assert!(best.independent.contains(&pending_tx1));
+
+        // Attempt to add a new transaction with a different nonce (not a duplicate)
+        let base_tx2 = base_tx1.with_nonce(6);
+        let valid_new_tx2 = f.validated(base_tx2);
+
+        // Send the new transaction through the broadcast channel
+        let pending_tx2 = PendingTransaction {
+            submission_id: 11, // Different submission ID
+            transaction: Arc::new(valid_new_tx2.clone()),
+            priority: Priority::Value(1000),
+        };
+        tx_sender.send(pending_tx2.clone()).unwrap();
+
+        // Add new transactions to the iterator
+        best.add_new_transactions();
+
+        // Verify that the new transaction has been added to 'all'
+        assert_eq!(best.all.len(), 7);
+        assert!(best.all.contains_key(valid_new_tx2.id()));
+
+        // Verify that the new transaction has not been added to the 'independent' set
+        assert_eq!(best.independent.len(), 2);
+        assert!(!best.independent.contains(&pending_tx2));
+    }
+
+    #[test]
+    fn test_best_transactions_filter_trait_object() {
+        // Initialize a new PendingPool with default MockOrdering and MockTransactionFactory
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add 5 transactions with increasing nonces to the pool
+        let num_tx = 5;
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        // Create a trait object of BestTransactions iterator from the pool
+        let best: Box<dyn crate::traits::BestTransactions<Item = _>> = Box::new(pool.best());
+
+        // Create a filter that only returns transactions with even nonces
+        let filter =
+            BestTransactionFilter::new(best, |tx: &Arc<ValidPoolTransaction<MockTransaction>>| {
+                tx.nonce().is_multiple_of(2)
+            });
+
+        // Verify that the filter only returns transactions with even nonces
+        for tx in filter {
+            assert_eq!(tx.nonce() % 2, 0);
+        }
+    }
+
+    #[test]
+    fn test_best_transactions_prioritized_senders() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add 5 plain transactions from different senders with increasing gas price
+        for gas_price in 0..5 {
+            let tx = MockTransaction::eip1559().with_gas_price((gas_price + 1) * 10);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        // Add another transaction with 5 gas price that's going to be prioritized by sender
+        let prioritized_tx = MockTransaction::eip1559().with_gas_price(5).with_gas_limit(200);
+        let valid_prioritized_tx = f.validated(prioritized_tx.clone());
+        pool.add_transaction(Arc::new(valid_prioritized_tx), 0);
+
+        // Add another transaction with 3 gas price that should not be prioritized by sender because
+        // of gas limit.
+        let prioritized_tx2 = MockTransaction::eip1559().with_gas_price(3);
+        let valid_prioritized_tx2 = f.validated(prioritized_tx2.clone());
+        pool.add_transaction(Arc::new(valid_prioritized_tx2), 0);
+
+        let prioritized_senders =
+            AddressSet::from_iter([prioritized_tx.sender(), prioritized_tx2.sender()]);
+        let best =
+            BestTransactionsWithPrioritizedSenders::new(prioritized_senders, 200, pool.best());
+
+        // Verify that the prioritized transaction is returned first
+        // and the rest are returned in the reverse order of gas price
+        let mut iter = best.into_iter();
+        let top_of_block_tx = iter.next().unwrap();
+        assert_eq!(top_of_block_tx.max_fee_per_gas(), 5);
+        assert_eq!(top_of_block_tx.sender(), prioritized_tx.sender());
+        for gas_price in (0..5).rev() {
+            assert_eq!(iter.next().unwrap().max_fee_per_gas(), (gas_price + 1) * 10);
+        }
+
+        // Due to the gas limit, the transaction from second-prioritized sender was not
+        // prioritized.
+        let top_of_block_tx2 = iter.next().unwrap();
+        assert_eq!(top_of_block_tx2.max_fee_per_gas(), 3);
+        assert_eq!(top_of_block_tx2.sender(), prioritized_tx2.sender());
+    }
+
+    #[test]
+    fn test_best_with_fees_iter_no_blob_fee_required() {
+        // Tests transactions without blob fees where base fees are checked.
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let base_fee: u64 = 10;
+        let base_fee_per_blob_gas: u64 = 0; // No blob fee requirement
+
+        // Insert transactions with max_fee_per_gas above the base fee
+        for nonce in 0..5 {
+            let tx = MockTransaction::eip1559()
+                .rng_hash()
+                .with_nonce(nonce)
+                .with_max_fee(base_fee as u128 + 5);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+
+        // All transactions should be returned as no blob fee requirement is imposed
+        for nonce in 0..5 {
+            let tx = best.next().expect("Transaction should be returned");
+            assert_eq!(tx.nonce(), nonce);
+        }
+
+        // Ensure no more transactions are left
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_with_fees_iter_mix_of_blob_and_non_blob_transactions() {
+        // Tests mixed scenarios with both blob and non-blob transactions.
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let base_fee: u64 = 10;
+        let base_fee_per_blob_gas: u64 = 15;
+
+        // Add a non-blob transaction that satisfies the base fee
+        let tx_non_blob =
+            MockTransaction::eip1559().rng_hash().with_nonce(0).with_max_fee(base_fee as u128 + 5);
+        pool.add_transaction(Arc::new(f.validated(tx_non_blob.clone())), 0);
+
+        // Add a blob transaction that satisfies both base fee and blob fee
+        let tx_blob = MockTransaction::eip4844()
+            .rng_hash()
+            .with_nonce(1)
+            .with_max_fee(base_fee as u128 + 5)
+            .with_blob_fee(base_fee_per_blob_gas as u128 + 5);
+        pool.add_transaction(Arc::new(f.validated(tx_blob.clone())), 0);
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+
+        // Verify both transactions are returned
+        let tx = best.next().expect("Transaction should be returned");
+        assert_eq!(tx.transaction, tx_non_blob);
+
+        let tx = best.next().expect("Transaction should be returned");
+        assert_eq!(tx.transaction, tx_blob);
+
+        // Ensure no more transactions are left
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_transactions_with_skipping_blobs() {
+        // Tests the skip_blobs functionality to ensure blob transactions are skipped.
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add a blob transaction
+        let tx_blob = MockTransaction::eip4844().rng_hash().with_nonce(0).with_blob_fee(100);
+        let valid_blob_tx = f.validated(tx_blob);
+        pool.add_transaction(Arc::new(valid_blob_tx), 0);
+
+        // Add a non-blob transaction
+        let tx_non_blob = MockTransaction::eip1559().rng_hash().with_nonce(1).with_max_fee(200);
+        let valid_non_blob_tx = f.validated(tx_non_blob.clone());
+        pool.add_transaction(Arc::new(valid_non_blob_tx), 0);
+
+        let mut best = pool.best();
+        best.skip_blobs();
+
+        // Only the non-blob transaction should be returned
+        let tx = best.next().expect("Transaction should be returned");
+        assert_eq!(tx.transaction, tx_non_blob);
+
+        // Ensure no more transactions are left
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn test_best_transactions_no_updates() {
+        // Tests the no_updates functionality to ensure it properly clears the
+        // new_transaction_receiver.
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add a transaction
+        let tx = MockTransaction::eip1559().rng_hash().with_nonce(0).with_max_fee(100);
+        let valid_tx = f.validated(tx);
+        pool.add_transaction(Arc::new(valid_tx), 0);
+
+        let mut best = pool.best();
+
+        // Use a broadcast channel for transaction updates
+        let (_tx_sender, tx_receiver) =
+            tokio::sync::broadcast::channel::<PendingTransaction<MockOrdering>>(1000);
+        best.new_transaction_receiver = Some(tx_receiver);
+
+        // Ensure receiver is set
+        assert!(best.new_transaction_receiver.is_some());
+
+        // Call no_updates to clear the receiver
+        best.no_updates();
+
+        // Ensure receiver is cleared
+        assert!(best.new_transaction_receiver.is_none());
+    }
+
+    #[test]
+    fn test_best_update_transaction_priority() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add 5 transactions with increasing nonces to the pool
+        let num_tx = 5;
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        // Create a BestTransactions iterator from the pool
+        let mut best = pool.best();
+
+        // Use a broadcast channel for transaction updates
+        let (tx_sender, tx_receiver) =
+            tokio::sync::broadcast::channel::<PendingTransaction<MockOrdering>>(1000);
+        best.new_transaction_receiver = Some(tx_receiver);
+
+        // yield one tx, effectively locking in the highest prio
+        let first = best.next().unwrap();
+
+        // Create a new transaction with nonce 5 and validate it
+        let new_higher_fee_tx = MockTransaction::eip1559().with_nonce(0);
+        let valid_new_higher_fee_tx = f.validated(new_higher_fee_tx);
+
+        // Send the new transaction through the broadcast channel
+        let pending_tx = PendingTransaction {
+            submission_id: 10,
+            transaction: Arc::new(valid_new_higher_fee_tx.clone()),
+            priority: Priority::Value(u128::MAX),
+        };
+        tx_sender.send(pending_tx).unwrap();
+
+        // ensure that the higher prio tx is skipped since we yielded a lower one
+        for tx in best {
+            assert_eq!(tx.sender_id(), first.sender_id());
+            assert_ne!(tx.sender_id(), valid_new_higher_fee_tx.sender_id());
+        }
+    }
+
+    /// Reproduces the "Blob Transaction Ordering, Multiple Clients" Hive scenario.
+    ///
+    /// Sender A contributes 5-blob transactions while sender B contributes 1-blob transactions.
+    /// A single payload build should be able to fill the block with 6 blobs total (5+1).
+    #[test]
+    fn test_blob_transaction_ordering_multiple_clients_shape() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let base_fee: u64 = 10;
+        let base_fee_per_blob_gas: u64 = 1;
+        let max_blob_count: u64 = 6;
+
+        let sender_a = MockTransaction::eip4844()
+            .with_blob_hashes(5)
+            .with_max_fee(base_fee as u128 + 20)
+            .with_priority_fee(base_fee as u128 + 20)
+            .with_blob_fee(120);
+        for nonce in 0..5u64 {
+            let tx = sender_a.clone().rng_hash().with_nonce(nonce);
+            pool.add_transaction(Arc::new(f.validated(tx)), 0);
+        }
+
+        let sender_b = MockTransaction::eip4844()
+            .with_blob_hashes(1)
+            .with_max_fee(base_fee as u128 + 20)
+            .with_priority_fee(base_fee as u128 + 20)
+            .with_blob_fee(100);
+        for nonce in 0..5u64 {
+            let tx = sender_b.clone().rng_hash().with_nonce(nonce);
+            pool.add_transaction(Arc::new(f.validated(tx)), 0);
+        }
+
+        let mut best = pool.best_with_basefee_and_blobfee(base_fee, base_fee_per_blob_gas);
+        let mut block_blob_count = 0u64;
+        let mut included_txs = 0u64;
+
+        while let Some(tx) = best.next() {
+            if let Some(blob_hashes) = tx.transaction.blob_versioned_hashes() {
+                let tx_blob_count = blob_hashes.len() as u64;
+
+                if block_blob_count + tx_blob_count > max_blob_count {
+                    crate::traits::BestTransactions::mark_invalid(
+                        &mut best,
+                        &tx,
+                        &InvalidPoolTransactionError::Eip4844(
+                            Eip4844PoolTransactionError::TooManyEip4844Blobs {
+                                have: block_blob_count + tx_blob_count,
+                                permitted: max_blob_count,
+                            },
+                        ),
+                    );
+                    continue;
+                }
+
+                block_blob_count += tx_blob_count;
+                included_txs += 1;
+
+                if block_blob_count == max_blob_count {
+                    best.skip_blobs();
+                    break;
+                }
+            }
+        }
+
+        assert_eq!(
+            block_blob_count, max_blob_count,
+            "expected a full blob block (5+1 blobs across senders)"
+        );
+        assert_eq!(included_txs, 2, "expected one 5-blob tx and one 1-blob tx in the block");
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/blob.rs
+++ b/patches/reth-transaction-pool/src/pool/blob.rs
@@ -1,0 +1,787 @@
+use super::txpool::PendingFees;
+use crate::{
+    identifier::TransactionId, pool::size::SizeTracker, traits::BestTransactionsAttributes,
+    PoolTransaction, SubPoolLimit, ValidPoolTransaction,
+};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+/// A set of validated blob transactions in the pool that are __not pending__.
+///
+/// The purpose of this pool is to keep track of blob transactions that are queued and to evict the
+/// worst blob transactions once the sub-pool is full.
+///
+/// This expects that certain constraints are met:
+///   - blob transactions are always gapless
+#[derive(Debug, Clone)]
+pub struct BlobTransactions<T: PoolTransaction> {
+    /// Keeps track of transactions inserted in the pool.
+    ///
+    /// This way we can determine when transactions were submitted to the pool.
+    submission_id: u64,
+    /// _All_ Transactions that are currently inside the pool grouped by their identifier.
+    by_id: BTreeMap<TransactionId, BlobTransaction<T>>,
+    /// _All_ transactions sorted by blob priority.
+    all: BTreeSet<BlobTransaction<T>>,
+    /// Keeps track of the current fees, so transaction priority can be calculated on insertion.
+    pending_fees: PendingFees,
+    /// Keeps track of the size of this pool.
+    ///
+    /// See also [`reth_primitives_traits::InMemorySize::size`].
+    size_of: SizeTracker,
+}
+
+// === impl BlobTransactions ===
+
+impl<T: PoolTransaction> BlobTransactions<T> {
+    /// Adds a new transactions to the pending queue.
+    ///
+    /// # Panics
+    ///
+    ///   - If the transaction is not a blob tx.
+    ///   - If the transaction is already included.
+    pub fn add_transaction(&mut self, tx: Arc<ValidPoolTransaction<T>>) {
+        assert!(tx.is_eip4844(), "transaction is not a blob tx");
+        let id = *tx.id();
+        assert!(!self.contains(&id), "transaction already included {:?}", self.get(&id).unwrap());
+        let submission_id = self.next_id();
+
+        // keep track of size
+        self.size_of += tx.size();
+
+        // set transaction, which will also calculate priority based on current pending fees
+        let transaction = BlobTransaction::new(tx, submission_id, &self.pending_fees);
+
+        self.by_id.insert(id, transaction.clone());
+        self.all.insert(transaction);
+    }
+
+    const fn next_id(&mut self) -> u64 {
+        let id = self.submission_id;
+        self.submission_id = self.submission_id.wrapping_add(1);
+        id
+    }
+
+    /// Removes the transaction from the pool
+    pub(crate) fn remove_transaction(
+        &mut self,
+        id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T>>> {
+        // remove from queues
+        let tx = self.by_id.remove(id)?;
+
+        self.all.remove(&tx);
+
+        // keep track of size
+        self.size_of -= tx.transaction.size();
+
+        Some(tx.transaction)
+    }
+
+    /// Returns all transactions that satisfy the given basefee and blobfee.
+    ///
+    /// Note: This does not remove any of the transactions from the pool.
+    pub(crate) fn satisfy_attributes(
+        &self,
+        best_transactions_attributes: BestTransactionsAttributes,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut transactions = Vec::new();
+        {
+            // short path if blob_fee is None in provided best transactions attributes
+            if let Some(blob_fee_to_satisfy) =
+                best_transactions_attributes.blob_fee.map(|fee| fee as u128)
+            {
+                let mut iter = self.by_id.iter().peekable();
+
+                while let Some((id, tx)) = iter.next() {
+                    if tx.transaction.max_fee_per_blob_gas().unwrap_or_default() <
+                        blob_fee_to_satisfy ||
+                        tx.transaction.max_fee_per_gas() <
+                            best_transactions_attributes.basefee as u128
+                    {
+                        // does not satisfy the blob fee or base fee
+                        // still parked in blob pool -> skip descendant transactions
+                        'this: while let Some((peek, _)) = iter.peek() {
+                            if peek.sender != id.sender {
+                                break 'this
+                            }
+                            iter.next();
+                        }
+                    } else {
+                        transactions.push(tx.transaction.clone());
+                    }
+                }
+            }
+        }
+        transactions
+    }
+
+    /// Returns true if the pool exceeds the given limit
+    #[inline]
+    pub(crate) fn exceeds(&self, limit: &SubPoolLimit) -> bool {
+        limit.is_exceeded(self.len(), self.size())
+    }
+
+    /// The reported size of all transactions in this pool.
+    pub(crate) fn size(&self) -> usize {
+        self.size_of.into()
+    }
+
+    /// Number of transactions in the entire pool
+    pub(crate) fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Returns whether the pool is empty
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Returns all transactions which:
+    ///  * have a `max_fee_per_blob_gas` greater than or equal to the given `blob_fee`, _and_
+    ///  * have a `max_fee_per_gas` greater than or equal to the given `base_fee`
+    fn satisfy_pending_fee_ids(&self, pending_fees: &PendingFees) -> Vec<TransactionId> {
+        let mut transactions = Vec::new();
+        {
+            let mut iter = self.by_id.iter().peekable();
+
+            while let Some((id, tx)) = iter.next() {
+                if tx.transaction.max_fee_per_blob_gas() < Some(pending_fees.blob_fee) ||
+                    tx.transaction.max_fee_per_gas() < pending_fees.base_fee as u128
+                {
+                    // still parked in blob pool -> skip descendant transactions
+                    'this: while let Some((peek, _)) = iter.peek() {
+                        if peek.sender != id.sender {
+                            break 'this
+                        }
+                        iter.next();
+                    }
+                } else {
+                    transactions.push(*id);
+                }
+            }
+        }
+        transactions
+    }
+
+    /// Resorts the transactions in the pool based on the pool's current [`PendingFees`].
+    pub(crate) fn reprioritize(&mut self) {
+        // mem::take to modify without allocating, then collect to rebuild the BTreeSet
+        self.all = std::mem::take(&mut self.all)
+            .into_iter()
+            .map(|mut tx| {
+                tx.update_priority(&self.pending_fees);
+                tx
+            })
+            .collect();
+
+        // we need to update `by_id` as well because removal from `all` can only happen if the
+        // `BlobTransaction`s in each struct are consistent
+        for tx in self.by_id.values_mut() {
+            tx.update_priority(&self.pending_fees);
+        }
+    }
+
+    /// Removes all transactions (and their descendants) which:
+    ///  * have a `max_fee_per_blob_gas` greater than or equal to the given `blob_fee`, _and_
+    ///  * have a `max_fee_per_gas` greater than or equal to the given `base_fee`
+    ///
+    /// This also sets the [`PendingFees`] for the pool, resorting transactions based on their
+    /// updated priority.
+    ///
+    /// Note: the transactions are not returned in a particular order.
+    pub(crate) fn enforce_pending_fees(
+        &mut self,
+        pending_fees: &PendingFees,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let removed = self
+            .satisfy_pending_fee_ids(pending_fees)
+            .into_iter()
+            .map(|id| self.remove_transaction(&id).expect("transaction exists"))
+            .collect();
+
+        // Update pending fees and reprioritize
+        self.pending_fees = pending_fees.clone();
+        self.reprioritize();
+
+        removed
+    }
+
+    /// Removes transactions until the pool satisfies its [`SubPoolLimit`].
+    ///
+    /// This is done by removing transactions according to their ordering in the pool, defined by
+    /// the [`BlobOrd`] struct.
+    ///
+    /// Removed transactions are returned in the order they were removed.
+    pub fn truncate_pool(&mut self, limit: SubPoolLimit) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut removed = Vec::new();
+
+        while self.exceeds(&limit) {
+            let tx = self.all.last().expect("pool is not empty");
+            let id = *tx.transaction.id();
+            removed.push(self.remove_transaction(&id).expect("transaction exists"));
+        }
+
+        removed
+    }
+
+    /// Returns `true` if the transaction with the given id is already included in this pool.
+    pub(crate) fn contains(&self, id: &TransactionId) -> bool {
+        self.by_id.contains_key(id)
+    }
+
+    /// Retrieves a transaction with the given ID from the pool, if it exists.
+    fn get(&self, id: &TransactionId) -> Option<&BlobTransaction<T>> {
+        self.by_id.get(id)
+    }
+
+    /// Asserts that the bijection between `by_id` and `all` is valid.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub(crate) fn assert_invariants(&self) {
+        assert_eq!(self.by_id.len(), self.all.len(), "by_id.len() != all.len()");
+    }
+}
+
+impl<T: PoolTransaction> Default for BlobTransactions<T> {
+    fn default() -> Self {
+        Self {
+            submission_id: 0,
+            by_id: Default::default(),
+            all: Default::default(),
+            size_of: Default::default(),
+            pending_fees: Default::default(),
+        }
+    }
+}
+
+/// A transaction that is ready to be included in a block.
+#[derive(Debug)]
+struct BlobTransaction<T: PoolTransaction> {
+    /// Actual blob transaction.
+    transaction: Arc<ValidPoolTransaction<T>>,
+    /// The value that determines the order of this transaction.
+    ord: BlobOrd,
+}
+
+impl<T: PoolTransaction> BlobTransaction<T> {
+    /// Creates a new blob transaction, based on the pool transaction, submission id, and current
+    /// pending fees.
+    pub(crate) fn new(
+        transaction: Arc<ValidPoolTransaction<T>>,
+        submission_id: u64,
+        pending_fees: &PendingFees,
+    ) -> Self {
+        let priority = blob_tx_priority(
+            transaction.max_fee_per_blob_gas().unwrap_or_default(),
+            pending_fees.blob_fee,
+            transaction.max_fee_per_gas(),
+            pending_fees.base_fee as u128,
+        );
+        let ord = BlobOrd { priority, submission_id };
+        Self { transaction, ord }
+    }
+
+    /// Updates the priority for the transaction based on the current pending fees.
+    pub(crate) fn update_priority(&mut self, pending_fees: &PendingFees) {
+        self.ord.priority = blob_tx_priority(
+            self.transaction.max_fee_per_blob_gas().unwrap_or_default(),
+            pending_fees.blob_fee,
+            self.transaction.max_fee_per_gas(),
+            pending_fees.base_fee as u128,
+        );
+    }
+}
+
+impl<T: PoolTransaction> Clone for BlobTransaction<T> {
+    fn clone(&self) -> Self {
+        Self { transaction: self.transaction.clone(), ord: self.ord.clone() }
+    }
+}
+
+impl<T: PoolTransaction> Eq for BlobTransaction<T> {}
+
+impl<T: PoolTransaction> PartialEq<Self> for BlobTransaction<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<T: PoolTransaction> PartialOrd<Self> for BlobTransaction<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: PoolTransaction> Ord for BlobTransaction<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ord.cmp(&other.ord)
+    }
+}
+
+/// This is the log base 2 of 1.125, which we'll use to calculate the priority
+const LOG_2_1_125: f64 = 0.16992500144231237;
+
+/// The blob step function, attempting to compute the delta given the `max_tx_fee`, and
+/// `current_fee`.
+///
+/// The `max_tx_fee` is the maximum fee that the transaction is willing to pay, this
+/// would be the priority fee for the EIP1559 component of transaction fees, and the blob fee cap
+/// for the blob component of transaction fees.
+///
+/// The `current_fee` is the current value of the fee, this would be the base fee for the EIP1559
+/// component, and the blob fee (computed from the current head) for the blob component.
+///
+/// This is supposed to get the number of fee jumps required to get from the current fee to the fee
+/// cap, or where the transaction would not be executable any more.
+///
+/// A positive value means that the transaction will remain executable unless the current fee
+/// increases.
+///
+/// A negative value means that the transaction is currently not executable, and requires the
+/// current fee to decrease by some number of jumps before the max fee is greater than the current
+/// fee.
+pub fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
+    if max_tx_fee == current_fee {
+        // if these are equal, then there's no fee jump
+        return 0
+    }
+
+    let max_tx_fee_jumps = if max_tx_fee == 0 {
+        // we can't take log2 of 0, so we set this to zero here
+        0f64
+    } else {
+        (max_tx_fee.ilog2() as f64) / LOG_2_1_125
+    };
+
+    let current_fee_jumps = if current_fee == 0 {
+        // we can't take log2 of 0, so we set this to zero here
+        0f64
+    } else {
+        (current_fee.ilog2() as f64) / LOG_2_1_125
+    };
+
+    // jumps = log1.125(txfee) - log1.125(basefee)
+    let jumps = max_tx_fee_jumps - current_fee_jumps;
+
+    // delta = sign(jumps) * log(abs(jumps))
+    match (jumps as i64).cmp(&0) {
+        Ordering::Equal => {
+            // can't take ilog2 of 0
+            0
+        }
+        Ordering::Greater => (jumps.ceil() as i64).ilog2() as i64,
+        Ordering::Less => -((-jumps.floor() as i64).ilog2() as i64),
+    }
+}
+
+/// Returns the priority for the transaction, based on the "delta" blob fee and priority fee.
+pub fn blob_tx_priority(
+    blob_fee_cap: u128,
+    blob_fee: u128,
+    max_priority_fee: u128,
+    base_fee: u128,
+) -> i64 {
+    let delta_blob_fee = fee_delta(blob_fee_cap, blob_fee);
+    let delta_priority_fee = fee_delta(max_priority_fee, base_fee);
+
+    // TODO: this could be u64:
+    // * if all are positive, zero is returned
+    // * if all are negative, the min negative value is returned
+    // * if some are positive and some are negative, the min negative value is returned
+    //
+    // the BlobOrd could then just be a u64, and higher values represent worse transactions (more
+    // jumps for one of the fees until the cap satisfies)
+    //
+    // priority = min(delta-basefee, delta-blobfee, 0)
+    delta_blob_fee.min(delta_priority_fee).min(0)
+}
+
+/// A struct used to determine the ordering for a specific blob transaction in the pool. This uses
+/// a `priority` value to determine the ordering, and uses the `submission_id` to break ties.
+///
+/// The `priority` value is calculated using the [`blob_tx_priority`] function, and should be
+/// re-calculated on each block.
+#[derive(Debug, Clone)]
+pub struct BlobOrd {
+    /// Identifier that tags when transaction was submitted in the pool.
+    pub(crate) submission_id: u64,
+    /// The priority for this transaction, calculated using the [`blob_tx_priority`] function,
+    /// taking into account both the blob and priority fee.
+    pub(crate) priority: i64,
+}
+
+impl Eq for BlobOrd {}
+
+impl PartialEq<Self> for BlobOrd {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl PartialOrd<Self> for BlobOrd {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BlobOrd {
+    /// Compares two `BlobOrd` instances.
+    ///
+    /// The comparison is performed in reverse order based on the priority field. This is
+    /// because transactions with larger negative values in the priority field will take more fee
+    /// jumps, making them take longer to become executable. Therefore, transactions with lower
+    /// ordering should return `Greater`, ensuring they are evicted first.
+    ///
+    /// If the priority values are equal, the submission ID is used to break ties.
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .priority
+            .cmp(&self.priority)
+            .then_with(|| self.submission_id.cmp(&other.submission_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{MockTransaction, MockTransactionFactory};
+
+    /// Represents the fees for a single transaction, which will be built inside of a test.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TransactionFees {
+        /// The blob fee cap for the transaction.
+        max_blob_fee: u128,
+        /// The max priority fee for the transaction.
+        max_priority_fee_per_gas: u128,
+        /// The base fee for the transaction.
+        max_fee_per_gas: u128,
+    }
+
+    /// Represents an ordering of transactions based on their fees and the current network fees.
+    #[derive(Debug, Clone)]
+    struct TransactionOrdering {
+        /// The transaction fees, in the order that they're expected to be returned
+        fees: Vec<TransactionFees>,
+        /// The network fees
+        network_fees: PendingFees,
+    }
+
+    #[test]
+    fn test_blob_ordering() {
+        // Tests are from:
+        // <https://github.com/ethereum/go-ethereum/blob/e91cdb49beb4b2a3872b5f2548bf2d6559e4f561/core/txpool/blobpool/evictheap_test.go>
+        let mut factory = MockTransactionFactory::default();
+
+        let vectors = vec![
+            // If everything is above basefee and blobfee, order by miner tip
+            TransactionOrdering {
+                fees: vec![
+                    TransactionFees {
+                        max_blob_fee: 2,
+                        max_priority_fee_per_gas: 0,
+                        max_fee_per_gas: 2,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 3,
+                        max_priority_fee_per_gas: 1,
+                        max_fee_per_gas: 1,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 1,
+                        max_priority_fee_per_gas: 2,
+                        max_fee_per_gas: 3,
+                    },
+                ],
+                network_fees: PendingFees { base_fee: 0, blob_fee: 0 },
+            },
+            // If only basefees are used (blob fee matches with network), return the ones
+            // above the basefee first (best priority = 0), then the ones furthest below
+            // the basefee last (worst priority). Ties broken by submission_id.
+            TransactionOrdering {
+                fees: vec![
+                    TransactionFees {
+                        max_blob_fee: 0,
+                        max_priority_fee_per_gas: 1,
+                        max_fee_per_gas: 2000,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 0,
+                        max_priority_fee_per_gas: 2,
+                        max_fee_per_gas: 2000,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 0,
+                        max_priority_fee_per_gas: 3,
+                        max_fee_per_gas: 2000,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 0,
+                        max_priority_fee_per_gas: 50,
+                        max_fee_per_gas: 1000,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 0,
+                        max_priority_fee_per_gas: 100,
+                        max_fee_per_gas: 1000,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 0,
+                        max_priority_fee_per_gas: 50,
+                        max_fee_per_gas: 500,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 0,
+                        max_priority_fee_per_gas: 100,
+                        max_fee_per_gas: 500,
+                    },
+                ],
+                network_fees: PendingFees { base_fee: 1999, blob_fee: 0 },
+            },
+            // If only blobfees are used (base fee matches with network), return the ones
+            // above the blobfee first (best priority = 0), then the ones furthest below
+            // the blobfee last (worst priority). Ties broken by submission_id.
+            TransactionOrdering {
+                fees: vec![
+                    TransactionFees {
+                        max_blob_fee: 2000,
+                        max_priority_fee_per_gas: 1,
+                        max_fee_per_gas: 0,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 2000,
+                        max_priority_fee_per_gas: 2,
+                        max_fee_per_gas: 0,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 2000,
+                        max_priority_fee_per_gas: 3,
+                        max_fee_per_gas: 0,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 1000,
+                        max_priority_fee_per_gas: 50,
+                        max_fee_per_gas: 0,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 1000,
+                        max_priority_fee_per_gas: 100,
+                        max_fee_per_gas: 0,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 500,
+                        max_priority_fee_per_gas: 50,
+                        max_fee_per_gas: 0,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 500,
+                        max_priority_fee_per_gas: 100,
+                        max_fee_per_gas: 0,
+                    },
+                ],
+                network_fees: PendingFees { base_fee: 0, blob_fee: 1999 },
+            },
+            // If both basefee and blobfee are specified, sort by the larger distance
+            // of the two from the current network conditions.
+            //
+            // Basefee: 1000, Blobfee: 100
+            //
+            // Txs with blob_fee=80: fee_delta(80, 100) = 0 (ilog2 granularity) => priority 0
+            // Txs with blob_fee=63: fee_delta(63, 100) = -2 => priority -2
+            //
+            // Priority 0 txs come first (best), then priority -2 (worst).
+            // Within same priority, ties broken by submission_id.
+            TransactionOrdering {
+                fees: vec![
+                    TransactionFees {
+                        max_blob_fee: 80,
+                        max_priority_fee_per_gas: 4,
+                        max_fee_per_gas: 630,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 80,
+                        max_priority_fee_per_gas: 1,
+                        max_fee_per_gas: 800,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 63,
+                        max_priority_fee_per_gas: 3,
+                        max_fee_per_gas: 800,
+                    },
+                    TransactionFees {
+                        max_blob_fee: 63,
+                        max_priority_fee_per_gas: 2,
+                        max_fee_per_gas: 630,
+                    },
+                ],
+                network_fees: PendingFees { base_fee: 1000, blob_fee: 100 },
+            },
+        ];
+
+        for ordering in vectors {
+            // create a new pool each time
+            let mut pool = BlobTransactions::default();
+
+            // create tx from fees
+            let txs = ordering
+                .fees
+                .iter()
+                .map(|fees| {
+                    MockTransaction::eip4844()
+                        .with_blob_fee(fees.max_blob_fee)
+                        .with_priority_fee(fees.max_priority_fee_per_gas)
+                        .with_max_fee(fees.max_fee_per_gas)
+                })
+                .collect::<Vec<_>>();
+
+            for tx in &txs {
+                pool.add_transaction(factory.validated_arc(tx.clone()));
+            }
+
+            // update fees and resort the pool
+            pool.pending_fees = ordering.network_fees.clone();
+            pool.reprioritize();
+
+            // now iterate through the pool and make sure they're in the same order as the original
+            // fees - map to TransactionFees so it's easier to compare the ordering without having
+            // to see irrelevant fields
+            let actual_txs = pool
+                .all
+                .iter()
+                .map(|tx| TransactionFees {
+                    max_blob_fee: tx.transaction.max_fee_per_blob_gas().unwrap_or_default(),
+                    max_priority_fee_per_gas: tx.transaction.priority_fee_or_price(),
+                    max_fee_per_gas: tx.transaction.max_fee_per_gas(),
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                ordering.fees, actual_txs,
+                "ordering mismatch, expected: {:#?}, actual: {:#?}",
+                ordering.fees, actual_txs
+            );
+        }
+    }
+
+    #[test]
+    fn priority_tests() {
+        // Test vectors from:
+        // <https://github.com/ethereum/go-ethereum/blob/e91cdb49beb4b2a3872b5f2548bf2d6559e4f561/core/txpool/blobpool/priority_test.go#L27-L49>
+        let vectors = vec![
+            (7u128, 10u128, 2i64),
+            (17_200_000_000, 17_200_000_000, 0),
+            (9_853_941_692, 11_085_092_510, 0),
+            (11_544_106_391, 10_356_781_100, 0),
+            (17_200_000_000, 7, -7),
+            (7, 17_200_000_000, 7),
+        ];
+
+        for (base_fee, tx_fee, expected) in vectors {
+            let actual = fee_delta(tx_fee, base_fee);
+            assert_eq!(
+                actual, expected,
+                "fee_delta({tx_fee}, {base_fee}) = {actual}, expected: {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_empty_pool_operations() {
+        let mut pool: BlobTransactions<MockTransaction> = BlobTransactions::default();
+
+        // Ensure pool is empty
+        assert!(pool.is_empty());
+        assert_eq!(pool.len(), 0);
+        assert_eq!(pool.size(), 0);
+
+        // Attempt to remove a non-existent transaction
+        let non_existent_id = TransactionId::new(0.into(), 0);
+        assert!(pool.remove_transaction(&non_existent_id).is_none());
+
+        // Check contains method on empty pool
+        assert!(!pool.contains(&non_existent_id));
+    }
+
+    #[test]
+    fn test_transaction_removal() {
+        let mut factory = MockTransactionFactory::default();
+        let mut pool = BlobTransactions::default();
+
+        // Add a transaction
+        let tx = factory.validated_arc(MockTransaction::eip4844());
+        let tx_id = *tx.id();
+        pool.add_transaction(tx);
+
+        // Remove the transaction
+        let removed = pool.remove_transaction(&tx_id);
+        assert!(removed.is_some());
+        assert_eq!(*removed.unwrap().id(), tx_id);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn test_satisfy_attributes_empty_pool() {
+        let pool: BlobTransactions<MockTransaction> = BlobTransactions::default();
+        let attributes = BestTransactionsAttributes { blob_fee: Some(100), basefee: 100 };
+        // Satisfy attributes on an empty pool should return an empty vector
+        let satisfied = pool.satisfy_attributes(attributes);
+        assert!(satisfied.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "transaction is not a blob tx")]
+    fn test_add_non_blob_transaction() {
+        // Ensure that adding a non-blob transaction causes a panic
+        let mut factory = MockTransactionFactory::default();
+        let mut pool = BlobTransactions::default();
+        let tx = factory.validated_arc(MockTransaction::eip1559()); // Not a blob transaction
+        pool.add_transaction(tx);
+    }
+
+    #[test]
+    #[should_panic(expected = "transaction already included")]
+    fn test_add_duplicate_blob_transaction() {
+        // Ensure that adding a duplicate blob transaction causes a panic
+        let mut factory = MockTransactionFactory::default();
+        let mut pool = BlobTransactions::default();
+        let tx = factory.validated_arc(MockTransaction::eip4844());
+        pool.add_transaction(tx.clone()); // First addition
+        pool.add_transaction(tx); // Attempt to add the same transaction again
+    }
+
+    #[test]
+    fn test_remove_transactions_until_limit() {
+        // Test truncating the pool until it satisfies the given size limit
+        let mut factory = MockTransactionFactory::default();
+        let mut pool = BlobTransactions::default();
+        let tx1 = factory.validated_arc(MockTransaction::eip4844().with_size(100));
+        let tx2 = factory.validated_arc(MockTransaction::eip4844().with_size(200));
+        let tx3 = factory.validated_arc(MockTransaction::eip4844().with_size(300));
+
+        // Add transactions to the pool
+        pool.add_transaction(tx1);
+        pool.add_transaction(tx2);
+        pool.add_transaction(tx3);
+
+        // Set a size limit that requires truncation
+        let limit = SubPoolLimit { max_txs: 2, max_size: 300 };
+        let removed = pool.truncate_pool(limit);
+
+        // Check that only one transaction was removed to satisfy the limit
+        assert_eq!(removed.len(), 1);
+        assert_eq!(pool.len(), 2);
+        assert!(pool.size() <= limit.max_size);
+    }
+
+    #[test]
+    fn test_empty_pool_invariants() {
+        // Ensure that the invariants hold for an empty pool
+        let pool: BlobTransactions<MockTransaction> = BlobTransactions::default();
+        pool.assert_invariants();
+        assert!(pool.is_empty());
+        assert_eq!(pool.size(), 0);
+        assert_eq!(pool.len(), 0);
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/events.rs
+++ b/patches/reth-transaction-pool/src/pool/events.rs
@@ -1,0 +1,110 @@
+use crate::{traits::PropagateKind, PoolTransaction, SubPool, ValidPoolTransaction};
+use alloy_primitives::{TxHash, B256};
+use std::sync::Arc;
+
+use crate::pool::QueuedReason;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// An event that happened to a transaction and contains its full body where possible.
+#[derive(Debug)]
+pub enum FullTransactionEvent<T: PoolTransaction> {
+    /// Transaction has been added to the pending pool.
+    Pending(TxHash),
+    /// Transaction has been added to the queued pool.
+    ///
+    /// If applicable, attached the specific reason why this was queued.
+    Queued(TxHash, Option<QueuedReason>),
+    /// Transaction has been included in the block belonging to this hash.
+    Mined {
+        /// The hash of the mined transaction.
+        tx_hash: TxHash,
+        /// The hash of the mined block that contains the transaction.
+        block_hash: B256,
+    },
+    /// Transaction has been replaced by the transaction belonging to the hash.
+    ///
+    /// E.g. same (sender + nonce) pair
+    Replaced {
+        /// The transaction that was replaced.
+        transaction: Arc<ValidPoolTransaction<T>>,
+        /// The transaction that replaced the event subject.
+        replaced_by: TxHash,
+    },
+    /// Transaction was dropped due to configured limits.
+    Discarded(TxHash),
+    /// Transaction became invalid indefinitely.
+    Invalid(TxHash),
+    /// Transaction was propagated to peers.
+    Propagated(Arc<Vec<PropagateKind>>),
+}
+
+impl<T: PoolTransaction> Clone for FullTransactionEvent<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Pending(hash) => Self::Pending(*hash),
+            Self::Queued(hash, reason) => Self::Queued(*hash, reason.clone()),
+            Self::Mined { tx_hash, block_hash } => {
+                Self::Mined { tx_hash: *tx_hash, block_hash: *block_hash }
+            }
+            Self::Replaced { transaction, replaced_by } => {
+                Self::Replaced { transaction: Arc::clone(transaction), replaced_by: *replaced_by }
+            }
+            Self::Discarded(hash) => Self::Discarded(*hash),
+            Self::Invalid(hash) => Self::Invalid(*hash),
+            Self::Propagated(propagated) => Self::Propagated(Arc::clone(propagated)),
+        }
+    }
+}
+
+/// Various events that describe status changes of a transaction.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum TransactionEvent {
+    /// Transaction has been added to the pending pool.
+    Pending,
+    /// Transaction has been added to the queued pool.
+    Queued,
+    /// Transaction has been included in the block belonging to this hash.
+    Mined(B256),
+    /// Transaction has been replaced by the transaction belonging to the hash.
+    ///
+    /// E.g. same (sender + nonce) pair
+    Replaced(TxHash),
+    /// Transaction was dropped due to configured limits.
+    Discarded,
+    /// Transaction became invalid indefinitely.
+    Invalid,
+    /// Transaction was propagated to peers.
+    Propagated(Arc<Vec<PropagateKind>>),
+}
+
+impl TransactionEvent {
+    /// Returns `true` if the event is final and no more events are expected for this transaction
+    /// hash.
+    pub const fn is_final(&self) -> bool {
+        matches!(self, Self::Replaced(_) | Self::Mined(_) | Self::Discarded | Self::Invalid)
+    }
+}
+
+/// Represents a new transaction
+#[derive(Debug)]
+pub struct NewTransactionEvent<T: PoolTransaction> {
+    /// The pool which the transaction was moved to.
+    pub subpool: SubPool,
+    /// Actual transaction
+    pub transaction: Arc<ValidPoolTransaction<T>>,
+}
+
+impl<T: PoolTransaction> NewTransactionEvent<T> {
+    /// Creates a new event for a pending transaction.
+    pub const fn pending(transaction: Arc<ValidPoolTransaction<T>>) -> Self {
+        Self { subpool: SubPool::Pending, transaction }
+    }
+}
+
+impl<T: PoolTransaction> Clone for NewTransactionEvent<T> {
+    fn clone(&self) -> Self {
+        Self { subpool: self.subpool, transaction: self.transaction.clone() }
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/listener.rs
+++ b/patches/reth-transaction-pool/src/pool/listener.rs
@@ -1,0 +1,374 @@
+//! Listeners for the transaction-pool
+
+use crate::{
+    pool::{
+        events::{FullTransactionEvent, NewTransactionEvent, TransactionEvent},
+        QueuedReason,
+    },
+    traits::{NewBlobSidecar, PropagateKind},
+    PoolTransaction, ValidPoolTransaction,
+};
+use alloy_primitives::{TxHash, B256};
+use futures_util::Stream;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc::{
+    self as mpsc, error::TrySendError, Receiver, Sender, UnboundedReceiver, UnboundedSender,
+};
+use tracing::debug;
+
+/// The size of the event channel used to propagate transaction events.
+const TX_POOL_EVENT_CHANNEL_SIZE: usize = 1024;
+
+/// A Stream that receives [`TransactionEvent`] only for the transaction with the given hash.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct TransactionEvents {
+    hash: TxHash,
+    events: UnboundedReceiver<TransactionEvent>,
+}
+
+impl TransactionEvents {
+    /// Create a new instance of this stream.
+    pub const fn new(hash: TxHash, events: UnboundedReceiver<TransactionEvent>) -> Self {
+        Self { hash, events }
+    }
+
+    /// The hash for this transaction
+    pub const fn hash(&self) -> TxHash {
+        self.hash
+    }
+}
+
+impl Stream for TransactionEvents {
+    type Item = TransactionEvent;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.get_mut().events.poll_recv(cx)
+    }
+}
+
+/// A Stream that receives [`FullTransactionEvent`] for _all_ transaction.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct AllTransactionsEvents<T: PoolTransaction> {
+    pub(crate) events: Receiver<FullTransactionEvent<T>>,
+}
+
+impl<T: PoolTransaction> AllTransactionsEvents<T> {
+    /// Create a new instance of this stream.
+    pub const fn new(events: Receiver<FullTransactionEvent<T>>) -> Self {
+        Self { events }
+    }
+}
+
+impl<T: PoolTransaction> Stream for AllTransactionsEvents<T> {
+    type Item = FullTransactionEvent<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().events.poll_recv(cx)
+    }
+}
+
+/// A type that broadcasts [`TransactionEvent`] to installed listeners.
+///
+/// This is essentially a multi-producer, multi-consumer channel where each event is broadcast to
+/// all active receivers.
+#[derive(Debug)]
+pub struct PoolEventBroadcast<T: PoolTransaction> {
+    /// All listeners for all transaction events.
+    all_events_broadcaster: AllPoolEventsBroadcaster<T>,
+    /// All listeners for events for a certain transaction hash.
+    broadcasters_by_hash: HashMap<TxHash, PoolEventBroadcaster>,
+}
+
+impl<T: PoolTransaction> Default for PoolEventBroadcast<T> {
+    fn default() -> Self {
+        Self {
+            all_events_broadcaster: AllPoolEventsBroadcaster::default(),
+            broadcasters_by_hash: HashMap::default(),
+        }
+    }
+}
+
+impl<T: PoolTransaction> PoolEventBroadcast<T> {
+    /// Calls the broadcast callback with the `PoolEventBroadcaster` that belongs to the hash.
+    fn broadcast_event(
+        &mut self,
+        hash: &TxHash,
+        event: TransactionEvent,
+        pool_event: FullTransactionEvent<T>,
+    ) {
+        // Broadcast to all listeners for the transaction hash.
+        if let Entry::Occupied(mut sink) = self.broadcasters_by_hash.entry(*hash) {
+            sink.get_mut().broadcast(event.clone());
+
+            if sink.get().is_empty() || event.is_final() {
+                sink.remove();
+            }
+        }
+
+        // Broadcast to all listeners for all transactions.
+        self.all_events_broadcaster.broadcast(pool_event);
+    }
+
+    /// Returns true if no listeners are installed
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.all_events_broadcaster.is_empty() && self.broadcasters_by_hash.is_empty()
+    }
+
+    /// Create a new subscription for the given transaction hash.
+    pub fn subscribe(&mut self, tx_hash: TxHash) -> TransactionEvents {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        match self.broadcasters_by_hash.entry(tx_hash) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().senders.push(tx);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(PoolEventBroadcaster { senders: vec![tx] });
+            }
+        };
+        TransactionEvents { hash: tx_hash, events: rx }
+    }
+
+    /// Create a new subscription for all transactions.
+    pub fn subscribe_all(&mut self) -> AllTransactionsEvents<T> {
+        let (tx, rx) = tokio::sync::mpsc::channel(TX_POOL_EVENT_CHANNEL_SIZE);
+        self.all_events_broadcaster.senders.push(tx);
+        AllTransactionsEvents::new(rx)
+    }
+
+    /// Notify listeners about a transaction that was added to the pending queue.
+    pub fn pending(&mut self, tx: &TxHash, replaced: Option<Arc<ValidPoolTransaction<T>>>) {
+        self.broadcast_event(tx, TransactionEvent::Pending, FullTransactionEvent::Pending(*tx));
+
+        if let Some(replaced) = replaced {
+            // notify listeners that this transaction was replaced
+            self.replaced(replaced, *tx);
+        }
+    }
+
+    /// Notify listeners about a transaction that was replaced.
+    pub fn replaced(&mut self, tx: Arc<ValidPoolTransaction<T>>, replaced_by: TxHash) {
+        let transaction = Arc::clone(&tx);
+        self.broadcast_event(
+            tx.hash(),
+            TransactionEvent::Replaced(replaced_by),
+            FullTransactionEvent::Replaced { transaction, replaced_by },
+        );
+    }
+
+    /// Notify listeners about a transaction that was added to the queued pool.
+    pub fn queued(&mut self, tx: &TxHash, reason: Option<QueuedReason>) {
+        self.broadcast_event(
+            tx,
+            TransactionEvent::Queued,
+            FullTransactionEvent::Queued(*tx, reason),
+        );
+    }
+
+    /// Notify listeners about a transaction that was propagated.
+    pub fn propagated(&mut self, tx: &TxHash, peers: Vec<PropagateKind>) {
+        let peers = Arc::new(peers);
+        self.broadcast_event(
+            tx,
+            TransactionEvent::Propagated(Arc::clone(&peers)),
+            FullTransactionEvent::Propagated(peers),
+        );
+    }
+
+    /// Notify listeners about all discarded transactions.
+    #[inline]
+    pub fn discarded_many(&mut self, discarded: &[Arc<ValidPoolTransaction<T>>]) {
+        if self.is_empty() {
+            return
+        }
+        for tx in discarded {
+            self.discarded(tx.hash());
+        }
+    }
+
+    /// Notify listeners about a transaction that was discarded.
+    pub fn discarded(&mut self, tx: &TxHash) {
+        self.broadcast_event(tx, TransactionEvent::Discarded, FullTransactionEvent::Discarded(*tx));
+    }
+
+    /// Notify listeners about a transaction that was invalid.
+    pub fn invalid(&mut self, tx: &TxHash) {
+        self.broadcast_event(tx, TransactionEvent::Invalid, FullTransactionEvent::Invalid(*tx));
+    }
+
+    /// Notify listeners that the transaction was mined
+    pub fn mined(&mut self, tx: &TxHash, block_hash: B256) {
+        self.broadcast_event(
+            tx,
+            TransactionEvent::Mined(block_hash),
+            FullTransactionEvent::Mined { tx_hash: *tx, block_hash },
+        );
+    }
+}
+
+/// All Sender half(s) of the event channels for all transactions.
+///
+/// This mimics [`tokio::sync::broadcast`] but uses separate channels.
+#[derive(Debug)]
+struct AllPoolEventsBroadcaster<T: PoolTransaction> {
+    /// Corresponding sender half(s) for event listener channel
+    senders: Vec<Sender<FullTransactionEvent<T>>>,
+}
+
+impl<T: PoolTransaction> Default for AllPoolEventsBroadcaster<T> {
+    fn default() -> Self {
+        Self { senders: Vec::new() }
+    }
+}
+
+impl<T: PoolTransaction> AllPoolEventsBroadcaster<T> {
+    // Broadcast an event to all listeners. Dropped listeners are silently evicted.
+    fn broadcast(&mut self, event: FullTransactionEvent<T>) {
+        self.senders.retain(|sender| match sender.try_send(event.clone()) {
+            Ok(_) | Err(TrySendError::Full(_)) => true,
+            Err(TrySendError::Closed(_)) => false,
+        })
+    }
+
+    /// Returns true if there are no listeners installed.
+    #[inline]
+    const fn is_empty(&self) -> bool {
+        self.senders.is_empty()
+    }
+}
+
+/// All Sender half(s) of the event channels for a specific transaction.
+///
+/// This mimics [`tokio::sync::broadcast`] but uses separate channels and is unbounded.
+#[derive(Default, Debug)]
+struct PoolEventBroadcaster {
+    /// Corresponding sender half(s) for event listener channel
+    senders: Vec<UnboundedSender<TransactionEvent>>,
+}
+
+impl PoolEventBroadcaster {
+    /// Returns `true` if there are no more listeners remaining.
+    const fn is_empty(&self) -> bool {
+        self.senders.is_empty()
+    }
+
+    // Broadcast an event to all listeners. Dropped listeners are silently evicted.
+    fn broadcast(&mut self, event: TransactionEvent) {
+        self.senders.retain(|sender| sender.send(event.clone()).is_ok())
+    }
+}
+
+/// An active listener for new pending transactions.
+#[derive(Debug)]
+pub struct PendingTransactionHashListener {
+    /// The sender of the channel to send transaction hashes to.
+    pub sender: mpsc::Sender<TxHash>,
+    /// Whether to include transactions that should not be propagated over the network.
+    pub kind: TransactionListenerKind,
+}
+
+impl PendingTransactionHashListener {
+    /// Attempts to send all hashes to the listener.
+    ///
+    /// Returns false if the channel is closed (receiver dropped)
+    pub fn send_all(&self, hashes: impl IntoIterator<Item = TxHash>) -> bool {
+        for tx_hash in hashes {
+            match self.sender.try_send(tx_hash) {
+                Ok(()) => {}
+                Err(err) => {
+                    return if matches!(err, mpsc::error::TrySendError::Full(_)) {
+                        debug!(
+                            target: "txpool",
+                            "[{:?}] failed to send pending tx; channel full",
+                            tx_hash,
+                        );
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        }
+        true
+    }
+}
+
+/// An active listener for new pending transactions.
+#[derive(Debug)]
+pub struct TransactionListener<T: PoolTransaction> {
+    /// The sender of the channel to send new transaction events to.
+    pub sender: mpsc::Sender<NewTransactionEvent<T>>,
+    /// Whether to include transactions that should not be propagated over the network.
+    pub kind: TransactionListenerKind,
+}
+
+impl<T: PoolTransaction> TransactionListener<T> {
+    /// Attempts to send the event to the listener.
+    ///
+    /// Returns false if the channel is closed (receiver dropped)
+    pub fn send(&self, event: NewTransactionEvent<T>) -> bool {
+        self.send_all(std::iter::once(event))
+    }
+
+    /// Attempts to send all events to the listener.
+    ///
+    /// Returns false if the channel is closed (receiver dropped)
+    pub fn send_all(&self, events: impl IntoIterator<Item = NewTransactionEvent<T>>) -> bool {
+        for event in events {
+            match self.sender.try_send(event) {
+                Ok(()) => {}
+                Err(err) => {
+                    return if let mpsc::error::TrySendError::Full(event) = err {
+                        debug!(
+                            target: "txpool",
+                            "[{:?}] failed to send pending tx; channel full",
+                            event.transaction.hash(),
+                        );
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        }
+        true
+    }
+}
+
+/// An active listener for new blobs
+#[derive(Debug)]
+pub(crate) struct BlobTransactionSidecarListener {
+    pub(crate) sender: mpsc::Sender<NewBlobSidecar>,
+}
+
+/// Determines what kind of new transactions should be emitted by a stream of transactions.
+///
+/// This gives control whether to include transactions that are allowed to be propagated.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TransactionListenerKind {
+    /// Any new pending transactions
+    All,
+    /// Only transactions that are allowed to be propagated.
+    ///
+    /// See also [`ValidPoolTransaction`]
+    PropagateOnly,
+}
+
+impl TransactionListenerKind {
+    /// Returns true if we're only interested in transactions that are allowed to be propagated.
+    #[inline]
+    pub const fn is_propagate_only(&self) -> bool {
+        matches!(self, Self::PropagateOnly)
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/mod.rs
+++ b/patches/reth-transaction-pool/src/pool/mod.rs
@@ -1,0 +1,1778 @@
+//! Transaction Pool internals.
+//!
+//! Incoming transactions are validated before they enter the pool first. The validation outcome can
+//! have 3 states:
+//!
+//!  1. Transaction can _never_ be valid
+//!  2. Transaction is _currently_ valid
+//!  3. Transaction is _currently_ invalid, but could potentially become valid in the future
+//!
+//! However, (2.) and (3.) of a transaction can only be determined on the basis of the current
+//! state, whereas (1.) holds indefinitely. This means once the state changes (2.) and (3.) the
+//! state of a transaction needs to be reevaluated again.
+//!
+//! The transaction pool is responsible for storing new, valid transactions and providing the next
+//! best transactions sorted by their priority. Where priority is determined by the transaction's
+//! score ([`TransactionOrdering`]).
+//!
+//! Furthermore, the following characteristics fall under (3.):
+//!
+//!  a) Nonce of a transaction is higher than the expected nonce for the next transaction of its
+//! sender. A distinction is made here whether multiple transactions from the same sender have
+//! gapless nonce increments.
+//!
+//!  a)(1) If _no_ transaction is missing in a chain of multiple
+//! transactions from the same sender (all nonce in row), all of them can in principle be executed
+//! on the current state one after the other.
+//!
+//!  a)(2) If there's a nonce gap, then all
+//! transactions after the missing transaction are blocked until the missing transaction arrives.
+//!
+//!  b) Transaction does not meet the dynamic fee cap requirement introduced by EIP-1559: The
+//! fee cap of the transaction needs to be no less than the base fee of block.
+//!
+//!
+//! In essence the transaction pool is made of three separate sub-pools:
+//!
+//!  - Pending Pool: Contains all transactions that are valid on the current state and satisfy (3.
+//!    a)(1): _No_ nonce gaps. A _pending_ transaction is considered _ready_ when it has the lowest
+//!    nonce of all transactions from the same sender. Once a _ready_ transaction with nonce `n` has
+//!    been executed, the next highest transaction from the same sender `n + 1` becomes ready.
+//!
+//!  - Queued Pool: Contains all transactions that are currently blocked by missing transactions:
+//!    (3. a)(2): _With_ nonce gaps or due to lack of funds.
+//!
+//!  - Basefee Pool: To account for the dynamic base fee requirement (3. b) which could render an
+//!    EIP-1559 and all subsequent transactions of the sender currently invalid.
+//!
+//! The classification of transactions is always dependent on the current state that is changed as
+//! soon as a new block is mined. Once a new block is mined, the account changeset must be applied
+//! to the transaction pool.
+//!
+//!
+//! Depending on the use case, consumers of the [`TransactionPool`](crate::traits::TransactionPool)
+//! are interested in (2.) and/or (3.).
+
+//! A generic [`TransactionPool`](crate::traits::TransactionPool) that only handles transactions.
+//!
+//! This Pool maintains two separate sub-pools for (2.) and (3.)
+//!
+//! ## Terminology
+//!
+//!  - _Pending_: pending transactions are transactions that fall under (2.). These transactions can
+//!    currently be executed and are stored in the pending sub-pool
+//!  - _Queued_: queued transactions are transactions that fall under category (3.). Those
+//!    transactions are _currently_ waiting for state changes that eventually move them into
+//!    category (2.) and become pending.
+
+use crate::{
+    blobstore::BlobStore,
+    error::{PoolError, PoolErrorKind, PoolResult},
+    identifier::{SenderId, SenderIdentifiers, TransactionId},
+    metrics::BlobStoreMetrics,
+    pool::{
+        listener::{
+            BlobTransactionSidecarListener, PendingTransactionHashListener, PoolEventBroadcast,
+            TransactionListener,
+        },
+        state::SubPool,
+        txpool::{SenderInfo, TxPool},
+        update::UpdateOutcome,
+    },
+    traits::{
+        AllPoolTransactions, BestTransactionsAttributes, BlockInfo, GetPooledTransactionLimit,
+        NewBlobSidecar, PoolSize, PoolTransaction, PropagatedTransactions, TransactionOrigin,
+    },
+    validate::{TransactionValidationOutcome, ValidPoolTransaction, ValidTransaction},
+    CanonicalStateUpdate, EthPoolTransaction, PoolConfig, TransactionOrdering,
+    TransactionValidator,
+};
+
+use alloy_primitives::{
+    map::{AddressSet, HashSet},
+    Address, TxHash, B256,
+};
+use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use reth_eth_wire_types::HandleMempoolData;
+use reth_execution_types::ChangedAccount;
+
+use alloy_eips::{eip7594::BlobTransactionSidecarVariant, Typed2718};
+use reth_primitives_traits::Recovered;
+use rustc_hash::FxHashMap;
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
+use tokio::sync::mpsc;
+use tracing::{debug, trace, warn};
+mod events;
+pub use best::{BestTransactionFilter, BestTransactionsWithPrioritizedSenders};
+pub use blob::{blob_tx_priority, fee_delta, BlobOrd, BlobTransactions};
+pub use events::{FullTransactionEvent, NewTransactionEvent, TransactionEvent};
+pub use listener::{AllTransactionsEvents, TransactionEvents, TransactionListenerKind};
+pub use parked::{BasefeeOrd, ParkedOrd, ParkedPool, QueuedOrd};
+pub use pending::PendingPool;
+
+mod best;
+pub use best::BestTransactions;
+
+mod blob;
+pub mod listener;
+mod parked;
+pub mod pending;
+pub mod size;
+pub(crate) mod state;
+pub mod txpool;
+mod update;
+
+/// Bound on number of pending transactions from `reth_network::TransactionsManager` to buffer.
+pub const PENDING_TX_LISTENER_BUFFER_SIZE: usize = 2048;
+/// Bound on number of new transactions from `reth_network::TransactionsManager` to buffer.
+pub const NEW_TX_LISTENER_BUFFER_SIZE: usize = 1024;
+
+const BLOB_SIDECAR_LISTENER_BUFFER_SIZE: usize = 512;
+
+/// Transaction pool internals.
+pub struct PoolInner<V, T, S>
+where
+    T: TransactionOrdering,
+{
+    /// Internal mapping of addresses to plain ints.
+    identifiers: RwLock<SenderIdentifiers>,
+    /// Transaction validator.
+    validator: V,
+    /// Storage for blob transactions
+    blob_store: S,
+    /// The internal pool that manages all transactions.
+    pool: RwLock<TxPool<T>>,
+    /// Pool settings.
+    config: PoolConfig,
+    /// Manages listeners for transaction state change events.
+    event_listener: RwLock<PoolEventBroadcast<T::Transaction>>,
+    /// Tracks whether any event listeners have ever been installed.
+    has_event_listeners: AtomicBool,
+    /// Listeners for new _full_ pending transactions.
+    pending_transaction_listener: RwLock<Vec<PendingTransactionHashListener>>,
+    /// Listeners for new transactions added to the pool.
+    transaction_listener: RwLock<Vec<TransactionListener<T::Transaction>>>,
+    /// Listener for new blob transaction sidecars added to the pool.
+    blob_transaction_sidecar_listener: Mutex<Vec<BlobTransactionSidecarListener>>,
+    /// Metrics for the blob store
+    blob_store_metrics: BlobStoreMetrics,
+}
+
+// === impl PoolInner ===
+
+impl<V, T, S> PoolInner<V, T, S>
+where
+    V: TransactionValidator,
+    T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
+    S: BlobStore,
+{
+    /// Create a new transaction pool instance.
+    pub fn new(validator: V, ordering: T, blob_store: S, config: PoolConfig) -> Self {
+        Self {
+            identifiers: Default::default(),
+            validator,
+            event_listener: Default::default(),
+            has_event_listeners: AtomicBool::new(false),
+            pool: RwLock::new(TxPool::new(ordering, config.clone())),
+            pending_transaction_listener: Default::default(),
+            transaction_listener: Default::default(),
+            blob_transaction_sidecar_listener: Default::default(),
+            config,
+            blob_store,
+            blob_store_metrics: Default::default(),
+        }
+    }
+
+    /// Returns the configured blob store.
+    pub const fn blob_store(&self) -> &S {
+        &self.blob_store
+    }
+
+    /// Returns stats about the size of the pool.
+    pub fn size(&self) -> PoolSize {
+        self.get_pool_data().size()
+    }
+
+    /// Returns the currently tracked block
+    pub fn block_info(&self) -> BlockInfo {
+        self.get_pool_data().block_info()
+    }
+    /// Sets the currently tracked block.
+    ///
+    /// This will also notify subscribers about any transactions that were promoted to the pending
+    /// pool due to fee changes.
+    pub fn set_block_info(&self, info: BlockInfo) {
+        let outcome = self.pool.write().set_block_info(info);
+
+        // Notify subscribers about promoted transactions due to fee changes
+        self.notify_on_transaction_updates(outcome.promoted, outcome.discarded);
+    }
+
+    /// Returns the internal [`SenderId`] for this address, allocating a new mapping when the
+    /// address is first observed.
+    ///
+    /// This must only be used on paths that intentionally begin tracking a sender, such as
+    /// transaction insertion. Read-only lookups should prefer [`Self::sender_id`] to avoid
+    /// growing the sender-id map for unknown addresses.
+    pub fn get_sender_id(&self, addr: Address) -> SenderId {
+        self.identifiers.write().sender_id_or_create(addr)
+    }
+
+    /// Returns the internal [`SenderId`] for this address if it is already tracked.
+    ///
+    /// Unlike [`Self::get_sender_id`], this never allocates a new sender mapping and is therefore
+    /// suitable for read-only queries or best-effort cleanup on unknown addresses.
+    pub fn sender_id(&self, addr: &Address) -> Option<SenderId> {
+        self.identifiers.read().sender_id(addr)
+    }
+
+    /// Returns the internal [`SenderId`]s for the given addresses.
+    pub fn get_sender_ids(&self, addrs: impl IntoIterator<Item = Address>) -> Vec<SenderId> {
+        self.identifiers.write().sender_ids_or_create(addrs)
+    }
+
+    /// Returns all senders in the pool
+    pub fn unique_senders(&self) -> AddressSet {
+        self.get_pool_data().unique_senders()
+    }
+
+    /// Converts the changed accounts to a map of sender ids to sender info (internal identifier
+    /// used for __tracked__ accounts)
+    fn changed_senders(
+        &self,
+        accs: impl Iterator<Item = ChangedAccount>,
+    ) -> FxHashMap<SenderId, SenderInfo> {
+        let identifiers = self.identifiers.read();
+        accs.into_iter()
+            .filter_map(|acc| {
+                let ChangedAccount { address, nonce, balance } = acc;
+                let sender_id = identifiers.sender_id(&address)?;
+                Some((sender_id, SenderInfo { state_nonce: nonce, balance }))
+            })
+            .collect()
+    }
+
+    /// Get the config the pool was configured with.
+    pub const fn config(&self) -> &PoolConfig {
+        &self.config
+    }
+
+    /// Get the validator reference.
+    pub const fn validator(&self) -> &V {
+        &self.validator
+    }
+
+    /// Adds a new transaction listener to the pool that gets notified about every new _pending_
+    /// transaction inserted into the pool
+    pub fn add_pending_listener(&self, kind: TransactionListenerKind) -> mpsc::Receiver<TxHash> {
+        let (sender, rx) = mpsc::channel(self.config.pending_tx_listener_buffer_size);
+        let listener = PendingTransactionHashListener { sender, kind };
+
+        let mut listeners = self.pending_transaction_listener.write();
+        // Clean up dead listeners before adding new one
+        listeners.retain(|l| !l.sender.is_closed());
+        listeners.push(listener);
+
+        rx
+    }
+
+    /// Adds a new transaction listener to the pool that gets notified about every new transaction.
+    pub fn add_new_transaction_listener(
+        &self,
+        kind: TransactionListenerKind,
+    ) -> mpsc::Receiver<NewTransactionEvent<T::Transaction>> {
+        let (sender, rx) = mpsc::channel(self.config.new_tx_listener_buffer_size);
+        let listener = TransactionListener { sender, kind };
+
+        let mut listeners = self.transaction_listener.write();
+        // Clean up dead listeners before adding new one
+        listeners.retain(|l| !l.sender.is_closed());
+        listeners.push(listener);
+
+        rx
+    }
+    /// Adds a new blob sidecar listener to the pool that gets notified about every new
+    /// eip4844 transaction's blob sidecar.
+    pub fn add_blob_sidecar_listener(&self) -> mpsc::Receiver<NewBlobSidecar> {
+        let (sender, rx) = mpsc::channel(BLOB_SIDECAR_LISTENER_BUFFER_SIZE);
+        let listener = BlobTransactionSidecarListener { sender };
+        self.blob_transaction_sidecar_listener.lock().push(listener);
+        rx
+    }
+
+    /// If the pool contains the transaction, this adds a new listener that gets notified about
+    /// transaction events.
+    pub fn add_transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents> {
+        if !self.get_pool_data().contains(&tx_hash) {
+            return None
+        }
+        let mut listener = self.event_listener.write();
+        let events = listener.subscribe(tx_hash);
+        self.mark_event_listener_installed();
+        Some(events)
+    }
+
+    /// Adds a listener for all transaction events.
+    pub fn add_all_transactions_event_listener(&self) -> AllTransactionsEvents<T::Transaction> {
+        let mut listener = self.event_listener.write();
+        let events = listener.subscribe_all();
+        self.mark_event_listener_installed();
+        events
+    }
+
+    #[inline]
+    fn has_event_listeners(&self) -> bool {
+        self.has_event_listeners.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    fn mark_event_listener_installed(&self) {
+        self.has_event_listeners.store(true, Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn update_event_listener_state(&self, listener: &PoolEventBroadcast<T::Transaction>) {
+        if listener.is_empty() {
+            self.has_event_listeners.store(false, Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    fn with_event_listener<F>(&self, emit: F)
+    where
+        F: FnOnce(&mut PoolEventBroadcast<T::Transaction>),
+    {
+        if !self.has_event_listeners() {
+            return
+        }
+        let mut listener = self.event_listener.write();
+        if !listener.is_empty() {
+            emit(&mut listener);
+        }
+        self.update_event_listener_state(&listener);
+    }
+
+    /// Returns a read lock to the pool's data.
+    pub fn get_pool_data(&self) -> RwLockReadGuard<'_, TxPool<T>> {
+        self.pool.read()
+    }
+
+    /// Returns transactions in the pool that can be propagated
+    pub fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut out = Vec::new();
+        self.append_pooled_transactions(&mut out);
+        out
+    }
+
+    /// Returns hashes of transactions in the pool that can be propagated.
+    pub fn pooled_transactions_hashes(&self) -> Vec<TxHash> {
+        let mut out = Vec::new();
+        self.append_pooled_transactions_hashes(&mut out);
+        out
+    }
+
+    /// Returns only the first `max` transactions in the pool that can be propagated.
+    pub fn pooled_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut out = Vec::new();
+        self.append_pooled_transactions_max(max, &mut out);
+        out
+    }
+
+    /// Extends the given vector with all transactions in the pool that can be propagated.
+    pub fn append_pooled_transactions(
+        &self,
+        out: &mut Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+    ) {
+        out.extend(
+            self.get_pool_data().all().transactions_iter().filter(|tx| tx.propagate).cloned(),
+        );
+    }
+
+    /// Extends the given vector with pooled transactions for the given hashes that are allowed to
+    /// be propagated.
+    pub fn append_pooled_transaction_elements(
+        &self,
+        tx_hashes: &[TxHash],
+        limit: GetPooledTransactionLimit,
+        out: &mut Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>,
+    ) where
+        <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    {
+        let transactions = self.get_all_propagatable(tx_hashes);
+        let mut size = 0;
+        for transaction in transactions {
+            let encoded_len = transaction.encoded_length();
+            let Some(pooled) = self.to_pooled_transaction(transaction) else {
+                continue;
+            };
+
+            size += encoded_len;
+            out.push(pooled.into_inner());
+
+            if limit.exceeds(size) {
+                break
+            }
+        }
+    }
+
+    /// Extends the given vector with the hashes of all transactions in the pool that can be
+    /// propagated.
+    pub fn append_pooled_transactions_hashes(&self, out: &mut Vec<TxHash>) {
+        out.extend(
+            self.get_pool_data()
+                .all()
+                .transactions_iter()
+                .filter(|tx| tx.propagate)
+                .map(|tx| *tx.hash()),
+        );
+    }
+
+    /// Extends the given vector with only the first `max` transactions in the pool that can be
+    /// propagated.
+    pub fn append_pooled_transactions_max(
+        &self,
+        max: usize,
+        out: &mut Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+    ) {
+        out.extend(
+            self.get_pool_data()
+                .all()
+                .transactions_iter()
+                .filter(|tx| tx.propagate)
+                .take(max)
+                .cloned(),
+        );
+    }
+
+    /// Returns only the first `max` hashes of transactions in the pool that can be propagated.
+    pub fn pooled_transactions_hashes_max(&self, max: usize) -> Vec<TxHash> {
+        if max == 0 {
+            return Vec::new();
+        }
+        self.get_pool_data()
+            .all()
+            .transactions_iter()
+            .filter(|tx| tx.propagate)
+            .take(max)
+            .map(|tx| *tx.hash())
+            .collect()
+    }
+
+    /// Converts the internally tracked transaction to the pooled format.
+    ///
+    /// If the transaction is an EIP-4844 transaction, the blob sidecar is fetched from the blob
+    /// store and attached to the transaction.
+    fn to_pooled_transaction(
+        &self,
+        transaction: Arc<ValidPoolTransaction<T::Transaction>>,
+    ) -> Option<Recovered<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
+    where
+        <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    {
+        if transaction.is_eip4844() {
+            let sidecar = self.blob_store.get(*transaction.hash()).ok()??;
+            transaction.transaction.clone().try_into_pooled_eip4844(sidecar)
+        } else {
+            transaction
+                .transaction
+                .clone_into_pooled()
+                .inspect_err(|err| {
+                    debug!(
+                        target: "txpool", %err,
+                        "failed to convert transaction to pooled element; skipping",
+                    );
+                })
+                .ok()
+        }
+    }
+
+    /// Returns pooled transactions for the given transaction hashes that are allowed to be
+    /// propagated.
+    pub fn get_pooled_transaction_elements(
+        &self,
+        tx_hashes: Vec<TxHash>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>
+    where
+        <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    {
+        let mut elements = Vec::new();
+        self.append_pooled_transaction_elements(&tx_hashes, limit, &mut elements);
+        elements.shrink_to_fit();
+        elements
+    }
+
+    /// Returns converted pooled transaction for the given transaction hash.
+    pub fn get_pooled_transaction_element(
+        &self,
+        tx_hash: TxHash,
+    ) -> Option<Recovered<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
+    where
+        <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    {
+        self.get(&tx_hash).and_then(|tx| self.to_pooled_transaction(tx))
+    }
+
+    /// Updates the entire pool after a new block was executed.
+    pub fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_, V::Block>) {
+        trace!(target: "txpool", ?update, "updating pool on canonical state change");
+
+        let block_info = update.block_info();
+        let CanonicalStateUpdate {
+            new_tip, changed_accounts, mined_transactions, update_kind, ..
+        } = update;
+        self.validator.on_new_head_block(new_tip);
+
+        let changed_senders = self.changed_senders(changed_accounts.into_iter());
+
+        // update the pool
+        let outcome = self.pool.write().on_canonical_state_change(
+            block_info,
+            mined_transactions,
+            changed_senders,
+            update_kind,
+        );
+
+        // This will discard outdated transactions based on the account's nonce
+        self.delete_discarded_blobs(outcome.discarded.iter());
+
+        // notify listeners about updates
+        self.notify_on_new_state(outcome);
+    }
+
+    /// Performs account updates on the pool.
+    ///
+    /// This will either promote or discard transactions based on the new account state.
+    ///
+    /// This should be invoked when the pool drifted and accounts are updated manually
+    pub fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
+        let changed_senders = self.changed_senders(accounts.into_iter());
+        let UpdateOutcome { promoted, discarded } =
+            self.pool.write().update_accounts(changed_senders);
+
+        self.notify_on_transaction_updates(promoted, discarded);
+    }
+
+    /// Add a single validated transaction into the pool.
+    ///
+    /// Returns the outcome and optionally metadata to be processed after the pool lock is
+    /// released.
+    ///
+    /// Note: this is only used internally by [`Self::add_transactions()`], all new transaction(s)
+    /// come in through that function, either as a batch or `std::iter::once`.
+    fn add_transaction(
+        &self,
+        pool: &mut RwLockWriteGuard<'_, TxPool<T>>,
+        origin: TransactionOrigin,
+        tx: TransactionValidationOutcome<T::Transaction>,
+    ) -> (PoolResult<AddedTransactionOutcome>, Option<AddedTransactionMeta<T::Transaction>>) {
+        match tx {
+            TransactionValidationOutcome::Valid {
+                balance,
+                state_nonce,
+                transaction,
+                propagate,
+                bytecode_hash,
+                authorities,
+            } => {
+                let sender_id = self.get_sender_id(transaction.sender());
+                let transaction_id = TransactionId::new(sender_id, transaction.nonce());
+
+                // split the valid transaction and the blob sidecar if it has any
+                let (transaction, blob_sidecar) = match transaction {
+                    ValidTransaction::Valid(tx) => (tx, None),
+                    ValidTransaction::ValidWithSidecar { transaction, sidecar } => {
+                        debug_assert!(
+                            transaction.is_eip4844(),
+                            "validator returned sidecar for non EIP-4844 transaction"
+                        );
+                        (transaction, Some(sidecar))
+                    }
+                };
+
+                let tx = ValidPoolTransaction {
+                    transaction,
+                    transaction_id,
+                    propagate,
+                    timestamp: Instant::now(),
+                    origin,
+                    authority_ids: authorities.map(|auths| self.get_sender_ids(auths)),
+                };
+
+                let added = match pool.add_transaction(tx, balance, state_nonce, bytecode_hash) {
+                    Ok(added) => added,
+                    Err(err) => return (Err(err), None),
+                };
+                let hash = *added.hash();
+                let state = added.transaction_state();
+
+                let meta = AddedTransactionMeta { added, blob_sidecar };
+
+                (Ok(AddedTransactionOutcome { hash, state }), Some(meta))
+            }
+            TransactionValidationOutcome::Invalid(tx, err) => {
+                self.with_event_listener(|listener| listener.invalid(tx.hash()));
+                (Err(PoolError::new(*tx.hash(), err)), None)
+            }
+            TransactionValidationOutcome::Error(tx_hash, err) => {
+                self.with_event_listener(|listener| listener.discarded(&tx_hash));
+                (Err(PoolError::other(tx_hash, err)), None)
+            }
+        }
+    }
+
+    /// Adds a transaction and returns the event stream.
+    pub fn add_transaction_and_subscribe(
+        &self,
+        origin: TransactionOrigin,
+        tx: TransactionValidationOutcome<T::Transaction>,
+    ) -> PoolResult<TransactionEvents> {
+        let listener = {
+            let mut listener = self.event_listener.write();
+            let events = listener.subscribe(tx.tx_hash());
+            self.mark_event_listener_installed();
+            events
+        };
+        let mut results = self.add_transactions(origin, std::iter::once(tx));
+        results.pop().expect("result length is the same as the input")?;
+        Ok(listener)
+    }
+
+    /// Adds all transactions in the iterator to the pool, returning a list of results.
+    ///
+    /// Convenience method that assigns the same origin to all transactions. Delegates to
+    /// [`Self::add_transactions_with_origins`].
+    pub fn add_transactions(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = TransactionValidationOutcome<T::Transaction>>,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        self.add_transactions_with_origins(transactions.into_iter().map(|tx| (origin, tx)))
+    }
+
+    /// Adds all transactions in the iterator to the pool, each with its own
+    /// [`TransactionOrigin`], returning a list of results.
+    pub fn add_transactions_with_origins(
+        &self,
+        transactions: impl IntoIterator<
+            Item = (TransactionOrigin, TransactionValidationOutcome<T::Transaction>),
+        >,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        // Collect results and metadata while holding the pool write lock
+        let (mut results, added_metas, discarded) = {
+            let mut pool = self.pool.write();
+            let mut added_metas = Vec::new();
+
+            let results = transactions
+                .into_iter()
+                .map(|(origin, tx)| {
+                    let (result, meta) = self.add_transaction(&mut pool, origin, tx);
+
+                    // Only collect metadata for successful insertions
+                    if result.is_ok() &&
+                        let Some(meta) = meta
+                    {
+                        added_metas.push(meta);
+                    }
+
+                    result
+                })
+                .collect::<Vec<_>>();
+
+            // Enforce the pool size limits if at least one transaction was added successfully
+            let discarded = if results.iter().any(Result::is_ok) {
+                pool.discard_worst()
+            } else {
+                Default::default()
+            };
+
+            (results, added_metas, discarded)
+        };
+
+        for meta in added_metas {
+            self.on_added_transaction(meta);
+        }
+
+        if !discarded.is_empty() {
+            // Delete any blobs associated with discarded blob transactions
+            self.delete_discarded_blobs(discarded.iter());
+            self.with_event_listener(|listener| listener.discarded_many(&discarded));
+
+            let discarded_hashes =
+                discarded.into_iter().map(|tx| *tx.hash()).collect::<HashSet<_>>();
+
+            // A newly added transaction may be immediately discarded, so we need to
+            // adjust the result here
+            for res in &mut results {
+                if let Ok(AddedTransactionOutcome { hash, .. }) = res &&
+                    discarded_hashes.contains(hash)
+                {
+                    *res = Err(PoolError::new(*hash, PoolErrorKind::DiscardedOnInsert))
+                }
+            }
+        };
+
+        results
+    }
+
+    /// Process a transaction that was added to the pool.
+    ///
+    /// Performs blob storage operations and sends all notifications. This should be called
+    /// after the pool write lock has been released to avoid blocking pool operations.
+    fn on_added_transaction(&self, meta: AddedTransactionMeta<T::Transaction>) {
+        // Handle blob sidecar storage and notifications for EIP-4844 transactions
+        if let Some(sidecar) = meta.blob_sidecar {
+            let hash = *meta.added.hash();
+            self.on_new_blob_sidecar(&hash, &sidecar);
+            self.insert_blob(hash, sidecar);
+        }
+
+        // Delete replaced blob sidecar if any
+        if let Some(replaced) = meta.added.replaced_blob_transaction() {
+            debug!(target: "txpool", "[{:?}] delete replaced blob sidecar", replaced);
+            self.delete_blob(replaced);
+        }
+
+        // Delete discarded blob sidecars if any, this doesnt do any IO.
+        if let Some(discarded) = meta.added.discarded_transactions() {
+            self.delete_discarded_blobs(discarded.iter());
+        }
+
+        // Notify pending transaction listeners
+        if let Some(pending) = meta.added.as_pending() {
+            self.on_new_pending_transaction(pending);
+        }
+
+        // Notify event listeners
+        self.notify_event_listeners(&meta.added);
+
+        // Notify new transaction listeners
+        self.on_new_transaction(meta.added.into_new_transaction_event());
+    }
+
+    /// Notify all listeners about a new pending transaction.
+    ///
+    /// See also [`Self::add_pending_listener`]
+    ///
+    /// CAUTION: This function is only intended to be used manually in order to use this type's
+    /// pending transaction receivers when manually implementing the
+    /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
+    /// [`TransactionPool::pending_transactions_listener_for`](crate::TransactionPool).
+    pub fn on_new_pending_transaction(&self, pending: &AddedPendingTransaction<T::Transaction>) {
+        let mut needs_cleanup = false;
+
+        {
+            let listeners = self.pending_transaction_listener.read();
+            for listener in listeners.iter() {
+                if !listener.send_all(pending.pending_transactions(listener.kind)) {
+                    needs_cleanup = true;
+                }
+            }
+        }
+
+        // Clean up dead listeners if we detected any closed channels
+        if needs_cleanup {
+            self.pending_transaction_listener
+                .write()
+                .retain(|listener| !listener.sender.is_closed());
+        }
+    }
+
+    /// Notify all listeners about a newly inserted pending transaction.
+    ///
+    /// See also [`Self::add_new_transaction_listener`]
+    ///
+    /// CAUTION: This function is only intended to be used manually in order to use this type's
+    /// transaction receivers when manually implementing the
+    /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
+    /// [`TransactionPool::new_transactions_listener_for`](crate::TransactionPool).
+    pub fn on_new_transaction(&self, event: NewTransactionEvent<T::Transaction>) {
+        let mut needs_cleanup = false;
+
+        {
+            let listeners = self.transaction_listener.read();
+            for listener in listeners.iter() {
+                if listener.kind.is_propagate_only() && !event.transaction.propagate {
+                    if listener.sender.is_closed() {
+                        needs_cleanup = true;
+                    }
+                    // Skip non-propagate transactions for propagate-only listeners
+                    continue
+                }
+
+                if !listener.send(event.clone()) {
+                    needs_cleanup = true;
+                }
+            }
+        }
+
+        // Clean up dead listeners if we detected any closed channels
+        if needs_cleanup {
+            self.transaction_listener.write().retain(|listener| !listener.sender.is_closed());
+        }
+    }
+
+    /// Notify all listeners about a blob sidecar for a newly inserted blob (eip4844) transaction.
+    fn on_new_blob_sidecar(&self, tx_hash: &TxHash, sidecar: &BlobTransactionSidecarVariant) {
+        let mut sidecar_listeners = self.blob_transaction_sidecar_listener.lock();
+        if sidecar_listeners.is_empty() {
+            return
+        }
+        let sidecar = Arc::new(sidecar.clone());
+        sidecar_listeners.retain_mut(|listener| {
+            let new_blob_event = NewBlobSidecar { tx_hash: *tx_hash, sidecar: sidecar.clone() };
+            match listener.sender.try_send(new_blob_event) {
+                Ok(()) => true,
+                Err(err) => {
+                    if matches!(err, mpsc::error::TrySendError::Full(_)) {
+                        debug!(
+                            target: "txpool",
+                            "[{:?}] failed to send blob sidecar; channel full",
+                            sidecar,
+                        );
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        })
+    }
+
+    /// Notifies transaction listeners about changes once a block was processed.
+    fn notify_on_new_state(&self, outcome: OnNewCanonicalStateOutcome<T::Transaction>) {
+        trace!(target: "txpool", promoted=outcome.promoted.len(), discarded= outcome.discarded.len() ,"notifying listeners on state change");
+
+        // notify about promoted pending transactions - emit hashes
+        let mut needs_pending_cleanup = false;
+        {
+            let listeners = self.pending_transaction_listener.read();
+            for listener in listeners.iter() {
+                if !listener.send_all(outcome.pending_transactions(listener.kind)) {
+                    needs_pending_cleanup = true;
+                }
+            }
+        }
+        if needs_pending_cleanup {
+            self.pending_transaction_listener.write().retain(|l| !l.sender.is_closed());
+        }
+
+        // emit full transactions
+        let mut needs_tx_cleanup = false;
+        {
+            let listeners = self.transaction_listener.read();
+            for listener in listeners.iter() {
+                if !listener.send_all(outcome.full_pending_transactions(listener.kind)) {
+                    needs_tx_cleanup = true;
+                }
+            }
+        }
+        if needs_tx_cleanup {
+            self.transaction_listener.write().retain(|l| !l.sender.is_closed());
+        }
+
+        let OnNewCanonicalStateOutcome { mined, promoted, discarded, block_hash } = outcome;
+
+        // broadcast specific transaction events
+        self.with_event_listener(|listener| {
+            for tx in &mined {
+                listener.mined(tx, block_hash);
+            }
+            for tx in &promoted {
+                listener.pending(tx.hash(), None);
+            }
+            for tx in &discarded {
+                listener.discarded(tx.hash());
+            }
+        })
+    }
+
+    /// Notifies all listeners about the transaction movements.
+    ///
+    /// This will emit events according to the provided changes.
+    ///
+    /// CAUTION: This function is only intended to be used manually in order to use this type's
+    /// [`TransactionEvents`] receivers when manually implementing the
+    /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
+    /// [`TransactionPool::transaction_event_listener`](crate::TransactionPool).
+    pub fn notify_on_transaction_updates(
+        &self,
+        promoted: Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+        discarded: Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+    ) {
+        // Notify about promoted pending transactions (similar to notify_on_new_state)
+        if !promoted.is_empty() {
+            let mut needs_pending_cleanup = false;
+            {
+                let listeners = self.pending_transaction_listener.read();
+                for listener in listeners.iter() {
+                    let promoted_hashes = promoted.iter().filter_map(|tx| {
+                        if listener.kind.is_propagate_only() && !tx.propagate {
+                            None
+                        } else {
+                            Some(*tx.hash())
+                        }
+                    });
+                    if !listener.send_all(promoted_hashes) {
+                        needs_pending_cleanup = true;
+                    }
+                }
+            }
+            if needs_pending_cleanup {
+                self.pending_transaction_listener.write().retain(|l| !l.sender.is_closed());
+            }
+
+            // in this case we should also emit promoted transactions in full
+            let mut needs_tx_cleanup = false;
+            {
+                let listeners = self.transaction_listener.read();
+                for listener in listeners.iter() {
+                    let promoted_txs = promoted.iter().filter_map(|tx| {
+                        if listener.kind.is_propagate_only() && !tx.propagate {
+                            None
+                        } else {
+                            Some(NewTransactionEvent::pending(tx.clone()))
+                        }
+                    });
+                    if !listener.send_all(promoted_txs) {
+                        needs_tx_cleanup = true;
+                    }
+                }
+            }
+            if needs_tx_cleanup {
+                self.transaction_listener.write().retain(|l| !l.sender.is_closed());
+            }
+        }
+
+        self.with_event_listener(|listener| {
+            for tx in &promoted {
+                listener.pending(tx.hash(), None);
+            }
+            for tx in &discarded {
+                listener.discarded(tx.hash());
+            }
+        });
+
+        if !discarded.is_empty() {
+            // This deletes outdated blob txs from the blob store, based on the account's nonce.
+            // This is called during txpool maintenance when the pool drifted.
+            self.delete_discarded_blobs(discarded.iter());
+        }
+    }
+
+    /// Fire events for the newly added transaction if there are any.
+    ///
+    /// See also [`Self::add_transaction_event_listener`].
+    ///
+    /// CAUTION: This function is only intended to be used manually in order to use this type's
+    /// [`TransactionEvents`] receivers when manually implementing the
+    /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
+    /// [`TransactionPool::transaction_event_listener`](crate::TransactionPool).
+    pub fn notify_event_listeners(&self, tx: &AddedTransaction<T::Transaction>) {
+        self.with_event_listener(|listener| match tx {
+            AddedTransaction::Pending(tx) => {
+                let AddedPendingTransaction { transaction, promoted, discarded, replaced } = tx;
+
+                listener.pending(transaction.hash(), replaced.clone());
+                for tx in promoted {
+                    listener.pending(tx.hash(), None);
+                }
+                for tx in discarded {
+                    listener.discarded(tx.hash());
+                }
+            }
+            AddedTransaction::Parked { transaction, replaced, queued_reason, .. } => {
+                listener.queued(transaction.hash(), queued_reason.clone());
+                if let Some(replaced) = replaced {
+                    listener.replaced(replaced.clone(), *transaction.hash());
+                }
+            }
+        });
+    }
+
+    /// Returns an iterator that yields transactions that are ready to be included in the block.
+    pub fn best_transactions(&self) -> BestTransactions<T> {
+        self.get_pool_data().best_transactions()
+    }
+
+    /// Returns an iterator that yields transactions that are ready to be included in the block with
+    /// the given base fee and optional blob fee attributes.
+    pub fn best_transactions_with_attributes(
+        &self,
+        best_transactions_attributes: BestTransactionsAttributes,
+    ) -> Box<dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T::Transaction>>>>
+    {
+        self.get_pool_data().best_transactions_with_attributes(best_transactions_attributes)
+    }
+
+    /// Returns only the first `max` transactions in the pending pool.
+    pub fn pending_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().pending_transactions_iter().take(max).collect()
+    }
+
+    /// Returns all transactions from the pending sub-pool
+    pub fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().pending_transactions()
+    }
+
+    /// Returns all transactions from parked pools
+    pub fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().queued_transactions()
+    }
+
+    /// Returns all transactions in the pool
+    pub fn all_transactions(&self) -> AllPoolTransactions<T::Transaction> {
+        let pool = self.get_pool_data();
+        AllPoolTransactions {
+            pending: pool.pending_transactions(),
+            queued: pool.queued_transactions(),
+        }
+    }
+
+    /// Returns _all_ transactions in the pool
+    pub fn all_transaction_hashes(&self) -> Vec<TxHash> {
+        self.get_pool_data().all().transactions_iter().map(|tx| *tx.hash()).collect()
+    }
+
+    /// Removes and returns all matching transactions from the pool.
+    ///
+    /// This behaves as if the transactions got discarded (_not_ mined), effectively introducing a
+    /// nonce gap for the given transactions.
+    pub fn remove_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if hashes.is_empty() {
+            return Vec::new()
+        }
+        let removed = self.pool.write().remove_transactions(hashes);
+
+        self.with_event_listener(|listener| listener.discarded_many(&removed));
+
+        removed
+    }
+
+    /// Removes and returns all matching transactions and their dependent transactions from the
+    /// pool.
+    pub fn remove_transactions_and_descendants(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if hashes.is_empty() {
+            return Vec::new()
+        }
+        let removed = self.pool.write().remove_transactions_and_descendants(hashes);
+
+        self.with_event_listener(|listener| {
+            for tx in &removed {
+                listener.discarded(tx.hash());
+            }
+        });
+
+        removed
+    }
+
+    /// Removes and returns all transactions by the specified sender from the pool.
+    pub fn remove_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
+        let removed = self.pool.write().remove_transactions_by_sender(sender_id);
+
+        self.with_event_listener(|listener| listener.discarded_many(&removed));
+
+        removed
+    }
+
+    /// Prunes and returns all matching transactions from the pool.
+    ///
+    /// This removes the transactions as if they were mined: descendant transactions are **not**
+    /// parked and remain eligible for inclusion.
+    pub fn prune_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if hashes.is_empty() {
+            return Vec::new()
+        }
+
+        self.pool.write().prune_transactions(hashes)
+    }
+
+    /// Removes and returns all transactions that are present in the pool.
+    pub fn retain_unknown<A>(&self, announcement: &mut A)
+    where
+        A: HandleMempoolData,
+    {
+        if announcement.is_empty() {
+            return
+        }
+        let pool = self.get_pool_data();
+        announcement.retain_by_hash(|tx| !pool.contains(tx))
+    }
+
+    /// Returns the transaction by hash.
+    pub fn get(&self, tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().get(tx_hash)
+    }
+
+    /// Returns all transactions of the address
+    pub fn get_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
+        self.get_pool_data().get_transactions_by_sender(sender_id)
+    }
+
+    /// Returns a pending transaction sent by the given sender with the given nonce.
+    pub fn get_pending_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let sender_id = self.sender_id(&sender)?;
+        self.get_pool_data().get_pending_transaction_by_sender_and_nonce(sender_id, nonce)
+    }
+
+    /// Returns all queued transactions of the address by sender
+    pub fn get_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
+        self.get_pool_data().queued_txs_by_sender(sender_id)
+    }
+
+    /// Returns all pending transactions filtered by predicate
+    pub fn pending_transactions_with_predicate(
+        &self,
+        predicate: impl FnMut(&ValidPoolTransaction<T::Transaction>) -> bool,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().pending_transactions_with_predicate(predicate)
+    }
+
+    /// Returns all pending transactions of the address by sender
+    pub fn get_pending_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
+        self.get_pool_data().pending_txs_by_sender(sender_id)
+    }
+
+    /// Returns the highest transaction of the address
+    pub fn get_highest_transaction_by_sender(
+        &self,
+        sender: Address,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let sender_id = self.sender_id(&sender)?;
+        self.get_pool_data().get_highest_transaction_by_sender(sender_id)
+    }
+
+    /// Returns the transaction with the highest nonce that is executable given the on chain nonce.
+    pub fn get_highest_consecutive_transaction_by_sender(
+        &self,
+        sender: Address,
+        on_chain_nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let sender_id = self.sender_id(&sender)?;
+        self.get_pool_data().get_highest_consecutive_transaction_by_sender(
+            sender_id.into_transaction_id(on_chain_nonce),
+        )
+    }
+
+    /// Returns the transaction given a [`TransactionId`]
+    pub fn get_transaction_by_transaction_id(
+        &self,
+        transaction_id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().all().get(transaction_id).map(|tx| tx.transaction.clone())
+    }
+
+    /// Returns all transactions that where submitted with the given [`TransactionOrigin`]
+    pub fn get_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data()
+            .all()
+            .transactions_iter()
+            .filter(|tx| tx.origin == origin)
+            .cloned()
+            .collect()
+    }
+
+    /// Returns all pending transactions filtered by [`TransactionOrigin`]
+    pub fn get_pending_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().pending_transactions_iter().filter(|tx| tx.origin == origin).collect()
+    }
+
+    /// Returns all the transactions belonging to the hashes.
+    ///
+    /// If no transaction exists, it is skipped.
+    pub fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if txs.is_empty() {
+            return Vec::new()
+        }
+        self.get_pool_data().get_all(txs).collect()
+    }
+
+    /// Returns all the transactions belonging to the hashes that are propagatable.
+    ///
+    /// If no transaction exists, it is skipped.
+    fn get_all_propagatable(
+        &self,
+        txs: &[TxHash],
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if txs.is_empty() {
+            return Vec::new()
+        }
+        let pool = self.get_pool_data();
+        txs.iter().filter_map(|tx| pool.get(tx).filter(|tx| tx.propagate)).collect()
+    }
+
+    /// Notify about propagated transactions.
+    pub fn on_propagated(&self, txs: PropagatedTransactions) {
+        if txs.is_empty() {
+            return
+        }
+        self.with_event_listener(|listener| {
+            txs.into_iter().for_each(|(hash, peers)| listener.propagated(&hash, peers));
+        });
+    }
+
+    /// Number of transactions in the entire pool
+    pub fn len(&self) -> usize {
+        self.get_pool_data().len()
+    }
+
+    /// Whether the pool is empty
+    pub fn is_empty(&self) -> bool {
+        self.get_pool_data().is_empty()
+    }
+
+    /// Returns whether or not the pool is over its configured size and transaction count limits.
+    pub fn is_exceeded(&self) -> bool {
+        self.pool.read().is_exceeded()
+    }
+
+    /// Inserts a blob transaction into the blob store
+    fn insert_blob(&self, hash: TxHash, blob: BlobTransactionSidecarVariant) {
+        debug!(target: "txpool", "[{:?}] storing blob sidecar", hash);
+        if let Err(err) = self.blob_store.insert(hash, blob) {
+            warn!(target: "txpool", %err, "[{:?}] failed to insert blob", hash);
+            self.blob_store_metrics.blobstore_failed_inserts.increment(1);
+        }
+        self.update_blob_store_metrics();
+    }
+
+    /// Delete a blob from the blob store
+    pub fn delete_blob(&self, blob: TxHash) {
+        let _ = self.blob_store.delete(blob);
+    }
+
+    /// Delete all blobs from the blob store
+    pub fn delete_blobs(&self, txs: Vec<TxHash>) {
+        let _ = self.blob_store.delete_all(txs);
+    }
+
+    /// Cleans up the blob store
+    pub fn cleanup_blobs(&self) {
+        let stat = self.blob_store.cleanup();
+        self.blob_store_metrics.blobstore_failed_deletes.increment(stat.delete_failed as u64);
+        self.update_blob_store_metrics();
+    }
+
+    fn update_blob_store_metrics(&self) {
+        if let Some(data_size) = self.blob_store.data_size_hint() {
+            self.blob_store_metrics.blobstore_byte_size.set(data_size as f64);
+        }
+        self.blob_store_metrics.blobstore_entries.set(self.blob_store.blobs_len() as f64);
+    }
+
+    /// Deletes all blob transactions that were discarded.
+    fn delete_discarded_blobs<'a>(
+        &'a self,
+        transactions: impl IntoIterator<Item = &'a Arc<ValidPoolTransaction<T::Transaction>>>,
+    ) {
+        let blob_txs = transactions
+            .into_iter()
+            .filter(|tx| tx.transaction.is_eip4844())
+            .map(|tx| *tx.hash())
+            .collect();
+        self.delete_blobs(blob_txs);
+    }
+}
+
+impl<V, T: TransactionOrdering, S> fmt::Debug for PoolInner<V, T, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PoolInner").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+/// Metadata for a transaction that was added to the pool.
+///
+/// This holds all the data needed to complete post-insertion operations (notifications,
+/// blob storage).
+#[derive(Debug)]
+struct AddedTransactionMeta<T: PoolTransaction> {
+    /// The transaction that was added to the pool
+    added: AddedTransaction<T>,
+    /// Optional blob sidecar for EIP-4844 transactions
+    blob_sidecar: Option<BlobTransactionSidecarVariant>,
+}
+
+/// Tracks an added transaction and all graph changes caused by adding it.
+#[derive(Debug, Clone)]
+pub struct AddedPendingTransaction<T: PoolTransaction> {
+    /// Inserted transaction.
+    pub transaction: Arc<ValidPoolTransaction<T>>,
+    /// Replaced transaction.
+    pub replaced: Option<Arc<ValidPoolTransaction<T>>>,
+    /// transactions promoted to the pending queue
+    pub promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+    /// transactions that failed and became discarded
+    pub discarded: Vec<Arc<ValidPoolTransaction<T>>>,
+}
+
+impl<T: PoolTransaction> AddedPendingTransaction<T> {
+    /// Returns all transactions that were promoted to the pending pool and adhere to the given
+    /// [`TransactionListenerKind`].
+    ///
+    /// If the kind is [`TransactionListenerKind::PropagateOnly`], then only transactions that
+    /// are allowed to be propagated are returned.
+    pub(crate) fn pending_transactions(
+        &self,
+        kind: TransactionListenerKind,
+    ) -> impl Iterator<Item = B256> + '_ {
+        let iter = std::iter::once(&self.transaction).chain(self.promoted.iter());
+        PendingTransactionIter { kind, iter }
+    }
+}
+
+pub(crate) struct PendingTransactionIter<Iter> {
+    kind: TransactionListenerKind,
+    iter: Iter,
+}
+
+impl<'a, Iter, T> Iterator for PendingTransactionIter<Iter>
+where
+    Iter: Iterator<Item = &'a Arc<ValidPoolTransaction<T>>>,
+    T: PoolTransaction + 'a,
+{
+    type Item = B256;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next = self.iter.next()?;
+            if self.kind.is_propagate_only() && !next.propagate {
+                continue
+            }
+            return Some(*next.hash())
+        }
+    }
+}
+
+/// An iterator over full pending transactions
+pub(crate) struct FullPendingTransactionIter<Iter> {
+    kind: TransactionListenerKind,
+    iter: Iter,
+}
+
+impl<'a, Iter, T> Iterator for FullPendingTransactionIter<Iter>
+where
+    Iter: Iterator<Item = &'a Arc<ValidPoolTransaction<T>>>,
+    T: PoolTransaction + 'a,
+{
+    type Item = NewTransactionEvent<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next = self.iter.next()?;
+            if self.kind.is_propagate_only() && !next.propagate {
+                continue
+            }
+            return Some(NewTransactionEvent {
+                subpool: SubPool::Pending,
+                transaction: next.clone(),
+            })
+        }
+    }
+}
+
+/// Represents a transaction that was added into the pool and its state
+#[derive(Debug, Clone)]
+pub enum AddedTransaction<T: PoolTransaction> {
+    /// Transaction was successfully added and moved to the pending pool.
+    Pending(AddedPendingTransaction<T>),
+    /// Transaction was successfully added but not yet ready for processing and moved to a
+    /// parked pool instead.
+    Parked {
+        /// Inserted transaction.
+        transaction: Arc<ValidPoolTransaction<T>>,
+        /// Replaced transaction.
+        replaced: Option<Arc<ValidPoolTransaction<T>>>,
+        /// The subpool it was moved to.
+        subpool: SubPool,
+        /// The specific reason why the transaction is queued (if applicable).
+        queued_reason: Option<QueuedReason>,
+    },
+}
+
+impl<T: PoolTransaction> AddedTransaction<T> {
+    /// Returns whether the transaction has been added to the pending pool.
+    pub const fn as_pending(&self) -> Option<&AddedPendingTransaction<T>> {
+        match self {
+            Self::Pending(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the replaced transaction if there was one
+    pub const fn replaced(&self) -> Option<&Arc<ValidPoolTransaction<T>>> {
+        match self {
+            Self::Pending(tx) => tx.replaced.as_ref(),
+            Self::Parked { replaced, .. } => replaced.as_ref(),
+        }
+    }
+
+    /// Returns the discarded transactions if there were any
+    pub(crate) fn discarded_transactions(&self) -> Option<&[Arc<ValidPoolTransaction<T>>]> {
+        match self {
+            Self::Pending(tx) => Some(&tx.discarded),
+            Self::Parked { .. } => None,
+        }
+    }
+
+    /// Returns the hash of the replaced transaction if it is a blob transaction.
+    pub(crate) fn replaced_blob_transaction(&self) -> Option<B256> {
+        self.replaced().filter(|tx| tx.transaction.is_eip4844()).map(|tx| *tx.transaction.hash())
+    }
+
+    /// Returns the hash of the transaction
+    pub fn hash(&self) -> &TxHash {
+        match self {
+            Self::Pending(tx) => tx.transaction.hash(),
+            Self::Parked { transaction, .. } => transaction.hash(),
+        }
+    }
+
+    /// Converts this type into the event type for listeners
+    pub fn into_new_transaction_event(self) -> NewTransactionEvent<T> {
+        match self {
+            Self::Pending(tx) => {
+                NewTransactionEvent { subpool: SubPool::Pending, transaction: tx.transaction }
+            }
+            Self::Parked { transaction, subpool, .. } => {
+                NewTransactionEvent { transaction, subpool }
+            }
+        }
+    }
+
+    /// Returns the subpool this transaction was added to
+    pub(crate) const fn subpool(&self) -> SubPool {
+        match self {
+            Self::Pending(_) => SubPool::Pending,
+            Self::Parked { subpool, .. } => *subpool,
+        }
+    }
+
+    /// Returns the [`TransactionId`] of the added transaction
+    #[cfg(test)]
+    pub(crate) fn id(&self) -> &TransactionId {
+        match self {
+            Self::Pending(added) => added.transaction.id(),
+            Self::Parked { transaction, .. } => transaction.id(),
+        }
+    }
+
+    /// Returns the queued reason if the transaction is parked with a queued reason.
+    pub const fn queued_reason(&self) -> Option<&QueuedReason> {
+        match self {
+            Self::Pending(_) => None,
+            Self::Parked { queued_reason, .. } => queued_reason.as_ref(),
+        }
+    }
+
+    /// Returns the transaction state based on the subpool and queued reason.
+    pub fn transaction_state(&self) -> AddedTransactionState {
+        match self.subpool() {
+            SubPool::Pending => AddedTransactionState::Pending,
+            _ => {
+                // For non-pending transactions, use the queued reason directly from the
+                // AddedTransaction
+                if let Some(reason) = self.queued_reason() {
+                    AddedTransactionState::Queued(reason.clone())
+                } else {
+                    // Fallback - this shouldn't happen with the new implementation
+                    AddedTransactionState::Queued(QueuedReason::NonceGap)
+                }
+            }
+        }
+    }
+}
+
+/// The specific reason why a transaction is queued (not ready for execution)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueuedReason {
+    /// Transaction has a nonce gap - missing prior transactions
+    NonceGap,
+    /// Transaction has parked ancestors - waiting for other transactions to be mined
+    ParkedAncestors,
+    /// Sender has insufficient balance to cover the transaction cost
+    InsufficientBalance,
+    /// Transaction exceeds the block gas limit
+    TooMuchGas,
+    /// Transaction doesn't meet the base fee requirement
+    InsufficientBaseFee,
+    /// Transaction doesn't meet the blob fee requirement (EIP-4844)
+    InsufficientBlobFee,
+}
+
+/// The state of a transaction when is was added to the pool
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddedTransactionState {
+    /// Ready for execution
+    Pending,
+    /// Not ready for execution due to a specific condition
+    Queued(QueuedReason),
+}
+
+impl AddedTransactionState {
+    /// Returns whether the transaction was submitted as queued.
+    pub const fn is_queued(&self) -> bool {
+        matches!(self, Self::Queued(_))
+    }
+
+    /// Returns whether the transaction was submitted as pending.
+    pub const fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    /// Returns the specific queued reason if the transaction is queued.
+    pub const fn queued_reason(&self) -> Option<&QueuedReason> {
+        match self {
+            Self::Queued(reason) => Some(reason),
+            Self::Pending => None,
+        }
+    }
+}
+
+/// The outcome of a successful transaction addition
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddedTransactionOutcome {
+    /// The hash of the transaction
+    pub hash: TxHash,
+    /// The state of the transaction
+    pub state: AddedTransactionState,
+}
+
+impl AddedTransactionOutcome {
+    /// Returns whether the transaction was submitted as queued.
+    pub const fn is_queued(&self) -> bool {
+        self.state.is_queued()
+    }
+
+    /// Returns whether the transaction was submitted as pending.
+    pub const fn is_pending(&self) -> bool {
+        self.state.is_pending()
+    }
+}
+
+/// Contains all state changes after a [`CanonicalStateUpdate`] was processed
+#[derive(Debug)]
+pub(crate) struct OnNewCanonicalStateOutcome<T: PoolTransaction> {
+    /// Hash of the block.
+    pub(crate) block_hash: B256,
+    /// All mined transactions.
+    pub(crate) mined: Vec<TxHash>,
+    /// Transactions promoted to the pending pool.
+    pub(crate) promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+    /// transaction that were discarded during the update
+    pub(crate) discarded: Vec<Arc<ValidPoolTransaction<T>>>,
+}
+
+impl<T: PoolTransaction> OnNewCanonicalStateOutcome<T> {
+    /// Returns all transactions that were promoted to the pending pool and adhere to the given
+    /// [`TransactionListenerKind`].
+    ///
+    /// If the kind is [`TransactionListenerKind::PropagateOnly`], then only transactions that
+    /// are allowed to be propagated are returned.
+    pub(crate) fn pending_transactions(
+        &self,
+        kind: TransactionListenerKind,
+    ) -> impl Iterator<Item = B256> + '_ {
+        let iter = self.promoted.iter();
+        PendingTransactionIter { kind, iter }
+    }
+
+    /// Returns all FULL transactions that were promoted to the pending pool and adhere to the given
+    /// [`TransactionListenerKind`].
+    ///
+    /// If the kind is [`TransactionListenerKind::PropagateOnly`], then only transactions that
+    /// are allowed to be propagated are returned.
+    pub(crate) fn full_pending_transactions(
+        &self,
+        kind: TransactionListenerKind,
+    ) -> impl Iterator<Item = NewTransactionEvent<T>> + '_ {
+        let iter = self.promoted.iter();
+        FullPendingTransactionIter { kind, iter }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        blobstore::{BlobStore, InMemoryBlobStore},
+        identifier::SenderId,
+        test_utils::{MockTransaction, TestPoolBuilder},
+        validate::ValidTransaction,
+        BlockInfo, PoolConfig, SubPoolLimit, TransactionOrigin, TransactionValidationOutcome, U256,
+    };
+    use alloy_eips::{eip4844::BlobTransactionSidecar, eip7594::BlobTransactionSidecarVariant};
+    use alloy_primitives::Address;
+    use std::{fs, path::PathBuf};
+
+    #[test]
+    fn test_discard_blobs_on_blob_tx_eviction() {
+        let blobs = {
+            // Read the contents of the JSON file into a string.
+            let json_content = fs::read_to_string(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_data/blob1.json"),
+            )
+            .expect("Failed to read the blob data file");
+
+            // Parse the JSON contents into a serde_json::Value.
+            let json_value: serde_json::Value =
+                serde_json::from_str(&json_content).expect("Failed to deserialize JSON");
+
+            // Extract blob data from JSON and convert it to Blob.
+            vec![
+                // Extract the "data" field from the JSON and parse it as a string.
+                json_value
+                    .get("data")
+                    .unwrap()
+                    .as_str()
+                    .expect("Data is not a valid string")
+                    .to_string(),
+            ]
+        };
+
+        // Generate a BlobTransactionSidecar from the blobs.
+        let sidecar = BlobTransactionSidecarVariant::Eip4844(
+            BlobTransactionSidecar::try_from_blobs_hex(blobs).unwrap(),
+        );
+
+        // Define the maximum limit for blobs in the sub-pool.
+        let blob_limit = SubPoolLimit::new(1000, usize::MAX);
+
+        // Create a test pool with default configuration and the specified blob limit.
+        let test_pool = &TestPoolBuilder::default()
+            .with_config(PoolConfig { blob_limit, ..Default::default() })
+            .pool;
+
+        // Set the block info for the pool, including a pending blob fee.
+        test_pool
+            .set_block_info(BlockInfo { pending_blob_fee: Some(10_000_000), ..Default::default() });
+
+        // Create an in-memory blob store.
+        let blob_store = InMemoryBlobStore::default();
+
+        // Loop to add transactions to the pool and test blob eviction.
+        for n in 0..blob_limit.max_txs + 10 {
+            // Create a mock transaction with the generated blob sidecar.
+            let mut tx = MockTransaction::eip4844_with_sidecar(sidecar.clone());
+
+            // Set non zero size
+            tx.set_size(1844674407370951);
+
+            // Insert the sidecar into the blob store if the current index is within the blob limit.
+            if n < blob_limit.max_txs {
+                blob_store.insert(*tx.get_hash(), sidecar.clone()).unwrap();
+            }
+
+            // Add the transaction to the pool with external origin and valid outcome.
+            test_pool.add_transactions(
+                TransactionOrigin::External,
+                [TransactionValidationOutcome::Valid {
+                    balance: U256::from(1_000),
+                    state_nonce: 0,
+                    bytecode_hash: None,
+                    transaction: ValidTransaction::ValidWithSidecar {
+                        transaction: tx,
+                        sidecar: sidecar.clone(),
+                    },
+                    propagate: true,
+                    authorities: None,
+                }],
+            );
+        }
+
+        // Assert that the size of the pool's blob component is equal to the maximum blob limit.
+        assert_eq!(test_pool.size().blob, blob_limit.max_txs);
+
+        // Assert that the size of the pool's blob_size component matches the expected value.
+        assert_eq!(test_pool.size().blob_size, 1844674407370951000);
+
+        // Assert that the pool's blob store matches the expected blob store.
+        assert_eq!(*test_pool.blob_store(), blob_store);
+    }
+
+    #[test]
+    fn test_auths_stored_in_identifiers() {
+        // Create a test pool with default configuration.
+        let test_pool = &TestPoolBuilder::default().with_config(Default::default()).pool;
+
+        let auth = Address::new([1; 20]);
+        let tx = MockTransaction::eip7702();
+
+        test_pool.add_transactions(
+            TransactionOrigin::Local,
+            [TransactionValidationOutcome::Valid {
+                balance: U256::from(1_000),
+                state_nonce: 0,
+                bytecode_hash: None,
+                transaction: ValidTransaction::Valid(tx),
+                propagate: true,
+                authorities: Some(vec![auth]),
+            }],
+        );
+
+        let identifiers = test_pool.identifiers.read();
+        assert_eq!(identifiers.sender_id(&auth), Some(SenderId::from(1)));
+    }
+
+    #[test]
+    fn sender_queries_do_not_allocate_ids_for_unknown_addresses() {
+        let test_pool = &TestPoolBuilder::default().with_config(Default::default()).pool;
+        let sender = Address::new([9; 20]);
+
+        assert_eq!(test_pool.sender_id(&sender), None);
+        assert!(test_pool.get_transactions_by_sender(sender).is_empty());
+        assert!(test_pool.get_pending_transaction_by_sender_and_nonce(sender, 0).is_none());
+        assert!(test_pool.get_queued_transactions_by_sender(sender).is_empty());
+        assert!(test_pool.get_pending_transactions_by_sender(sender).is_empty());
+        assert!(test_pool.get_highest_transaction_by_sender(sender).is_none());
+        assert!(test_pool.get_highest_consecutive_transaction_by_sender(sender, 0).is_none());
+        assert!(test_pool.remove_transactions_by_sender(sender).is_empty());
+        assert_eq!(test_pool.sender_id(&sender), None);
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/parked.rs
+++ b/patches/reth-transaction-pool/src/pool/parked.rs
@@ -1,0 +1,1150 @@
+use crate::{
+    identifier::{SenderId, TransactionId},
+    pool::size::SizeTracker,
+    PoolTransaction, SubPoolLimit, ValidPoolTransaction, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+};
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
+use std::{
+    cmp::Ordering,
+    collections::{hash_map::Entry, BTreeMap, BTreeSet},
+    ops::{Bound::Unbounded, Deref},
+    sync::Arc,
+};
+
+/// A pool of transactions that are currently parked and are waiting for external changes (e.g.
+/// basefee, ancestor transactions, balance) that eventually move the transaction into the pending
+/// pool.
+///
+/// Note: This type is generic over [`ParkedPool`] which enforces that the underlying transaction
+/// type is [`ValidPoolTransaction`] wrapped in an [Arc].
+#[derive(Debug, Clone)]
+pub struct ParkedPool<T: ParkedOrd> {
+    /// Keeps track of transactions inserted in the pool.
+    ///
+    /// This way we can determine when transactions were submitted to the pool.
+    submission_id: u64,
+    /// _All_ Transactions that are currently inside the pool grouped by their identifier.
+    by_id: BTreeMap<TransactionId, ParkedPoolTransaction<T>>,
+    /// Keeps track of last submission id for each sender.
+    ///
+    /// This are sorted in reverse order, so the last (highest) submission id is first, and the
+    /// lowest (oldest) is the last.
+    last_sender_submission: BTreeSet<SubmissionSenderId>,
+    /// Keeps track of the number of transactions in the pool by the sender and the last submission
+    /// id.
+    sender_transaction_count: FxHashMap<SenderId, SenderTransactionCount>,
+    /// Keeps track of the size of this pool.
+    ///
+    /// See also [`reth_primitives_traits::InMemorySize::size`].
+    size_of: SizeTracker,
+}
+
+// === impl ParkedPool ===
+
+impl<T: ParkedOrd> ParkedPool<T> {
+    /// Adds a new transactions to the pending queue.
+    pub fn add_transaction(&mut self, tx: Arc<ValidPoolTransaction<T::Transaction>>) {
+        let id = *tx.id();
+        debug_assert!(
+            !self.contains(&id),
+            "transaction already included {:?}",
+            self.get(&id).unwrap().transaction.transaction
+        );
+        let submission_id = self.next_id();
+
+        // keep track of size
+        self.size_of += tx.size();
+
+        // update or create sender entry
+        self.add_sender_count(tx.sender_id(), submission_id);
+        let transaction = ParkedPoolTransaction { submission_id, transaction: tx.into() };
+
+        self.by_id.insert(id, transaction);
+    }
+
+    /// Increments the count of transactions for the given sender and updates the tracked submission
+    /// id.
+    fn add_sender_count(&mut self, sender: SenderId, submission_id: u64) {
+        match self.sender_transaction_count.entry(sender) {
+            Entry::Occupied(mut entry) => {
+                let value = entry.get_mut();
+                // remove the __currently__ tracked submission id
+                self.last_sender_submission
+                    .remove(&SubmissionSenderId::new(sender, value.last_submission_id));
+
+                value.count += 1;
+                value.last_submission_id = submission_id;
+            }
+            Entry::Vacant(entry) => {
+                entry
+                    .insert(SenderTransactionCount { count: 1, last_submission_id: submission_id });
+            }
+        }
+        // insert a new entry
+        self.last_sender_submission.insert(SubmissionSenderId::new(sender, submission_id));
+    }
+
+    /// Decrements the count of transactions for the given sender.
+    ///
+    /// If the count reaches zero, the sender is removed from the map.
+    ///
+    /// Note: this does not update the tracked submission id for the sender, because we're only
+    /// interested in the __last__ submission id when truncating the pool.
+    fn remove_sender_count(&mut self, sender_id: SenderId) {
+        let removed_sender = match self.sender_transaction_count.entry(sender_id) {
+            Entry::Occupied(mut entry) => {
+                let value = entry.get_mut();
+                value.count -= 1;
+                if value.count == 0 {
+                    entry.remove()
+                } else {
+                    return
+                }
+            }
+            Entry::Vacant(_) => {
+                // This should never happen because the bisection between the two maps
+                unreachable!("sender count not found {:?}", sender_id);
+            }
+        };
+
+        // all transactions for this sender have been removed
+        assert!(
+            self.last_sender_submission
+                .remove(&SubmissionSenderId::new(sender_id, removed_sender.last_submission_id)),
+            "last sender transaction not found {sender_id:?}"
+        );
+    }
+
+    /// Returns an iterator over all transactions in the pool
+    pub(crate) fn all(
+        &self,
+    ) -> impl ExactSizeIterator<Item = Arc<ValidPoolTransaction<T::Transaction>>> + '_ {
+        self.by_id.values().map(|tx| tx.transaction.clone().into())
+    }
+
+    /// Removes the transaction from the pool
+    pub(crate) fn remove_transaction(
+        &mut self,
+        id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        // remove from queues
+        let tx = self.by_id.remove(id)?;
+        self.remove_sender_count(tx.transaction.sender_id());
+
+        // keep track of size
+        self.size_of -= tx.transaction.size();
+
+        Some(tx.transaction.into())
+    }
+
+    /// Retrieves transactions by sender, using `SmallVec` to efficiently handle up to
+    /// `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER` transactions.
+    pub(crate) fn get_txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> SmallVec<[TransactionId; TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER]> {
+        self.by_id
+            .range((sender.start_bound(), Unbounded))
+            .take_while(move |(other, _)| sender == other.sender)
+            .map(|(tx_id, _)| *tx_id)
+            .collect()
+    }
+
+    /// Returns all transactions for the given sender, using a `BTree` range query.
+    pub(crate) fn txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.by_id
+            .range((sender.start_bound(), Unbounded))
+            .take_while(move |(other, _)| sender == other.sender)
+            .map(|(_, tx)| Arc::clone(&tx.transaction))
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_senders_by_submission_id(
+        &self,
+    ) -> impl Iterator<Item = SubmissionSenderId> + '_ {
+        self.last_sender_submission.iter().copied()
+    }
+
+    /// Truncates the pool by removing transactions, until the given [`SubPoolLimit`] has been met.
+    ///
+    /// This is done by first ordering senders by the last time they have submitted a transaction
+    ///
+    /// Uses sender ids sorted by each sender's last submission id. Senders with older last
+    /// submission ids are first. Note that _last_ submission ids are the newest submission id for
+    /// that sender, so this sorts senders by the last time they submitted a transaction in
+    /// descending order. Senders that have least recently submitted a transaction are first.
+    ///
+    /// Then, for each sender, all transactions for that sender are removed, until the pool limits
+    /// have been met.
+    ///
+    /// Any removed transactions are returned.
+    pub fn truncate_pool(
+        &mut self,
+        limit: SubPoolLimit,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if !self.exceeds(&limit) {
+            // if we are below the limits, we don't need to drop anything
+            return Vec::new()
+        }
+
+        let mut removed = Vec::with_capacity(limit.tx_excess(self.len()).unwrap_or(1));
+
+        while !self.last_sender_submission.is_empty() && limit.is_exceeded(self.len(), self.size())
+        {
+            // NOTE: This will not panic due to `!last_sender_transaction.is_empty()`
+            let sender_id = self.last_sender_submission.last().unwrap().sender_id;
+
+            // Drop transactions from this sender until the pool is under limits
+            while let Some((tx_id, _)) = self.by_id.range(sender_id.range()).next_back() {
+                let tx_id = *tx_id;
+                if let Some(tx) = self.remove_transaction(&tx_id) {
+                    removed.push(tx);
+                }
+
+                if !self.exceeds(&limit) {
+                    break
+                }
+            }
+        }
+
+        removed
+    }
+
+    const fn next_id(&mut self) -> u64 {
+        let id = self.submission_id;
+        self.submission_id = self.submission_id.wrapping_add(1);
+        id
+    }
+
+    /// The reported size of all transactions in this pool.
+    pub(crate) fn size(&self) -> usize {
+        self.size_of.into()
+    }
+
+    /// Number of transactions in the entire pool
+    pub(crate) fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Returns true if the pool exceeds the given limit
+    #[inline]
+    pub(crate) fn exceeds(&self, limit: &SubPoolLimit) -> bool {
+        limit.is_exceeded(self.len(), self.size())
+    }
+
+    /// Returns whether the pool is empty
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Returns `true` if the transaction with the given id is already included in this pool.
+    pub(crate) fn contains(&self, id: &TransactionId) -> bool {
+        self.by_id.contains_key(id)
+    }
+
+    /// Retrieves a transaction with the given ID from the pool, if it exists.
+    fn get(&self, id: &TransactionId) -> Option<&ParkedPoolTransaction<T>> {
+        self.by_id.get(id)
+    }
+
+    /// Asserts that all subpool invariants
+    #[cfg(any(test, feature = "test-utils"))]
+    pub(crate) fn assert_invariants(&self) {
+        assert_eq!(
+            self.last_sender_submission.len(),
+            self.sender_transaction_count.len(),
+            "last_sender_submission.len() != sender_transaction_count.len()"
+        );
+    }
+}
+
+impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
+    /// Returns all transactions that satisfy the given basefee.
+    ///
+    /// Note: this does _not_ remove the transactions
+    pub(crate) fn satisfy_base_fee_transactions(
+        &self,
+        basefee: u64,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut txs = Vec::new();
+        self.satisfy_base_fee_ids(basefee as u128, |tx| {
+            txs.push(tx.clone());
+        });
+        txs
+    }
+
+    /// Returns all transactions that satisfy the given basefee.
+    fn satisfy_base_fee_ids<F>(&self, basefee: u128, mut tx_handler: F)
+    where
+        F: FnMut(&Arc<ValidPoolTransaction<T>>),
+    {
+        let mut iter = self.by_id.iter().peekable();
+
+        while let Some((id, tx)) = iter.next() {
+            if tx.transaction.max_fee_per_gas() < basefee {
+                // still parked -> skip descendant transactions
+                'this: while let Some((peek, _)) = iter.peek() {
+                    if peek.sender != id.sender {
+                        break 'this
+                    }
+                    iter.next();
+                }
+            } else {
+                tx_handler(&tx.transaction);
+            }
+        }
+    }
+
+    /// Removes all transactions from this subpool that can afford the given basefee,
+    /// invoking the provided handler for each transaction as it is removed.
+    ///
+    /// This method enforces the basefee constraint by identifying transactions that now
+    /// satisfy the basefee requirement (typically after a basefee decrease) and processing
+    /// them via the provided transaction handler closure.
+    ///
+    /// Respects per-sender nonce ordering: if the lowest-nonce transaction for a sender
+    /// still cannot afford the basefee, higher-nonce transactions from that sender are skipped.
+    ///
+    /// Note: the transactions are not returned in a particular order.
+    pub(crate) fn enforce_basefee_with<F>(&mut self, basefee: u64, mut tx_handler: F)
+    where
+        F: FnMut(Arc<ValidPoolTransaction<T>>),
+    {
+        let mut to_remove = Vec::new();
+        self.satisfy_base_fee_ids(basefee as u128, |tx| {
+            to_remove.push(*tx.id());
+        });
+
+        for id in to_remove {
+            if let Some(tx) = self.remove_transaction(&id) {
+                tx_handler(tx);
+            }
+        }
+    }
+
+    /// Removes all transactions and their dependent transaction from the subpool that no longer
+    /// satisfy the given basefee.
+    ///
+    /// Legacy method maintained for compatibility with read-only queries.
+    /// For basefee enforcement, prefer `enforce_basefee_with` for better performance.
+    ///
+    /// Note: the transactions are not returned in a particular order.
+    #[cfg(test)]
+    pub(crate) fn enforce_basefee(&mut self, basefee: u64) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut removed = Vec::new();
+        self.enforce_basefee_with(basefee, |tx| {
+            removed.push(tx);
+        });
+        removed
+    }
+}
+
+impl<T: ParkedOrd> Default for ParkedPool<T> {
+    fn default() -> Self {
+        Self {
+            submission_id: 0,
+            by_id: Default::default(),
+            last_sender_submission: Default::default(),
+            sender_transaction_count: Default::default(),
+            size_of: Default::default(),
+        }
+    }
+}
+
+/// Keeps track of the number of transactions and the latest submission id for each sender.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SenderTransactionCount {
+    count: u64,
+    last_submission_id: u64,
+}
+
+/// Represents a transaction in this pool.
+#[derive(Debug)]
+struct ParkedPoolTransaction<T: ParkedOrd> {
+    /// Identifier that tags when transaction was submitted in the pool.
+    submission_id: u64,
+    /// Actual transaction.
+    transaction: T,
+}
+
+impl<T: ParkedOrd> Clone for ParkedPoolTransaction<T> {
+    fn clone(&self) -> Self {
+        Self { submission_id: self.submission_id, transaction: self.transaction.clone() }
+    }
+}
+
+impl<T: ParkedOrd> Eq for ParkedPoolTransaction<T> {}
+
+impl<T: ParkedOrd> PartialEq<Self> for ParkedPoolTransaction<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<T: ParkedOrd> PartialOrd<Self> for ParkedPoolTransaction<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: ParkedOrd> Ord for ParkedPoolTransaction<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // This compares by the transactions first, and only if two tx are equal this compares
+        // the unique `submission_id`.
+        // "better" transactions are Greater
+        self.transaction
+            .cmp(&other.transaction)
+            .then_with(|| other.submission_id.cmp(&self.submission_id))
+    }
+}
+
+/// Includes a [`SenderId`] and `submission_id`. This is used to sort senders by their last
+/// submission id.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(crate) struct SubmissionSenderId {
+    /// The sender id
+    pub(crate) sender_id: SenderId,
+    /// The submission id
+    pub(crate) submission_id: u64,
+}
+
+impl SubmissionSenderId {
+    /// Creates a new [`SubmissionSenderId`] based on the [`SenderId`] and `submission_id`.
+    const fn new(sender_id: SenderId, submission_id: u64) -> Self {
+        Self { sender_id, submission_id }
+    }
+}
+
+impl Ord for SubmissionSenderId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reverse ordering for `submission_id`
+        other.submission_id.cmp(&self.submission_id)
+    }
+}
+
+impl PartialOrd for SubmissionSenderId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Helper trait used for custom `Ord` wrappers around a transaction.
+///
+/// This is effectively a wrapper for `Arc<ValidPoolTransaction>` with custom `Ord` implementation.
+pub trait ParkedOrd:
+    Ord
+    + Clone
+    + From<Arc<ValidPoolTransaction<Self::Transaction>>>
+    + Into<Arc<ValidPoolTransaction<Self::Transaction>>>
+    + Deref<Target = Arc<ValidPoolTransaction<Self::Transaction>>>
+{
+    /// The wrapper transaction type.
+    type Transaction: PoolTransaction;
+}
+
+/// Helper macro to implement necessary conversions for `ParkedOrd` trait
+macro_rules! impl_ord_wrapper {
+    ($name:ident) => {
+        impl<T: PoolTransaction> Clone for $name<T> {
+            fn clone(&self) -> Self {
+                Self(self.0.clone())
+            }
+        }
+
+        impl<T: PoolTransaction> Eq for $name<T> {}
+
+        impl<T: PoolTransaction> PartialEq<Self> for $name<T> {
+            fn eq(&self, other: &Self) -> bool {
+                self.cmp(other) == Ordering::Equal
+            }
+        }
+
+        impl<T: PoolTransaction> PartialOrd<Self> for $name<T> {
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl<T: PoolTransaction> Deref for $name<T> {
+            type Target = Arc<ValidPoolTransaction<T>>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl<T: PoolTransaction> ParkedOrd for $name<T> {
+            type Transaction = T;
+        }
+
+        impl<T: PoolTransaction> From<Arc<ValidPoolTransaction<T>>> for $name<T> {
+            fn from(value: Arc<ValidPoolTransaction<T>>) -> Self {
+                Self(value)
+            }
+        }
+
+        impl<T: PoolTransaction> From<$name<T>> for Arc<ValidPoolTransaction<T>> {
+            fn from(value: $name<T>) -> Arc<ValidPoolTransaction<T>> {
+                value.0
+            }
+        }
+    };
+}
+
+/// A new type wrapper for [`ValidPoolTransaction`]
+///
+/// This sorts transactions by their base fee.
+///
+/// Caution: This assumes all transaction in the `BaseFee` sub-pool have a fee value.
+#[derive(Debug)]
+pub struct BasefeeOrd<T: PoolTransaction>(Arc<ValidPoolTransaction<T>>);
+
+impl_ord_wrapper!(BasefeeOrd);
+
+impl<T: PoolTransaction> Ord for BasefeeOrd<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.transaction.max_fee_per_gas().cmp(&other.0.transaction.max_fee_per_gas())
+    }
+}
+
+/// A new type wrapper for [`ValidPoolTransaction`]
+///
+/// This sorts transactions by their distance.
+///
+/// `Queued` transactions are transactions that are currently blocked by other parked (basefee,
+/// queued) or missing transactions.
+///
+/// The primary order function always compares the transaction costs first. In case these
+/// are equal, it compares the timestamps when the transactions were created.
+#[derive(Debug)]
+pub struct QueuedOrd<T: PoolTransaction>(Arc<ValidPoolTransaction<T>>);
+
+impl_ord_wrapper!(QueuedOrd);
+
+impl<T: PoolTransaction> Ord for QueuedOrd<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Higher fee is better
+        self.max_fee_per_gas().cmp(&other.max_fee_per_gas()).then_with(||
+            // Lower timestamp is better
+            other.timestamp.cmp(&self.timestamp))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{MockTransaction, MockTransactionFactory, MockTransactionSet};
+    use alloy_consensus::{Transaction, TxType};
+    use alloy_primitives::address;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_enforce_parked_basefee() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        let tx = f.validated_arc(MockTransaction::eip1559().inc_price());
+        pool.add_transaction(tx.clone());
+
+        assert!(pool.contains(tx.id()));
+        assert_eq!(pool.len(), 1);
+
+        let removed = pool.enforce_basefee(u64::MAX);
+        assert!(removed.is_empty());
+
+        let removed = pool.enforce_basefee((tx.max_fee_per_gas() - 1) as u64);
+        assert_eq!(removed.len(), 1);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn test_enforce_parked_basefee_descendant() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        let t = MockTransaction::eip1559().inc_price_by(10);
+        let root_tx = f.validated_arc(t.clone());
+        pool.add_transaction(root_tx.clone());
+
+        let descendant_tx = f.validated_arc(t.inc_nonce().decr_price());
+        pool.add_transaction(descendant_tx.clone());
+
+        assert!(pool.contains(root_tx.id()));
+        assert!(pool.contains(descendant_tx.id()));
+        assert_eq!(pool.len(), 2);
+
+        let removed = pool.enforce_basefee(u64::MAX);
+        assert!(removed.is_empty());
+        assert_eq!(pool.len(), 2);
+        // two dependent tx in the pool with decreasing fee
+
+        // remove root transaction via descendant tx fee
+        let removed = pool.enforce_basefee(descendant_tx.max_fee_per_gas() as u64);
+        assert_eq!(removed.len(), 2);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn test_enforce_parked_basefee_removes_only_eligible_ancestor() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        let t = MockTransaction::eip1559().inc_price_by(10);
+
+        let root_tx = f.validated_arc(t.clone());
+        pool.add_transaction(root_tx.clone());
+
+        let descendant_tx = f.validated_arc(t.inc_nonce().decr_price());
+        pool.add_transaction(descendant_tx.clone());
+
+        let removed = pool.enforce_basefee(root_tx.max_fee_per_gas() as u64);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].id(), root_tx.id());
+        assert_eq!(pool.len(), 1);
+        assert!(!pool.contains(root_tx.id()));
+        assert!(pool.contains(descendant_tx.id()));
+    }
+
+    #[test]
+    fn truncate_parked_by_submission_id() {
+        // this test ensures that we evict from the pending pool by sender
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        let a_sender = address!("0x000000000000000000000000000000000000000a");
+        let b_sender = address!("0x000000000000000000000000000000000000000b");
+        let c_sender = address!("0x000000000000000000000000000000000000000c");
+        let d_sender = address!("0x000000000000000000000000000000000000000d");
+
+        // create a chain of transactions by sender A, B, C
+        let mut tx_set = MockTransactionSet::dependent(a_sender, 0, 4, TxType::Eip1559);
+        let a = tx_set.clone().into_vec();
+
+        let b = MockTransactionSet::dependent(b_sender, 0, 3, TxType::Eip1559).into_vec();
+        tx_set.extend(b.clone());
+
+        // C has the same number of txs as B
+        let c = MockTransactionSet::dependent(c_sender, 0, 3, TxType::Eip1559).into_vec();
+        tx_set.extend(c.clone());
+
+        let d = MockTransactionSet::dependent(d_sender, 0, 1, TxType::Eip1559).into_vec();
+        tx_set.extend(d.clone());
+
+        let all_txs = tx_set.into_vec();
+
+        // just construct a list of all txs to add
+        let expected_parked = vec![c[0].clone(), c[1].clone(), c[2].clone(), d[0].clone()]
+            .into_iter()
+            .map(|tx| (tx.sender(), tx.nonce()))
+            .collect::<HashSet<_>>();
+
+        // we expect the truncate operation to go through the senders with the most txs, removing
+        // txs based on when they were submitted, removing the oldest txs first, until the pool is
+        // not over the limit
+        let expected_removed = vec![
+            a[0].clone(),
+            a[1].clone(),
+            a[2].clone(),
+            a[3].clone(),
+            b[0].clone(),
+            b[1].clone(),
+            b[2].clone(),
+        ]
+        .into_iter()
+        .map(|tx| (tx.sender(), tx.nonce()))
+        .collect::<HashSet<_>>();
+
+        // add all the transactions to the pool
+        for tx in all_txs {
+            pool.add_transaction(f.validated_arc(tx));
+        }
+
+        // we should end up with the most recently submitted transactions
+        let pool_limit = SubPoolLimit { max_txs: 4, max_size: usize::MAX };
+
+        // truncate the pool
+        let removed = pool.truncate_pool(pool_limit);
+        assert_eq!(removed.len(), expected_removed.len());
+
+        // get the inner txs from the removed txs
+        let removed =
+            removed.into_iter().map(|tx| (tx.sender(), tx.nonce())).collect::<HashSet<_>>();
+        assert_eq!(removed, expected_removed);
+
+        // get the parked pool
+        let parked = pool.all().collect::<Vec<_>>();
+        assert_eq!(parked.len(), expected_parked.len());
+
+        // get the inner txs from the parked txs
+        let parked = parked.into_iter().map(|tx| (tx.sender(), tx.nonce())).collect::<HashSet<_>>();
+        assert_eq!(parked, expected_parked);
+    }
+
+    #[test]
+    fn test_truncate_parked_with_large_tx() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        let default_limits = SubPoolLimit::default();
+
+        // create a chain of transactions by sender A
+        // make sure they are all one over half the limit
+        let a_sender = address!("0x000000000000000000000000000000000000000a");
+
+        // 2 txs, that should put the pool over the size limit but not max txs
+        let a_txs = MockTransactionSet::dependent(a_sender, 0, 2, TxType::Eip1559)
+            .into_iter()
+            .map(|mut tx| {
+                tx.set_size(default_limits.max_size / 2 + 1);
+                tx
+            })
+            .collect::<Vec<_>>();
+
+        // add all the transactions to the pool
+        for tx in a_txs {
+            pool.add_transaction(f.validated_arc(tx));
+        }
+
+        // truncate the pool, it should remove at least one transaction
+        let removed = pool.truncate_pool(default_limits);
+        assert_eq!(removed.len(), 1);
+    }
+
+    #[test]
+    fn test_senders_by_submission_id() {
+        // this test ensures that we evict from the pending pool by sender
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        let a_sender = address!("0x000000000000000000000000000000000000000a");
+        let b_sender = address!("0x000000000000000000000000000000000000000b");
+        let c_sender = address!("0x000000000000000000000000000000000000000c");
+        let d_sender = address!("0x000000000000000000000000000000000000000d");
+
+        // create a chain of transactions by sender A, B, C
+        let mut tx_set = MockTransactionSet::dependent(a_sender, 0, 4, TxType::Eip1559);
+        let a = tx_set.clone().into_vec();
+
+        let b = MockTransactionSet::dependent(b_sender, 0, 3, TxType::Eip1559).into_vec();
+        tx_set.extend(b.clone());
+
+        // C has the same number of txs as B
+        let c = MockTransactionSet::dependent(c_sender, 0, 3, TxType::Eip1559).into_vec();
+        tx_set.extend(c.clone());
+
+        let d = MockTransactionSet::dependent(d_sender, 0, 1, TxType::Eip1559).into_vec();
+        tx_set.extend(d.clone());
+
+        let all_txs = tx_set.into_vec();
+
+        // add all the transactions to the pool
+        for tx in all_txs {
+            pool.add_transaction(f.validated_arc(tx));
+        }
+
+        // get senders by submission id - a4, b3, c3, d1, reversed
+        let senders = pool.get_senders_by_submission_id().map(|s| s.sender_id).collect::<Vec<_>>();
+        assert_eq!(senders.len(), 4);
+        let expected_senders = vec![d_sender, c_sender, b_sender, a_sender]
+            .into_iter()
+            .map(|s| f.ids.sender_id(&s).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(senders, expected_senders);
+
+        // manually order the txs
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        let all_txs = vec![d[0].clone(), b[0].clone(), c[0].clone(), a[0].clone()];
+
+        // add all the transactions to the pool
+        for tx in all_txs {
+            pool.add_transaction(f.validated_arc(tx));
+        }
+
+        let senders = pool.get_senders_by_submission_id().map(|s| s.sender_id).collect::<Vec<_>>();
+        assert_eq!(senders.len(), 4);
+        let expected_senders = vec![a_sender, c_sender, b_sender, d_sender]
+            .into_iter()
+            .map(|s| f.ids.sender_id(&s).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(senders, expected_senders);
+    }
+
+    #[test]
+    fn test_add_sender_count_new_sender() {
+        // Initialize a mock transaction factory
+        let mut f = MockTransactionFactory::default();
+        // Create an empty transaction pool
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        // Generate a validated transaction and add it to the pool
+        let tx = f.validated_arc(MockTransaction::eip1559().inc_price());
+        pool.add_transaction(tx);
+
+        // Define a new sender ID and submission ID
+        let sender: SenderId = 11.into();
+        let submission_id = 1;
+
+        // Add the sender count to the pool
+        pool.add_sender_count(sender, submission_id);
+
+        // Assert that the sender transaction count is updated correctly
+        assert_eq!(pool.sender_transaction_count.len(), 2);
+        let sender_info = pool.sender_transaction_count.get(&sender).unwrap();
+        assert_eq!(sender_info.count, 1);
+        assert_eq!(sender_info.last_submission_id, submission_id);
+
+        // Assert that the last sender submission is updated correctly
+        assert_eq!(pool.last_sender_submission.len(), 2);
+        let submission_info = pool.last_sender_submission.iter().next().unwrap();
+        assert_eq!(submission_info.sender_id, sender);
+        assert_eq!(submission_info.submission_id, submission_id);
+    }
+
+    #[test]
+    fn test_add_sender_count_existing_sender() {
+        // Initialize a mock transaction factory
+        let mut f = MockTransactionFactory::default();
+        // Create an empty transaction pool
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        // Generate a validated transaction and add it to the pool
+        let tx = f.validated_arc(MockTransaction::eip1559().inc_price());
+        pool.add_transaction(tx);
+
+        // Define a sender ID and initial submission ID
+        let sender: SenderId = 11.into();
+        let initial_submission_id = 1;
+
+        // Add the sender count to the pool with the initial submission ID
+        pool.add_sender_count(sender, initial_submission_id);
+
+        // Define a new submission ID
+        let new_submission_id = 2;
+        // Add the sender count to the pool with the new submission ID
+        pool.add_sender_count(sender, new_submission_id);
+
+        // Assert that the sender transaction count is updated correctly
+        assert_eq!(pool.sender_transaction_count.len(), 2);
+        let sender_info = pool.sender_transaction_count.get(&sender).unwrap();
+        assert_eq!(sender_info.count, 2);
+        assert_eq!(sender_info.last_submission_id, new_submission_id);
+
+        // Assert that the last sender submission is updated correctly
+        assert_eq!(pool.last_sender_submission.len(), 2);
+        let submission_info = pool.last_sender_submission.iter().next().unwrap();
+        assert_eq!(submission_info.sender_id, sender);
+        assert_eq!(submission_info.submission_id, new_submission_id);
+    }
+
+    #[test]
+    fn test_add_sender_count_multiple_senders() {
+        // Initialize a mock transaction factory
+        let mut f = MockTransactionFactory::default();
+        // Create an empty transaction pool
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        // Generate two validated transactions and add them to the pool
+        let tx1 = f.validated_arc(MockTransaction::eip1559().inc_price());
+        let tx2 = f.validated_arc(MockTransaction::eip1559().inc_price());
+        pool.add_transaction(tx1);
+        pool.add_transaction(tx2);
+
+        // Define two different sender IDs and their corresponding submission IDs
+        let sender1: SenderId = 11.into();
+        let sender2: SenderId = 22.into();
+
+        // Add the sender counts to the pool
+        pool.add_sender_count(sender1, 1);
+        pool.add_sender_count(sender2, 2);
+
+        // Assert that the sender transaction counts are updated correctly
+        assert_eq!(pool.sender_transaction_count.len(), 4);
+
+        let sender1_info = pool.sender_transaction_count.get(&sender1).unwrap();
+        assert_eq!(sender1_info.count, 1);
+        assert_eq!(sender1_info.last_submission_id, 1);
+
+        let sender2_info = pool.sender_transaction_count.get(&sender2).unwrap();
+        assert_eq!(sender2_info.count, 1);
+        assert_eq!(sender2_info.last_submission_id, 2);
+
+        // Assert that the last sender submission is updated correctly
+        assert_eq!(pool.last_sender_submission.len(), 3);
+
+        // Verify that sender 1 is not in the last sender submission
+        let submission_info1 =
+            pool.last_sender_submission.iter().find(|info| info.sender_id == sender1);
+        assert!(submission_info1.is_none());
+
+        // Verify that sender 2 is in the last sender submission
+        let submission_info2 =
+            pool.last_sender_submission.iter().find(|info| info.sender_id == sender2).unwrap();
+        assert_eq!(submission_info2.sender_id, sender2);
+        assert_eq!(submission_info2.submission_id, 2);
+    }
+
+    #[test]
+    fn test_remove_sender_count() {
+        // Initialize a mock transaction factory
+        let mut f = MockTransactionFactory::default();
+        // Create an empty transaction pool
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        // Generate two validated transactions and add them to the pool
+        let tx1 = f.validated_arc(MockTransaction::eip1559().inc_price());
+        let tx2 = f.validated_arc(MockTransaction::eip1559().inc_price());
+        pool.add_transaction(tx1);
+        pool.add_transaction(tx2);
+
+        // Define two different sender IDs and their corresponding submission IDs
+        let sender1: SenderId = 11.into();
+        let sender2: SenderId = 22.into();
+
+        // Add the sender counts to the pool
+        pool.add_sender_count(sender1, 1);
+
+        // We add sender 2 multiple times to test the removal of sender counts
+        pool.add_sender_count(sender2, 2);
+        pool.add_sender_count(sender2, 3);
+
+        // Before removing the sender count we should have 4 sender transaction counts
+        assert_eq!(pool.sender_transaction_count.len(), 4);
+        assert!(pool.sender_transaction_count.contains_key(&sender1));
+
+        // We should have 1 sender transaction count for sender 1 before removing the sender count
+        assert_eq!(pool.sender_transaction_count.get(&sender1).unwrap().count, 1);
+
+        // Remove the sender count for sender 1
+        pool.remove_sender_count(sender1);
+
+        // After removing the sender count we should have 3 sender transaction counts remaining
+        assert_eq!(pool.sender_transaction_count.len(), 3);
+        assert!(!pool.sender_transaction_count.contains_key(&sender1));
+
+        // Check the sender transaction count for sender 2 before removing the sender count
+        assert_eq!(
+            *pool.sender_transaction_count.get(&sender2).unwrap(),
+            SenderTransactionCount { count: 2, last_submission_id: 3 }
+        );
+
+        // Remove the sender count for sender 2
+        pool.remove_sender_count(sender2);
+
+        // After removing the sender count for sender 2, we still have 3 sender transaction counts
+        // remaining.
+        //
+        // This is because we added sender 2 multiple times and we only removed the last submission.
+        assert_eq!(pool.sender_transaction_count.len(), 3);
+        assert!(pool.sender_transaction_count.contains_key(&sender2));
+
+        // Sender transaction count for sender 2 should be updated correctly
+        assert_eq!(
+            *pool.sender_transaction_count.get(&sender2).unwrap(),
+            SenderTransactionCount { count: 1, last_submission_id: 3 }
+        );
+    }
+
+    #[test]
+    fn test_pool_size() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Create a transaction with a specific size and add it to the pool
+        let tx = f.validated_arc(MockTransaction::eip1559().set_size(1024).clone());
+        pool.add_transaction(tx);
+
+        // Assert that the reported size of the pool is correct
+        assert_eq!(pool.size(), 1024);
+    }
+
+    #[test]
+    fn test_pool_len() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Initially, the pool should have zero transactions
+        assert_eq!(pool.len(), 0);
+
+        // Add a transaction to the pool and check the length
+        let tx = f.validated_arc(MockTransaction::eip1559());
+        pool.add_transaction(tx);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn test_pool_contains() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Create a transaction and get its ID
+        let tx = f.validated_arc(MockTransaction::eip1559());
+        let tx_id = *tx.id();
+
+        // Before adding, the transaction should not be in the pool
+        assert!(!pool.contains(&tx_id));
+
+        // After adding, the transaction should be present in the pool
+        pool.add_transaction(tx);
+        assert!(pool.contains(&tx_id));
+    }
+
+    #[test]
+    fn test_get_transaction() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Add a transaction to the pool and get its ID
+        let tx = f.validated_arc(MockTransaction::eip1559());
+        let tx_id = *tx.id();
+        pool.add_transaction(tx.clone());
+
+        // Retrieve the transaction using `get()` and assert it matches the added transaction
+        let retrieved = pool.get(&tx_id).expect("Transaction should exist in the pool");
+        assert_eq!(retrieved.transaction.id(), tx.id());
+    }
+
+    #[test]
+    fn test_all_transactions() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Add two transactions to the pool
+        let tx1 = f.validated_arc(MockTransaction::eip1559());
+        let tx2 = f.validated_arc(MockTransaction::eip1559());
+        pool.add_transaction(tx1.clone());
+        pool.add_transaction(tx2.clone());
+
+        // Collect all transaction IDs from the pool
+        let all_txs: Vec<_> = pool.all().map(|tx| *tx.id()).collect();
+        assert_eq!(all_txs.len(), 2);
+
+        // Check that the IDs of both transactions are present
+        assert!(all_txs.contains(tx1.id()));
+        assert!(all_txs.contains(tx2.id()));
+    }
+
+    #[test]
+    fn test_truncate_pool_edge_case() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Add two transactions to the pool
+        let tx1 = f.validated_arc(MockTransaction::eip1559());
+        let tx2 = f.validated_arc(MockTransaction::eip1559());
+        pool.add_transaction(tx1);
+        pool.add_transaction(tx2);
+
+        // Set a limit that matches the current number of transactions
+        let limit = SubPoolLimit { max_txs: 2, max_size: usize::MAX };
+        let removed = pool.truncate_pool(limit);
+
+        // No transactions should be removed
+        assert!(removed.is_empty());
+
+        // Set a stricter limit that requires truncating one transaction
+        let limit = SubPoolLimit { max_txs: 1, max_size: usize::MAX };
+        let removed = pool.truncate_pool(limit);
+
+        // One transaction should be removed, and the pool should have one left
+        assert_eq!(removed.len(), 1);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn test_satisfy_base_fee_transactions() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Add two transactions with different max fees
+        let tx1 = f.validated_arc(MockTransaction::eip1559().set_max_fee(100).clone());
+        let tx2 = f.validated_arc(MockTransaction::eip1559().set_max_fee(200).clone());
+        pool.add_transaction(tx1);
+        pool.add_transaction(tx2.clone());
+
+        // Check that only the second transaction satisfies the base fee requirement
+        let satisfied = pool.satisfy_base_fee_transactions(150);
+        assert_eq!(satisfied.len(), 1);
+        assert_eq!(satisfied[0].id(), tx2.id())
+    }
+
+    #[test]
+    fn test_remove_transaction() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Add a transaction to the pool and get its ID
+        let tx = f.validated_arc(MockTransaction::eip1559());
+        let tx_id = *tx.id();
+        pool.add_transaction(tx);
+
+        // Ensure the transaction is in the pool before removal
+        assert!(pool.contains(&tx_id));
+
+        // Remove the transaction and check that it is no longer in the pool
+        let removed = pool.remove_transaction(&tx_id);
+        assert!(removed.is_some());
+        assert!(!pool.contains(&tx_id));
+    }
+
+    #[test]
+    fn test_enforce_basefee_with_handler_zero_allocation() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+
+        // Add multiple transactions across different fee ranges
+        let sender_a = address!("0x000000000000000000000000000000000000000a");
+        let sender_b = address!("0x000000000000000000000000000000000000000b");
+
+        // Add transactions where nonce ordering allows proper processing:
+        // Sender A: both transactions can afford basefee (500 >= 400, 600 >= 400)
+        // Sender B: transaction cannot afford basefee (300 < 400)
+        let txs = vec![
+            f.validated_arc(
+                MockTransaction::eip1559()
+                    .set_sender(sender_a)
+                    .set_nonce(0)
+                    .set_max_fee(500)
+                    .clone(),
+            ),
+            f.validated_arc(
+                MockTransaction::eip1559()
+                    .set_sender(sender_a)
+                    .set_nonce(1)
+                    .set_max_fee(600)
+                    .clone(),
+            ),
+            f.validated_arc(
+                MockTransaction::eip1559()
+                    .set_sender(sender_b)
+                    .set_nonce(0)
+                    .set_max_fee(300)
+                    .clone(),
+            ),
+        ];
+
+        let expected_affordable = vec![txs[0].clone(), txs[1].clone()]; // Both sender A txs
+        for tx in txs {
+            pool.add_transaction(tx);
+        }
+
+        // Test the handler approach with zero allocations
+        let mut processed_txs = Vec::new();
+        let mut handler_call_count = 0;
+
+        pool.enforce_basefee_with(400, |tx| {
+            processed_txs.push(tx);
+            handler_call_count += 1;
+        });
+
+        // Verify correct number of transactions processed
+        assert_eq!(handler_call_count, 2);
+        assert_eq!(processed_txs.len(), 2);
+
+        // Verify the correct transactions were processed (those with fee >= 400)
+        let processed_ids: Vec<_> = processed_txs.iter().map(|tx| *tx.id()).collect();
+        for expected_tx in expected_affordable {
+            assert!(processed_ids.contains(expected_tx.id()));
+        }
+
+        // Verify transactions were removed from pool
+        assert_eq!(pool.len(), 1); // Only the 300 fee tx should remain
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/pending.rs
+++ b/patches/reth-transaction-pool/src/pool/pending.rs
@@ -1,0 +1,1134 @@
+//! Pending transactions
+
+use crate::{
+    identifier::{SenderId, TransactionId},
+    pool::{
+        best::{BestTransactions, BestTransactionsWithFees},
+        size::SizeTracker,
+    },
+    Priority, SubPoolLimit, TransactionOrdering, ValidPoolTransaction,
+};
+use imbl::OrdMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::{cmp::Ordering, collections::hash_map::Entry, ops::Bound::Unbounded, sync::Arc};
+use tokio::sync::broadcast;
+
+/// A pool of validated and gapless transactions that are ready to be executed on the current state
+/// and are waiting to be included in a block.
+///
+/// This pool distinguishes between `independent` transactions and pending transactions. A
+/// transaction is `independent`, if it is in the pending pool, and it has the current on chain
+/// nonce of the sender. Meaning `independent` transactions can be executed right away, other
+/// pending transactions depend on at least one `independent` transaction.
+///
+/// Once an `independent` transaction was executed it *unlocks* the next nonce, if this transaction
+/// is also pending, then this will be moved to the `independent` queue.
+#[derive(Debug, Clone)]
+pub struct PendingPool<T: TransactionOrdering> {
+    /// How to order transactions.
+    ordering: T,
+    /// Keeps track of transactions inserted in the pool.
+    ///
+    /// This way we can determine when transactions were submitted to the pool.
+    submission_id: u64,
+    /// _All_ Transactions that are currently inside the pool grouped by their identifier.
+    by_id: OrdMap<TransactionId, PendingTransaction<T>>,
+    /// The highest nonce transactions for each sender - like the `independent` set, but the
+    /// highest instead of lowest nonce.
+    highest_nonces: FxHashMap<SenderId, PendingTransaction<T>>,
+    /// Independent transactions that can be included directly and don't require other
+    /// transactions.
+    independent_transactions: FxHashMap<SenderId, PendingTransaction<T>>,
+    /// Keeps track of the size of this pool.
+    ///
+    /// See also [`reth_primitives_traits::InMemorySize::size`].
+    size_of: SizeTracker,
+    /// Used to broadcast new transactions that have been added to the `PendingPool` to existing
+    /// `static_files` of this pool.
+    new_transaction_notifier: broadcast::Sender<PendingTransaction<T>>,
+}
+
+// === impl PendingPool ===
+
+impl<T: TransactionOrdering> PendingPool<T> {
+    /// Create a new pending pool instance.
+    pub fn new(ordering: T) -> Self {
+        Self::with_buffer(ordering, 200)
+    }
+
+    /// Create a new pool instance with the given buffer capacity.
+    pub fn with_buffer(ordering: T, buffer_capacity: usize) -> Self {
+        let (new_transaction_notifier, _) = broadcast::channel(buffer_capacity);
+        Self {
+            ordering,
+            submission_id: 0,
+            by_id: Default::default(),
+            independent_transactions: Default::default(),
+            highest_nonces: Default::default(),
+            size_of: Default::default(),
+            new_transaction_notifier,
+        }
+    }
+
+    /// Clear all transactions from the pool without resetting other values.
+    /// Used for atomic reordering during basefee update.
+    ///
+    /// # Returns
+    ///
+    /// Returns all transactions by id.
+    fn clear_transactions(&mut self) -> OrdMap<TransactionId, PendingTransaction<T>> {
+        self.independent_transactions.clear();
+        self.highest_nonces.clear();
+        self.size_of.reset();
+        std::mem::take(&mut self.by_id)
+    }
+
+    /// Returns an iterator over all transactions that are _currently_ ready.
+    ///
+    /// 1. The iterator _always_ returns transactions in order: it never returns a transaction with
+    ///    an unsatisfied dependency and only returns them if dependency transaction were yielded
+    ///    previously. In other words: the nonces of transactions with the same sender will _always_
+    ///    increase by exactly 1.
+    ///
+    /// The order of transactions which satisfy (1.) is determined by their computed priority: a
+    /// transaction with a higher priority is returned before a transaction with a lower priority.
+    ///
+    /// If two transactions have the same priority score, then the transactions which spent more
+    /// time in pool (were added earlier) are returned first.
+    ///
+    /// NOTE: while this iterator returns transaction that pool considers valid at this point, they
+    /// could potentially become invalid at point of execution. Therefore, this iterator
+    /// provides a way to mark transactions that the consumer of this iterator considers invalid. In
+    /// which case the transaction's subgraph is also automatically marked invalid, See (1.).
+    /// Invalid transactions are skipped.
+    pub fn best(&self) -> BestTransactions<T> {
+        BestTransactions {
+            all: self.by_id.clone(),
+            independent: self.independent_transactions.values().cloned().collect(),
+            invalid: Default::default(),
+            new_transaction_receiver: Some(self.new_transaction_notifier.subscribe()),
+            last_priority: None,
+            skip_blobs: false,
+        }
+    }
+
+    /// Same as `best` but only returns transactions that satisfy the given basefee and blobfee.
+    pub(crate) fn best_with_basefee_and_blobfee(
+        &self,
+        base_fee: u64,
+        base_fee_per_blob_gas: u64,
+    ) -> BestTransactionsWithFees<T> {
+        BestTransactionsWithFees { best: self.best(), base_fee, base_fee_per_blob_gas }
+    }
+
+    /// Same as `best` but also includes the given unlocked transactions.
+    ///
+    /// This mimics the [`Self::add_transaction`] method, but does not insert the transactions into
+    /// pool but only into the returned iterator.
+    ///
+    /// Note: this does not insert the unlocked transactions into the pool.
+    ///
+    /// # Panics
+    ///
+    /// if the transaction is already included
+    pub(crate) fn best_with_unlocked_and_attributes(
+        &self,
+        unlocked: Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+        base_fee: u64,
+        base_fee_per_blob_gas: u64,
+    ) -> BestTransactionsWithFees<T> {
+        let mut best = self.best();
+        for (submission_id, tx) in (self.submission_id + 1..).zip(unlocked) {
+            debug_assert!(!best.all.contains_key(tx.id()), "transaction already included");
+            let priority = self.ordering.priority(&tx.transaction, base_fee);
+            let tx_id = *tx.id();
+            let transaction = PendingTransaction { submission_id, transaction: tx, priority };
+            if best.ancestor(&tx_id).is_none() {
+                best.independent.insert(transaction.clone());
+            }
+            best.all.insert(tx_id, transaction);
+        }
+
+        BestTransactionsWithFees { best, base_fee, base_fee_per_blob_gas }
+    }
+
+    /// Returns an iterator over all transactions in the pool
+    pub(crate) fn all(
+        &self,
+    ) -> impl ExactSizeIterator<Item = Arc<ValidPoolTransaction<T::Transaction>>> + '_ {
+        self.by_id.values().map(|tx| tx.transaction.clone())
+    }
+
+    /// Updates the pool with the new blob fee. Removes
+    /// from the subpool all transactions and their dependents that no longer satisfy the given
+    /// blob fee (`tx.max_blob_fee < blob_fee`).
+    ///
+    /// Note: the transactions are not returned in a particular order.
+    ///
+    /// # Returns
+    ///
+    /// Removed transactions that no longer satisfy the blob fee.
+    pub(crate) fn update_blob_fee(
+        &mut self,
+        blob_fee: u128,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        // Create a collection for removed transactions.
+        let mut removed = Vec::new();
+
+        // Drain and iterate over all transactions.
+        let mut transactions_iter = self.clear_transactions().into_iter().peekable();
+        while let Some((id, tx)) = transactions_iter.next() {
+            if tx.transaction.is_eip4844() && tx.transaction.max_fee_per_blob_gas() < Some(blob_fee)
+            {
+                // Add this tx to the removed collection since it no longer satisfies the blob fee
+                // condition. Decrease the total pool size.
+                removed.push(Arc::clone(&tx.transaction));
+
+                // Remove all dependent transactions.
+                'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
+                    if next_id.sender != id.sender {
+                        break 'this
+                    }
+                    removed.push(Arc::clone(&next_tx.transaction));
+                    transactions_iter.next();
+                }
+            } else {
+                self.size_of += tx.transaction.size();
+                self.update_independents_and_highest_nonces(&tx);
+                self.by_id.insert(id, tx);
+            }
+        }
+
+        removed
+    }
+
+    /// Updates the pool with the new base fee. Reorders transactions by new priorities. Removes
+    /// from the subpool all transactions and their dependents that no longer satisfy the given
+    /// base fee (`tx.fee < base_fee`).
+    ///
+    /// Note: the transactions are not returned in a particular order.
+    ///
+    /// # Returns
+    ///
+    /// Removed transactions that no longer satisfy the base fee.
+    pub(crate) fn update_base_fee(
+        &mut self,
+        base_fee: u64,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        // Create a collection for removed transactions.
+        let mut removed = Vec::new();
+
+        // Drain and iterate over all transactions.
+        let mut transactions_iter = self.clear_transactions().into_iter().peekable();
+        while let Some((id, mut tx)) = transactions_iter.next() {
+            if tx.transaction.max_fee_per_gas() < base_fee as u128 {
+                // Add this tx to the removed collection since it no longer satisfies the base fee
+                // condition. Decrease the total pool size.
+                removed.push(Arc::clone(&tx.transaction));
+
+                // Remove all dependent transactions.
+                'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
+                    if next_id.sender != id.sender {
+                        break 'this
+                    }
+                    removed.push(Arc::clone(&next_tx.transaction));
+                    transactions_iter.next();
+                }
+            } else {
+                // Re-insert the transaction with new priority.
+                tx.priority = self.ordering.priority(&tx.transaction.transaction, base_fee);
+
+                self.size_of += tx.transaction.size();
+                self.update_independents_and_highest_nonces(&tx);
+                self.by_id.insert(id, tx);
+            }
+        }
+
+        removed
+    }
+
+    /// Updates the independent transaction and highest nonces set, assuming the given transaction
+    /// is being _added_ to the pool.
+    fn update_independents_and_highest_nonces(&mut self, tx: &PendingTransaction<T>) {
+        match self.highest_nonces.entry(tx.transaction.sender_id()) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().transaction.nonce() < tx.transaction.nonce() {
+                    *entry.get_mut() = tx.clone();
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(tx.clone());
+            }
+        }
+        match self.independent_transactions.entry(tx.transaction.sender_id()) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().transaction.nonce() > tx.transaction.nonce() {
+                    *entry.get_mut() = tx.clone();
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(tx.clone());
+            }
+        }
+    }
+
+    /// Adds a new transactions to the pending queue.
+    ///
+    /// # Panics
+    ///
+    /// if the transaction is already included
+    pub fn add_transaction(
+        &mut self,
+        tx: Arc<ValidPoolTransaction<T::Transaction>>,
+        base_fee: u64,
+    ) {
+        debug_assert!(
+            !self.contains(tx.id()),
+            "transaction already included {:?}",
+            self.get(tx.id()).unwrap().transaction
+        );
+
+        // keep track of size
+        self.size_of += tx.size();
+
+        let tx_id = *tx.id();
+
+        let submission_id = self.next_id();
+        let priority = self.ordering.priority(&tx.transaction, base_fee);
+        let tx = PendingTransaction { submission_id, transaction: tx, priority };
+
+        self.update_independents_and_highest_nonces(&tx);
+
+        // send the new transaction to any existing pendingpool static file iterators
+        if self.new_transaction_notifier.receiver_count() > 0 {
+            let _ = self.new_transaction_notifier.send(tx.clone());
+        }
+
+        self.by_id.insert(tx_id, tx);
+    }
+
+    /// Removes the transaction from the pool.
+    ///
+    /// Note: If the transaction has a descendant transaction
+    /// it will advance it to the best queue.
+    pub(crate) fn remove_transaction(
+        &mut self,
+        id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if let Some(lowest) = self.independent_transactions.get(&id.sender) &&
+            lowest.transaction.nonce() == id.nonce
+        {
+            self.independent_transactions.remove(&id.sender);
+            // mark the next as independent if it exists
+            if let Some(unlocked) = self.get(&id.descendant()) {
+                self.independent_transactions.insert(id.sender, unlocked.clone());
+            }
+        }
+
+        let tx = self.by_id.remove(id)?;
+        self.size_of -= tx.transaction.size();
+
+        match self.highest_nonces.entry(id.sender) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().transaction.nonce() == id.nonce {
+                    // we just removed the tx with the highest nonce for this sender, find the
+                    // highest remaining tx from that sender
+                    if let Some((_, new_highest)) = self
+                        .by_id
+                        .range((
+                            id.sender.start_bound(),
+                            std::ops::Bound::Included(TransactionId::new(id.sender, u64::MAX)),
+                        ))
+                        .last()
+                    {
+                        // insert the new highest nonce for this sender
+                        entry.insert(new_highest.clone());
+                    } else {
+                        entry.remove();
+                    }
+                }
+            }
+            Entry::Vacant(_) => {
+                debug_assert!(
+                    false,
+                    "removed transaction without a tracked highest nonce {:?}",
+                    id
+                );
+            }
+        }
+
+        Some(tx.transaction)
+    }
+
+    const fn next_id(&mut self) -> u64 {
+        let id = self.submission_id;
+        self.submission_id = self.submission_id.wrapping_add(1);
+        id
+    }
+
+    /// Traverses the pool, starting at the highest nonce set, removing the transactions which
+    /// would put the pool under the specified limits.
+    ///
+    /// This attempts to remove transactions by roughly the same amount for each sender. This is
+    /// done by removing the highest-nonce transactions for each sender.
+    ///
+    /// If the `remove_locals` flag is unset, transactions will be removed per-sender until a
+    /// local transaction is the highest nonce transaction for that sender. If all senders have a
+    /// local highest-nonce transaction, the pool will not be truncated further.
+    ///
+    /// Otherwise, if the `remove_locals` flag is set, transactions will be removed per-sender
+    /// until the pool is under the given limits.
+    ///
+    /// Any removed transactions will be added to the `end_removed` vector.
+    pub fn remove_to_limit(
+        &mut self,
+        limit: &SubPoolLimit,
+        remove_locals: bool,
+        end_removed: &mut Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+    ) {
+        // This serves as a termination condition for the loop - it represents the number of
+        // _valid_ unique senders that might have descendants in the pool.
+        //
+        // If `remove_locals` is false, a value of zero means that there are no non-local txs in the
+        // pool that can be removed.
+        //
+        // If `remove_locals` is true, a value of zero means that there are no txs in the pool that
+        // can be removed.
+        let mut non_local_senders = self.highest_nonces.len();
+
+        // keeps track of unique senders from previous iterations, to understand how many unique
+        // senders were removed in the last iteration
+        let mut unique_senders = self.highest_nonces.len();
+
+        // keeps track of which senders we've marked as local
+        let mut local_senders = FxHashSet::default();
+
+        // keep track of transactions to remove and how many have been removed so far
+        let original_length = self.len();
+        let mut removed = Vec::new();
+        let mut total_removed = 0;
+
+        // track total `size` of transactions to remove
+        let original_size = self.size();
+        let mut total_size = 0;
+
+        loop {
+            // check how many unique senders were removed last iteration
+            let unique_removed = unique_senders - self.highest_nonces.len();
+
+            // the new number of unique senders
+            unique_senders = self.highest_nonces.len();
+            non_local_senders -= unique_removed;
+
+            // we can reuse the temp array
+            removed.clear();
+
+            // we prefer removing transactions with lower ordering
+            let mut worst_transactions = self.highest_nonces.values().collect::<Vec<_>>();
+            worst_transactions.sort_unstable();
+
+            // loop through the highest nonces set, removing transactions until we reach the limit
+            for tx in worst_transactions {
+                // return early if the pool is under limits
+                if !limit.is_exceeded(original_length - total_removed, original_size - total_size) ||
+                    non_local_senders == 0
+                {
+                    // need to remove remaining transactions before exiting
+                    for id in &removed {
+                        if let Some(tx) = self.remove_transaction(id) {
+                            end_removed.push(tx);
+                        }
+                    }
+
+                    return
+                }
+
+                if !remove_locals && tx.transaction.is_local() {
+                    let sender_id = tx.transaction.sender_id();
+                    if local_senders.insert(sender_id) {
+                        non_local_senders -= 1;
+                    }
+                    continue
+                }
+
+                total_size += tx.transaction.size();
+                total_removed += 1;
+                removed.push(*tx.transaction.id());
+            }
+
+            // remove the transactions from this iteration
+            for id in &removed {
+                if let Some(tx) = self.remove_transaction(id) {
+                    end_removed.push(tx);
+                }
+            }
+
+            // return if either the pool is under limits or there are no more _eligible_
+            // transactions to remove
+            if !self.exceeds(limit) || non_local_senders == 0 {
+                return
+            }
+        }
+    }
+
+    /// Truncates the pool to the given [`SubPoolLimit`], removing transactions until the subpool
+    /// limits are met.
+    ///
+    /// This attempts to remove transactions by roughly the same amount for each sender. For more
+    /// information on this exact process see docs for
+    /// [`remove_to_limit`](PendingPool::remove_to_limit).
+    ///
+    /// This first truncates all of the non-local transactions in the pool. If the subpool is still
+    /// not under the limit, this truncates the entire pool, including non-local transactions. The
+    /// removed transactions are returned.
+    pub fn truncate_pool(
+        &mut self,
+        limit: SubPoolLimit,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut removed = Vec::new();
+        // return early if the pool is already under the limits
+        if !self.exceeds(&limit) {
+            return removed
+        }
+
+        // first truncate only non-local transactions, returning if the pool end up under the limit
+        self.remove_to_limit(&limit, false, &mut removed);
+        if !self.exceeds(&limit) {
+            return removed
+        }
+
+        // now repeat for local transactions, since local transactions must be removed now for the
+        // pool to be under the limit
+        self.remove_to_limit(&limit, true, &mut removed);
+
+        removed
+    }
+
+    /// Returns true if the pool exceeds the given limit
+    #[inline]
+    pub(crate) fn exceeds(&self, limit: &SubPoolLimit) -> bool {
+        limit.is_exceeded(self.len(), self.size())
+    }
+
+    /// The reported size of all transactions in this pool.
+    pub(crate) fn size(&self) -> usize {
+        self.size_of.into()
+    }
+
+    /// Number of transactions in the entire pool
+    pub(crate) fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// All transactions grouped by id
+    pub const fn by_id(&self) -> &OrdMap<TransactionId, PendingTransaction<T>> {
+        &self.by_id
+    }
+
+    /// Independent transactions
+    pub const fn independent_transactions(&self) -> &FxHashMap<SenderId, PendingTransaction<T>> {
+        &self.independent_transactions
+    }
+
+    /// Subscribes to new transactions
+    pub fn new_transaction_receiver(&self) -> broadcast::Receiver<PendingTransaction<T>> {
+        self.new_transaction_notifier.subscribe()
+    }
+
+    /// Whether the pool is empty
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Returns `true` if the transaction with the given id is already included in this pool.
+    pub(crate) fn contains(&self, id: &TransactionId) -> bool {
+        self.by_id.contains_key(id)
+    }
+
+    /// Get transactions by sender
+    pub(crate) fn get_txs_by_sender(&self, sender: SenderId) -> Vec<TransactionId> {
+        self.iter_txs_by_sender(sender).copied().collect()
+    }
+
+    /// Returns an iterator over all transaction with the sender id
+    pub(crate) fn iter_txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> impl Iterator<Item = &TransactionId> + '_ {
+        self.by_id
+            .range((sender.start_bound(), Unbounded))
+            .take_while(move |(other, _)| sender == other.sender)
+            .map(|(tx_id, _)| tx_id)
+    }
+
+    /// Returns all transactions for the given sender, using a `BTree` range query.
+    pub(crate) fn txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.by_id
+            .range((sender.start_bound(), Unbounded))
+            .take_while(move |(other, _)| sender == other.sender)
+            .map(|(_, tx)| tx.transaction.clone())
+            .collect()
+    }
+
+    /// Retrieves a transaction with the given ID from the pool, if it exists.
+    fn get(&self, id: &TransactionId) -> Option<&PendingTransaction<T>> {
+        self.by_id.get(id)
+    }
+
+    /// Returns a reference to the independent transactions in the pool
+    #[cfg(test)]
+    pub(crate) const fn independent(&self) -> &FxHashMap<SenderId, PendingTransaction<T>> {
+        &self.independent_transactions
+    }
+
+    /// Asserts that the bijection between `by_id` and `all` is valid.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub(crate) fn assert_invariants(&self) {
+        assert!(
+            self.independent_transactions.len() <= self.by_id.len(),
+            "independent_transactions.len() > by_id.len()"
+        );
+        assert!(
+            self.highest_nonces.len() <= self.by_id.len(),
+            "highest_nonces.len() > by_id.len()"
+        );
+        assert_eq!(
+            self.highest_nonces.len(),
+            self.independent_transactions.len(),
+            "highest_nonces.len() != independent_transactions.len()"
+        );
+    }
+}
+
+/// A transaction that is ready to be included in a block.
+#[derive(Debug)]
+pub struct PendingTransaction<T: TransactionOrdering> {
+    /// Identifier that tags when transaction was submitted in the pool.
+    pub submission_id: u64,
+    /// Actual transaction.
+    pub transaction: Arc<ValidPoolTransaction<T::Transaction>>,
+    /// The priority value assigned by the used `Ordering` function.
+    pub priority: Priority<T::PriorityValue>,
+}
+
+impl<T: TransactionOrdering> PendingTransaction<T> {
+    /// The next transaction of the sender: `nonce + 1`
+    pub fn unlocks(&self) -> TransactionId {
+        self.transaction.transaction_id.descendant()
+    }
+}
+
+impl<T: TransactionOrdering> Clone for PendingTransaction<T> {
+    fn clone(&self) -> Self {
+        Self {
+            submission_id: self.submission_id,
+            transaction: Arc::clone(&self.transaction),
+            priority: self.priority.clone(),
+        }
+    }
+}
+
+impl<T: TransactionOrdering> Eq for PendingTransaction<T> {}
+
+impl<T: TransactionOrdering> PartialEq<Self> for PendingTransaction<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<T: TransactionOrdering> PartialOrd<Self> for PendingTransaction<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: TransactionOrdering> Ord for PendingTransaction<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // This compares by `priority` and only if two tx have the exact same priority this compares
+        // the unique `submission_id`. This ensures that transactions with same priority are not
+        // equal, so they're not replaced in the set
+        self.priority
+            .cmp(&other.priority)
+            .then_with(|| other.submission_id.cmp(&self.submission_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_utils::{MockOrdering, MockTransaction, MockTransactionFactory, MockTransactionSet},
+        PoolTransaction,
+    };
+    use alloy_consensus::{Transaction, TxType};
+    use alloy_primitives::address;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_enforce_basefee() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let tx = f.validated_arc(MockTransaction::eip1559().inc_price());
+        pool.add_transaction(tx.clone(), 0);
+
+        assert!(pool.contains(tx.id()));
+        assert_eq!(pool.len(), 1);
+
+        let removed = pool.update_base_fee(0);
+        assert!(removed.is_empty());
+
+        let removed = pool.update_base_fee((tx.max_fee_per_gas() + 1) as u64);
+        assert_eq!(removed.len(), 1);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn test_enforce_basefee_descendant() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let t = MockTransaction::eip1559().inc_price_by(10);
+        let root_tx = f.validated_arc(t.clone());
+        pool.add_transaction(root_tx.clone(), 0);
+
+        let descendant_tx = f.validated_arc(t.inc_nonce().decr_price());
+        pool.add_transaction(descendant_tx.clone(), 0);
+
+        assert!(pool.contains(root_tx.id()));
+        assert!(pool.contains(descendant_tx.id()));
+        assert_eq!(pool.len(), 2);
+
+        assert_eq!(pool.independent_transactions.len(), 1);
+        assert_eq!(pool.highest_nonces.len(), 1);
+
+        let removed = pool.update_base_fee(0);
+        assert!(removed.is_empty());
+
+        // two dependent tx in the pool with decreasing fee
+
+        {
+            let mut pool2 = pool.clone();
+            let removed = pool2.update_base_fee((descendant_tx.max_fee_per_gas() + 1) as u64);
+            assert_eq!(removed.len(), 1);
+            assert_eq!(pool2.len(), 1);
+            // descendant got popped
+            assert!(pool2.contains(root_tx.id()));
+            assert!(!pool2.contains(descendant_tx.id()));
+        }
+
+        // remove root transaction via fee
+        let removed = pool.update_base_fee((root_tx.max_fee_per_gas() + 1) as u64);
+        assert_eq!(removed.len(), 2);
+        assert!(pool.is_empty());
+        pool.assert_invariants();
+    }
+
+    #[test]
+    fn evict_worst() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        let t = MockTransaction::eip1559();
+        pool.add_transaction(f.validated_arc(t.clone()), 0);
+
+        let t2 = MockTransaction::eip1559().inc_price_by(10);
+        pool.add_transaction(f.validated_arc(t2), 0);
+
+        // First transaction should be evicted.
+        assert_eq!(
+            pool.highest_nonces.values().min().map(|tx| *tx.transaction.hash()),
+            Some(*t.hash())
+        );
+
+        // truncate pool with max size = 1, ensure it's the same transaction
+        let removed = pool.truncate_pool(SubPoolLimit { max_txs: 1, max_size: usize::MAX });
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].hash(), t.hash());
+    }
+
+    #[test]
+    fn correct_independent_descendants() {
+        // this test ensures that we set the right highest nonces set for each sender
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        let a_sender = address!("0x000000000000000000000000000000000000000a");
+        let b_sender = address!("0x000000000000000000000000000000000000000b");
+        let c_sender = address!("0x000000000000000000000000000000000000000c");
+        let d_sender = address!("0x000000000000000000000000000000000000000d");
+
+        // create a chain of transactions by sender A, B, C
+        let mut tx_set = MockTransactionSet::dependent(a_sender, 0, 4, TxType::Eip1559);
+        let a = tx_set.clone().into_vec();
+
+        let b = MockTransactionSet::dependent(b_sender, 0, 3, TxType::Eip1559).into_vec();
+        tx_set.extend(b.clone());
+
+        // C has the same number of txs as B
+        let c = MockTransactionSet::dependent(c_sender, 0, 3, TxType::Eip1559).into_vec();
+        tx_set.extend(c.clone());
+
+        let d = MockTransactionSet::dependent(d_sender, 0, 1, TxType::Eip1559).into_vec();
+        tx_set.extend(d.clone());
+
+        // add all the transactions to the pool
+        let all_txs = tx_set.into_vec();
+        for tx in all_txs {
+            pool.add_transaction(f.validated_arc(tx), 0);
+        }
+
+        pool.assert_invariants();
+
+        // the independent set is the roots of each of these tx chains, these are the highest
+        // nonces for each sender
+        let expected_highest_nonces = [d[0].clone(), c[2].clone(), b[2].clone(), a[3].clone()]
+            .iter()
+            .map(|tx| (tx.sender(), tx.nonce()))
+            .collect::<HashSet<_>>();
+        let actual_highest_nonces = pool
+            .highest_nonces
+            .values()
+            .map(|tx| (tx.transaction.sender(), tx.transaction.nonce()))
+            .collect::<HashSet<_>>();
+        assert_eq!(expected_highest_nonces, actual_highest_nonces);
+        pool.assert_invariants();
+    }
+
+    #[test]
+    fn truncate_by_sender() {
+        // This test ensures that transactions are removed from the pending pool by sender.
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        // Addresses for simulated senders A, B, C, and D.
+        let a = address!("0x000000000000000000000000000000000000000a");
+        let b = address!("0x000000000000000000000000000000000000000b");
+        let c = address!("0x000000000000000000000000000000000000000c");
+        let d = address!("0x000000000000000000000000000000000000000d");
+
+        // Create transaction chains for senders A, B, C, and D.
+        let a_txs = MockTransactionSet::sequential_transactions_by_sender(a, 4, TxType::Eip1559);
+        let b_txs = MockTransactionSet::sequential_transactions_by_sender(b, 3, TxType::Eip1559);
+        let c_txs = MockTransactionSet::sequential_transactions_by_sender(c, 3, TxType::Eip1559);
+        let d_txs = MockTransactionSet::sequential_transactions_by_sender(d, 1, TxType::Eip1559);
+
+        // Set up expected pending transactions.
+        let expected_pending = vec![
+            a_txs.transactions[0].clone(),
+            b_txs.transactions[0].clone(),
+            c_txs.transactions[0].clone(),
+            a_txs.transactions[1].clone(),
+        ]
+        .into_iter()
+        .map(|tx| (tx.sender(), tx.nonce()))
+        .collect::<HashSet<_>>();
+
+        // Set up expected removed transactions.
+        let expected_removed = vec![
+            d_txs.transactions[0].clone(),
+            c_txs.transactions[2].clone(),
+            b_txs.transactions[2].clone(),
+            a_txs.transactions[3].clone(),
+            c_txs.transactions[1].clone(),
+            b_txs.transactions[1].clone(),
+            a_txs.transactions[2].clone(),
+        ]
+        .into_iter()
+        .map(|tx| (tx.sender(), tx.nonce()))
+        .collect::<HashSet<_>>();
+
+        // Consolidate all transactions into a single vector.
+        let all_txs =
+            [a_txs.into_vec(), b_txs.into_vec(), c_txs.into_vec(), d_txs.into_vec()].concat();
+
+        // Add all the transactions to the pool.
+        for tx in all_txs {
+            pool.add_transaction(f.validated_arc(tx), 0);
+        }
+
+        // Sanity check, ensuring everything is consistent.
+        pool.assert_invariants();
+
+        // Define the maximum total transactions to be 4, removing transactions for each sender.
+        // Expected order of removal:
+        // * d1, c3, b3, a4
+        // * c2, b2, a3
+        //
+        // Remaining transactions:
+        // * a1, a2
+        // * b1
+        // * c1
+        let pool_limit = SubPoolLimit { max_txs: 4, max_size: usize::MAX };
+
+        // Truncate the pool based on the defined limit.
+        let removed = pool.truncate_pool(pool_limit);
+        pool.assert_invariants();
+        assert_eq!(removed.len(), expected_removed.len());
+
+        // Get the set of removed transactions and compare with the expected set.
+        let removed =
+            removed.into_iter().map(|tx| (tx.sender(), tx.nonce())).collect::<HashSet<_>>();
+        assert_eq!(removed, expected_removed);
+
+        // Retrieve the current pending transactions after truncation.
+        let pending = pool.all().collect::<Vec<_>>();
+        assert_eq!(pending.len(), expected_pending.len());
+
+        // Get the set of pending transactions and compare with the expected set.
+        let pending =
+            pending.into_iter().map(|tx| (tx.sender(), tx.nonce())).collect::<HashSet<_>>();
+        assert_eq!(pending, expected_pending);
+    }
+
+    // <https://github.com/paradigmxyz/reth/issues/12340>
+    #[test]
+    fn test_eligible_updates_promoted() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        let num_senders = 10;
+
+        let first_txs: Vec<_> = (0..num_senders) //
+            .map(|_| MockTransaction::eip1559())
+            .collect();
+        let second_txs: Vec<_> =
+            first_txs.iter().map(|tx| tx.clone().rng_hash().inc_nonce()).collect();
+
+        for tx in first_txs {
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        let mut best = pool.best();
+
+        for _ in 0..num_senders {
+            if let Some(tx) = best.next() {
+                assert_eq!(tx.nonce(), 0);
+            } else {
+                panic!("cannot read one of first_txs");
+            }
+        }
+
+        for tx in second_txs {
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        for _ in 0..num_senders {
+            if let Some(tx) = best.next() {
+                assert_eq!(tx.nonce(), 1);
+            } else {
+                panic!("cannot read one of second_txs");
+            }
+        }
+    }
+
+    #[test]
+    fn test_empty_pool_behavior() {
+        let mut pool = PendingPool::<MockOrdering>::new(MockOrdering::default());
+
+        // Ensure the pool is empty
+        assert!(pool.is_empty());
+        assert_eq!(pool.len(), 0);
+        assert_eq!(pool.size(), 0);
+
+        // Verify that attempting to truncate an empty pool does not panic and returns an empty vec
+        let removed = pool.truncate_pool(SubPoolLimit { max_txs: 10, max_size: 1000 });
+        assert!(removed.is_empty());
+
+        // Verify that retrieving transactions from an empty pool yields nothing
+        assert!(pool.all().next().is_none());
+    }
+
+    #[test]
+    fn test_add_remove_transaction() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        // Add a transaction and check if it's in the pool
+        let tx = f.validated_arc(MockTransaction::eip1559());
+        pool.add_transaction(tx.clone(), 0);
+        assert!(pool.contains(tx.id()));
+        assert_eq!(pool.len(), 1);
+
+        // Remove the transaction and ensure it's no longer in the pool
+        let removed_tx = pool.remove_transaction(tx.id()).unwrap();
+        assert_eq!(removed_tx.id(), tx.id());
+        assert!(!pool.contains(tx.id()));
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn test_reorder_on_basefee_update() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        // Add two transactions with different fees
+        let tx1 = f.validated_arc(MockTransaction::eip1559().inc_price());
+        let tx2 = f.validated_arc(MockTransaction::eip1559().inc_price_by(20));
+        pool.add_transaction(tx1.clone(), 0);
+        pool.add_transaction(tx2.clone(), 0);
+
+        // Ensure the transactions are in the correct order
+        let mut best = pool.best();
+        assert_eq!(best.next().unwrap().hash(), tx2.hash());
+        assert_eq!(best.next().unwrap().hash(), tx1.hash());
+
+        // Update the base fee to a value higher than tx1's fee, causing it to be removed
+        let removed = pool.update_base_fee((tx1.max_fee_per_gas() + 1) as u64);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].hash(), tx1.hash());
+
+        // Verify that only tx2 remains in the pool
+        assert_eq!(pool.len(), 1);
+        assert!(pool.contains(tx2.id()));
+        assert!(!pool.contains(tx1.id()));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "transaction already included")]
+    fn test_handle_duplicates() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        // Add the same transaction twice and ensure it only appears once
+        let tx = f.validated_arc(MockTransaction::eip1559());
+        pool.add_transaction(tx.clone(), 0);
+        assert!(pool.contains(tx.id()));
+        assert_eq!(pool.len(), 1);
+
+        // Attempt to add the same transaction again, which should be ignored
+        pool.add_transaction(tx, 0);
+    }
+
+    #[test]
+    fn test_update_blob_fee() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        // Add transactions with varying blob fees
+        let tx1 = f.validated_arc(MockTransaction::eip4844().set_blob_fee(50).clone());
+        let tx2 = f.validated_arc(MockTransaction::eip4844().set_blob_fee(150).clone());
+        pool.add_transaction(tx1.clone(), 0);
+        pool.add_transaction(tx2.clone(), 0);
+
+        // Update the blob fee to a value that causes tx1 to be removed
+        let removed = pool.update_blob_fee(100);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].hash(), tx1.hash());
+
+        // Verify that only tx2 remains in the pool
+        assert!(pool.contains(tx2.id()));
+        assert!(!pool.contains(tx1.id()));
+    }
+
+    #[test]
+    fn local_senders_tracking() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        // Addresses for simulated senders A, B, C
+        let a = address!("0x000000000000000000000000000000000000000a");
+        let b = address!("0x000000000000000000000000000000000000000b");
+        let c = address!("0x000000000000000000000000000000000000000c");
+
+        // sender A (local) - 11+ transactions (large enough to keep limit exceeded)
+        // sender B (external) - 2 transactions
+        // sender C (external) - 2 transactions
+
+        // Create transaction chains for senders A, B, C
+        let a_txs = MockTransactionSet::sequential_transactions_by_sender(a, 11, TxType::Eip1559);
+        let b_txs = MockTransactionSet::sequential_transactions_by_sender(b, 2, TxType::Eip1559);
+        let c_txs = MockTransactionSet::sequential_transactions_by_sender(c, 2, TxType::Eip1559);
+
+        // create local txs for sender A
+        for tx in a_txs.into_vec() {
+            let final_tx = Arc::new(f.validated_with_origin(crate::TransactionOrigin::Local, tx));
+
+            pool.add_transaction(final_tx, 0);
+        }
+
+        // create external txs for senders B and C
+        let remaining_txs = [b_txs.into_vec(), c_txs.into_vec()].concat();
+        for tx in remaining_txs {
+            let final_tx = f.validated_arc(tx);
+
+            pool.add_transaction(final_tx, 0);
+        }
+
+        // Sanity check, ensuring everything is consistent.
+        pool.assert_invariants();
+
+        let pool_limit = SubPoolLimit { max_txs: 10, max_size: usize::MAX };
+        pool.truncate_pool(pool_limit);
+
+        let sender_a = f.ids.sender_id(&a).unwrap();
+        let sender_b = f.ids.sender_id(&b).unwrap();
+        let sender_c = f.ids.sender_id(&c).unwrap();
+
+        assert_eq!(pool.get_txs_by_sender(sender_a).len(), 10);
+        assert!(pool.get_txs_by_sender(sender_b).is_empty());
+        assert!(pool.get_txs_by_sender(sender_c).is_empty());
+    }
+
+    #[test]
+    fn test_remove_non_highest_keeps_highest() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let sender = address!("0x00000000000000000000000000000000000000aa");
+        let txs = MockTransactionSet::dependent(sender, 0, 3, TxType::Eip1559).into_vec();
+        for tx in txs {
+            pool.add_transaction(f.validated_arc(tx), 0);
+        }
+        pool.assert_invariants();
+        let sender_id = f.ids.sender_id(&sender).unwrap();
+        let mid_id = TransactionId::new(sender_id, 1);
+        let _ = pool.remove_transaction(&mid_id);
+        let highest = pool.highest_nonces.get(&sender_id).unwrap();
+        assert_eq!(highest.transaction.nonce(), 2);
+        pool.assert_invariants();
+    }
+
+    #[test]
+    fn test_cascade_removal_recomputes_highest() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let sender = address!("0x00000000000000000000000000000000000000bb");
+        let txs = MockTransactionSet::dependent(sender, 0, 4, TxType::Eip1559).into_vec();
+        for tx in txs {
+            pool.add_transaction(f.validated_arc(tx), 0);
+        }
+        pool.assert_invariants();
+        let sender_id = f.ids.sender_id(&sender).unwrap();
+        let id3 = TransactionId::new(sender_id, 3);
+        let _ = pool.remove_transaction(&id3);
+        let highest = pool.highest_nonces.get(&sender_id).unwrap();
+        assert_eq!(highest.transaction.nonce(), 2);
+        let id2 = TransactionId::new(sender_id, 2);
+        let _ = pool.remove_transaction(&id2);
+        let highest = pool.highest_nonces.get(&sender_id).unwrap();
+        assert_eq!(highest.transaction.nonce(), 1);
+        pool.assert_invariants();
+    }
+
+    #[test]
+    fn test_remove_only_tx_clears_highest() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let sender = address!("0x00000000000000000000000000000000000000cc");
+        let txs = MockTransactionSet::dependent(sender, 0, 1, TxType::Eip1559).into_vec();
+        for tx in txs {
+            pool.add_transaction(f.validated_arc(tx), 0);
+        }
+        pool.assert_invariants();
+        let sender_id = f.ids.sender_id(&sender).unwrap();
+        let id0 = TransactionId::new(sender_id, 0);
+        let _ = pool.remove_transaction(&id0);
+        assert!(!pool.highest_nonces.contains_key(&sender_id));
+        pool.assert_invariants();
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/size.rs
+++ b/patches/reth-transaction-pool/src/pool/size.rs
@@ -1,0 +1,36 @@
+//! Tracks a size value.
+
+use std::ops::{AddAssign, SubAssign};
+
+/// Keeps track of accumulated size in bytes.
+///
+/// Note: We do not assume that size tracking is always exact. Depending on the bookkeeping of the
+/// additions and subtractions the total size might be slightly off. Therefore, the underlying value
+/// is an `isize`, so that the value does not wrap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SizeTracker(isize);
+
+impl SizeTracker {
+    /// Reset the size tracker.
+    pub const fn reset(&mut self) {
+        self.0 = 0;
+    }
+}
+
+impl AddAssign<usize> for SizeTracker {
+    fn add_assign(&mut self, rhs: usize) {
+        self.0 += rhs as isize
+    }
+}
+
+impl SubAssign<usize> for SizeTracker {
+    fn sub_assign(&mut self, rhs: usize) {
+        self.0 -= rhs as isize
+    }
+}
+
+impl From<SizeTracker> for usize {
+    fn from(value: SizeTracker) -> Self {
+        value.0 as Self
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/state.rs
+++ b/patches/reth-transaction-pool/src/pool/state.rs
@@ -1,0 +1,409 @@
+use crate::pool::QueuedReason;
+
+bitflags::bitflags! {
+    /// Marker to represents the current state of a transaction in the pool and from which the corresponding sub-pool is derived, depending on what bits are set.
+    ///
+    /// This mirrors [erigon's ephemeral state field](https://github.com/ledgerwatch/erigon/wiki/Transaction-Pool-Design#ordering-function).
+    ///
+    /// The [SubPool] the transaction belongs to is derived from its state and determined by the following sequential checks:
+    ///
+    /// - If it satisfies the [TxState::PENDING_POOL_BITS] it belongs in the pending sub-pool: [SubPool::Pending].
+    /// - If it is an EIP-4844 blob transaction it belongs in the blob sub-pool: [SubPool::Blob].
+    /// - If it satisfies the [TxState::BASE_FEE_POOL_BITS] it belongs in the base fee sub-pool: [SubPool::BaseFee].
+    ///
+    /// Otherwise, it belongs in the queued sub-pool: [SubPool::Queued].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
+    pub(crate) struct TxState: u8 {
+        /// Set to `1` if all ancestor transactions are pending.
+        const NO_PARKED_ANCESTORS = 0b10000000;
+        /// Set to `1` if the transaction is either the next transaction of the sender (on chain nonce == tx.nonce) or all prior transactions are also present in the pool.
+        const NO_NONCE_GAPS = 0b01000000;
+        /// Bit derived from the sender's balance.
+        ///
+        /// Set to `1` if the sender's balance can cover the maximum cost for this transaction (`feeCap * gasLimit + value`).
+        /// This includes cumulative costs of prior transactions, which ensures that the sender has enough funds for all max cost of prior transactions.
+        const ENOUGH_BALANCE = 0b00100000;
+        /// Bit set to true if the transaction has a lower gas limit than the block's gas limit.
+        const NOT_TOO_MUCH_GAS = 0b00010000;
+        /// Covers the Dynamic fee requirement.
+        ///
+        /// Set to 1 if `maxFeePerGas` of the transaction meets the requirement of the pending block.
+        const ENOUGH_FEE_CAP_BLOCK = 0b00001000;
+        /// Covers the dynamic blob fee requirement, only relevant for EIP-4844 blob transactions.
+        ///
+        /// Set to 1 if `maxBlobFeePerGas` of the transaction meets the requirement of the pending block.
+        const ENOUGH_BLOB_FEE_CAP_BLOCK = 0b00000100;
+        /// Marks whether the transaction is a blob transaction.
+        ///
+        /// We track this as part of the state for simplicity, since blob transactions are handled differently and are mutually exclusive with normal transactions.
+        const BLOB_TRANSACTION = 0b00000010;
+
+        const PENDING_POOL_BITS = Self::NO_PARKED_ANCESTORS.bits() | Self::NO_NONCE_GAPS.bits() | Self::ENOUGH_BALANCE.bits() | Self::NOT_TOO_MUCH_GAS.bits() |  Self::ENOUGH_FEE_CAP_BLOCK.bits() | Self::ENOUGH_BLOB_FEE_CAP_BLOCK.bits();
+
+        const BASE_FEE_POOL_BITS = Self::NO_PARKED_ANCESTORS.bits() | Self::NO_NONCE_GAPS.bits() | Self::ENOUGH_BALANCE.bits() | Self::NOT_TOO_MUCH_GAS.bits();
+
+        const QUEUED_POOL_BITS  = Self::NO_PARKED_ANCESTORS.bits();
+
+        const BLOB_POOL_BITS  = Self::BLOB_TRANSACTION.bits();
+    }
+}
+
+impl TxState {
+    /// The state of a transaction is considered `pending`, if the transaction has:
+    ///   - _No_ parked ancestors
+    ///   - enough balance
+    ///   - enough fee cap
+    ///   - enough blob fee cap
+    #[inline]
+    pub(crate) const fn is_pending(&self) -> bool {
+        self.bits() >= Self::PENDING_POOL_BITS.bits()
+    }
+
+    /// Whether this transaction is a blob transaction.
+    #[inline]
+    pub(crate) const fn is_blob(&self) -> bool {
+        self.contains(Self::BLOB_TRANSACTION)
+    }
+
+    /// Returns `true` if the transaction has a nonce gap.
+    #[inline]
+    pub(crate) const fn has_nonce_gap(&self) -> bool {
+        !self.intersects(Self::NO_NONCE_GAPS)
+    }
+
+    /// Adds the transaction into the pool.
+    ///
+    /// This pool consists of four sub-pools: `Queued`, `Pending`, `BaseFee`, and `Blob`.
+    ///
+    /// The `Queued` pool contains transactions with gaps in its dependency tree: It requires
+    /// additional transactions that are note yet present in the pool. And transactions that the
+    /// sender can not afford with the current balance.
+    ///
+    /// The `Pending` pool contains all transactions that have no nonce gaps, and can be afforded by
+    /// the sender. It only contains transactions that are ready to be included in the pending
+    /// block. The pending pool contains all transactions that could be listed currently, but not
+    /// necessarily independently. However, this pool never contains transactions with nonce gaps. A
+    /// transaction is considered `ready` when it has the lowest nonce of all transactions from the
+    /// same sender. Which is equals to the chain nonce of the sender in the pending pool.
+    ///
+    /// The `BaseFee` pool contains transactions that currently can't satisfy the dynamic fee
+    /// requirement. With EIP-1559, transactions can become executable or not without any changes to
+    /// the sender's balance or nonce and instead their `feeCap` determines whether the
+    /// transaction is _currently_ (on the current state) ready or needs to be parked until the
+    /// `feeCap` satisfies the block's `baseFee`.
+    ///
+    /// The `Blob` pool contains _blob_ transactions that currently can't satisfy the dynamic fee
+    /// requirement, or blob fee requirement. Transactions become executable only if the
+    /// transaction `feeCap` is greater than the block's `baseFee` and the `maxBlobFee` is greater
+    /// than the block's `blobFee`.
+    ///
+    /// Determines the specific reason why a transaction is queued based on its subpool and state.
+    pub(crate) const fn determine_queued_reason(&self, subpool: SubPool) -> Option<QueuedReason> {
+        match subpool {
+            SubPool::Pending => None, // Not queued
+            SubPool::Queued => {
+                // Check state flags to determine specific reason
+                if !self.contains(Self::NO_NONCE_GAPS) {
+                    Some(QueuedReason::NonceGap)
+                } else if !self.contains(Self::ENOUGH_BALANCE) {
+                    Some(QueuedReason::InsufficientBalance)
+                } else if !self.contains(Self::NO_PARKED_ANCESTORS) {
+                    Some(QueuedReason::ParkedAncestors)
+                } else if !self.contains(Self::NOT_TOO_MUCH_GAS) {
+                    Some(QueuedReason::TooMuchGas)
+                } else {
+                    // Fallback for unexpected queued state
+                    Some(QueuedReason::NonceGap)
+                }
+            }
+            SubPool::BaseFee => Some(QueuedReason::InsufficientBaseFee),
+            SubPool::Blob => {
+                // For blob transactions, derive the queued reason from flags similarly to Queued.
+                if !self.contains(Self::NO_NONCE_GAPS) {
+                    Some(QueuedReason::NonceGap)
+                } else if !self.contains(Self::ENOUGH_BALANCE) {
+                    Some(QueuedReason::InsufficientBalance)
+                } else if !self.contains(Self::NO_PARKED_ANCESTORS) {
+                    Some(QueuedReason::ParkedAncestors)
+                } else if !self.contains(Self::NOT_TOO_MUCH_GAS) {
+                    Some(QueuedReason::TooMuchGas)
+                } else if !self.contains(Self::ENOUGH_FEE_CAP_BLOCK) {
+                    Some(QueuedReason::InsufficientBaseFee)
+                } else if !self.contains(Self::ENOUGH_BLOB_FEE_CAP_BLOCK) {
+                    Some(QueuedReason::InsufficientBlobFee)
+                } else {
+                    // Fallback for unexpected non-pending blob state
+                    Some(QueuedReason::InsufficientBlobFee)
+                }
+            }
+        }
+    }
+}
+
+/// Identifier for the transaction Sub-pool
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(u8)]
+pub enum SubPool {
+    /// The queued sub-pool contains transactions that are not ready to be included in the next
+    /// block because they have missing or queued ancestors or the sender the lacks funds to
+    /// execute this transaction.
+    Queued = 0,
+    /// The base-fee sub-pool contains transactions that are not ready to be included in the next
+    /// block because they don't meet the base fee requirement.
+    BaseFee,
+    /// The blob sub-pool contains all blob transactions that are __not__ pending.
+    Blob,
+    /// The pending sub-pool contains transactions that are ready to be included in the next block.
+    Pending,
+}
+
+impl SubPool {
+    /// Whether this transaction is to be moved to the pending sub-pool.
+    #[inline]
+    pub const fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    /// Whether this transaction is in the queued pool.
+    #[inline]
+    pub const fn is_queued(&self) -> bool {
+        matches!(self, Self::Queued)
+    }
+
+    /// Whether this transaction is in the base fee pool.
+    #[inline]
+    pub const fn is_base_fee(&self) -> bool {
+        matches!(self, Self::BaseFee)
+    }
+
+    /// Whether this transaction is in the blob pool.
+    #[inline]
+    pub const fn is_blob(&self) -> bool {
+        matches!(self, Self::Blob)
+    }
+
+    /// Returns whether this is a promotion depending on the current sub-pool location.
+    #[inline]
+    pub fn is_promoted(&self, other: Self) -> bool {
+        self > &other
+    }
+}
+
+impl From<TxState> for SubPool {
+    fn from(value: TxState) -> Self {
+        if value.is_pending() {
+            Self::Pending
+        } else if value.is_blob() {
+            // all _non-pending_ blob transactions are in the blob sub-pool
+            Self::Blob
+        } else if value.bits() < TxState::BASE_FEE_POOL_BITS.bits() {
+            Self::Queued
+        } else {
+            Self::BaseFee
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_promoted() {
+        assert!(SubPool::BaseFee.is_promoted(SubPool::Queued));
+        assert!(SubPool::Pending.is_promoted(SubPool::BaseFee));
+        assert!(SubPool::Pending.is_promoted(SubPool::Queued));
+        assert!(SubPool::Pending.is_promoted(SubPool::Blob));
+        assert!(!SubPool::BaseFee.is_promoted(SubPool::Pending));
+        assert!(!SubPool::Queued.is_promoted(SubPool::BaseFee));
+    }
+
+    #[test]
+    fn test_tx_state() {
+        let mut state = TxState::default();
+        state |= TxState::NO_NONCE_GAPS;
+        assert!(state.intersects(TxState::NO_NONCE_GAPS))
+    }
+
+    #[test]
+    fn test_tx_queued() {
+        let state = TxState::default();
+        assert_eq!(SubPool::Queued, state.into());
+
+        let state = TxState::NO_PARKED_ANCESTORS |
+            TxState::NO_NONCE_GAPS |
+            TxState::NOT_TOO_MUCH_GAS |
+            TxState::ENOUGH_FEE_CAP_BLOCK;
+        assert_eq!(SubPool::Queued, state.into());
+    }
+
+    #[test]
+    fn test_tx_pending() {
+        let state = TxState::PENDING_POOL_BITS;
+        assert_eq!(SubPool::Pending, state.into());
+        assert!(state.is_pending());
+
+        let bits = 0b11111100;
+        let state = TxState::from_bits(bits).unwrap();
+        assert_eq!(SubPool::Pending, state.into());
+        assert!(state.is_pending());
+
+        let bits = 0b11111110;
+        let state = TxState::from_bits(bits).unwrap();
+        assert_eq!(SubPool::Pending, state.into());
+        assert!(state.is_pending());
+    }
+
+    #[test]
+    fn test_blob() {
+        let mut state = TxState::PENDING_POOL_BITS;
+        state.insert(TxState::BLOB_TRANSACTION);
+        assert!(state.is_pending());
+
+        state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+        assert!(state.is_blob());
+        assert!(!state.is_pending());
+
+        state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+        state.remove(TxState::ENOUGH_FEE_CAP_BLOCK);
+        assert!(state.is_blob());
+        assert!(!state.is_pending());
+    }
+
+    #[test]
+    fn test_tx_state_no_nonce_gap() {
+        let mut state = TxState::default();
+        state |= TxState::NO_NONCE_GAPS;
+        assert!(!state.has_nonce_gap());
+    }
+
+    #[test]
+    fn test_tx_state_with_nonce_gap() {
+        let state = TxState::default();
+        assert!(state.has_nonce_gap());
+    }
+
+    #[test]
+    fn test_tx_state_enough_balance() {
+        let mut state = TxState::default();
+        state.insert(TxState::ENOUGH_BALANCE);
+        assert!(state.contains(TxState::ENOUGH_BALANCE));
+    }
+
+    #[test]
+    fn test_tx_state_not_too_much_gas() {
+        let mut state = TxState::default();
+        state.insert(TxState::NOT_TOO_MUCH_GAS);
+        assert!(state.contains(TxState::NOT_TOO_MUCH_GAS));
+    }
+
+    #[test]
+    fn test_tx_state_enough_fee_cap_block() {
+        let mut state = TxState::default();
+        state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+        assert!(state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn test_tx_base_fee() {
+        let state = TxState::BASE_FEE_POOL_BITS;
+        assert_eq!(SubPool::BaseFee, state.into());
+    }
+
+    #[test]
+    fn test_blob_transaction_only() {
+        let state = TxState::BLOB_TRANSACTION;
+        assert_eq!(SubPool::Blob, state.into());
+        assert!(state.is_blob());
+        assert!(!state.is_pending());
+    }
+
+    #[test]
+    fn test_blob_transaction_with_base_fee_bits() {
+        let mut state = TxState::BASE_FEE_POOL_BITS;
+        state.insert(TxState::BLOB_TRANSACTION);
+        assert_eq!(SubPool::Blob, state.into());
+        assert!(state.is_blob());
+        assert!(!state.is_pending());
+    }
+
+    #[test]
+    fn test_blob_reason_insufficient_base_fee() {
+        // Blob tx with all structural bits set and blob fee sufficient, but base fee insufficient
+        let state = TxState::NO_PARKED_ANCESTORS |
+            TxState::NO_NONCE_GAPS |
+            TxState::ENOUGH_BALANCE |
+            TxState::NOT_TOO_MUCH_GAS |
+            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
+            TxState::BLOB_TRANSACTION;
+        // ENOUGH_FEE_CAP_BLOCK intentionally not set
+        let subpool: SubPool = state.into();
+        assert_eq!(subpool, SubPool::Blob);
+        let reason = state.determine_queued_reason(subpool);
+        assert_eq!(reason, Some(QueuedReason::InsufficientBaseFee));
+    }
+
+    #[test]
+    fn test_blob_reason_insufficient_blob_fee() {
+        // Blob tx with all structural bits set and base fee sufficient, but blob fee insufficient
+        let state = TxState::NO_PARKED_ANCESTORS |
+            TxState::NO_NONCE_GAPS |
+            TxState::ENOUGH_BALANCE |
+            TxState::NOT_TOO_MUCH_GAS |
+            TxState::ENOUGH_FEE_CAP_BLOCK |
+            TxState::BLOB_TRANSACTION;
+        // ENOUGH_BLOB_FEE_CAP_BLOCK intentionally not set
+        let subpool: SubPool = state.into();
+        assert_eq!(subpool, SubPool::Blob);
+        let reason = state.determine_queued_reason(subpool);
+        assert_eq!(reason, Some(QueuedReason::InsufficientBlobFee));
+    }
+
+    #[test]
+    fn test_blob_reason_nonce_gap() {
+        // Blob tx with nonce gap should report NonceGap regardless of fee bits
+        let mut state = TxState::NO_PARKED_ANCESTORS |
+            TxState::ENOUGH_BALANCE |
+            TxState::NOT_TOO_MUCH_GAS |
+            TxState::ENOUGH_FEE_CAP_BLOCK |
+            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
+            TxState::BLOB_TRANSACTION;
+        state.remove(TxState::NO_NONCE_GAPS);
+        let subpool: SubPool = state.into();
+        assert_eq!(subpool, SubPool::Blob);
+        let reason = state.determine_queued_reason(subpool);
+        assert_eq!(reason, Some(QueuedReason::NonceGap));
+    }
+
+    #[test]
+    fn test_blob_reason_insufficient_balance() {
+        // Blob tx with insufficient balance
+        let state = TxState::NO_PARKED_ANCESTORS |
+            TxState::NO_NONCE_GAPS |
+            TxState::NOT_TOO_MUCH_GAS |
+            TxState::ENOUGH_FEE_CAP_BLOCK |
+            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
+            TxState::BLOB_TRANSACTION;
+        // ENOUGH_BALANCE intentionally not set
+        let subpool: SubPool = state.into();
+        assert_eq!(subpool, SubPool::Blob);
+        let reason = state.determine_queued_reason(subpool);
+        assert_eq!(reason, Some(QueuedReason::InsufficientBalance));
+    }
+
+    #[test]
+    fn test_blob_reason_too_much_gas() {
+        // Blob tx exceeding gas limit
+        let mut state = TxState::NO_PARKED_ANCESTORS |
+            TxState::NO_NONCE_GAPS |
+            TxState::ENOUGH_BALANCE |
+            TxState::ENOUGH_FEE_CAP_BLOCK |
+            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
+            TxState::BLOB_TRANSACTION;
+        state.remove(TxState::NOT_TOO_MUCH_GAS);
+        let subpool: SubPool = state.into();
+        assert_eq!(subpool, SubPool::Blob);
+        let reason = state.determine_queued_reason(subpool);
+        assert_eq!(reason, Some(QueuedReason::TooMuchGas));
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/txpool.rs
+++ b/patches/reth-transaction-pool/src/pool/txpool.rs
@@ -1,0 +1,4798 @@
+//! The internal transaction pool implementation.
+
+use crate::{
+    config::{LocalTransactionConfig, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER},
+    error::{
+        Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
+        PoolError, PoolErrorKind,
+    },
+    identifier::{SenderId, TransactionId},
+    metrics::{AllTransactionsMetrics, TxPoolMetrics},
+    pool::{
+        best::BestTransactions,
+        blob::BlobTransactions,
+        parked::{BasefeeOrd, ParkedPool, QueuedOrd},
+        pending::PendingPool,
+        state::{SubPool, TxState},
+        update::{Destination, PoolUpdate, UpdateOutcome},
+        AddedPendingTransaction, AddedTransaction, OnNewCanonicalStateOutcome,
+    },
+    traits::{BestTransactionsAttributes, BlockInfo, PoolSize},
+    PoolConfig, PoolResult, PoolTransaction, PoolUpdateKind, PriceBumpConfig, TransactionOrdering,
+    ValidPoolTransaction, U256,
+};
+use alloy_consensus::constants::{
+    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID, KECCAK_EMPTY,
+    LEGACY_TX_TYPE_ID,
+};
+use alloy_eips::{
+    eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE},
+    eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+    Typed2718,
+};
+#[cfg(test)]
+use alloy_primitives::Address;
+use alloy_primitives::{
+    map::{AddressSet, B256Map, B256Set},
+    TxHash, B256,
+};
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
+#[cfg(test)]
+use std::collections::{HashMap, HashSet};
+use std::{
+    cmp::Ordering,
+    collections::{btree_map::Entry, hash_map, BTreeMap},
+    fmt,
+    ops::Bound::{Excluded, Unbounded},
+    sync::Arc,
+};
+use tracing::{trace, warn};
+
+#[cfg_attr(doc, aquamarine::aquamarine)]
+// TODO: Inlined diagram due to a bug in aquamarine library, should become an include when it's
+// fixed. See https://github.com/mersinvald/aquamarine/issues/50
+// include_mmd!("docs/mermaid/txpool.mmd")
+/// A pool that manages transactions.
+///
+/// This pool maintains the state of all transactions and stores them accordingly.
+///
+/// ```mermaid
+/// graph TB
+///   subgraph TxPool
+///     direction TB
+///     pool[(All Transactions)]
+///     subgraph Subpools
+///         direction TB
+///         B3[(Queued)]
+///         B1[(Pending)]
+///         B2[(Basefee)]
+///         B4[(Blob)]
+///     end
+///   end
+///   discard([discard])
+///   production([Block Production])
+///   new([New Block])
+///   A[Incoming Tx] --> B[Validation] -->|ins
+///   pool --> |if ready + blobfee too low| B4
+///   pool --> |if ready| B1
+///   pool --> |if ready + basfee too low| B2
+///   pool --> |nonce gap or lack of funds| B3
+///   pool --> |update| pool
+///   B1 --> |best| production
+///   B2 --> |worst| discard
+///   B3 --> |worst| discard
+///   B4 --> |worst| discard
+///   B1 --> |increased blob fee| B4
+///   B4 --> |decreased blob fee| B1
+///   B1 --> |increased base fee| B2
+///   B2 --> |decreased base fee| B1
+///   B3 --> |promote| B1
+///   B3 --> |promote| B2
+///   new --> |apply state changes| pool
+/// ```
+pub struct TxPool<T: TransactionOrdering> {
+    /// pending subpool
+    ///
+    /// Holds transactions that are ready to be executed on the current state.
+    pending_pool: PendingPool<T>,
+    /// Pool settings to enforce limits etc.
+    config: PoolConfig,
+    /// queued subpool
+    ///
+    /// Holds all parked transactions that depend on external changes from the sender:
+    ///
+    ///    - blocked by missing ancestor transaction (has nonce gaps)
+    ///    - sender lacks funds to pay for this transaction.
+    queued_pool: ParkedPool<QueuedOrd<T::Transaction>>,
+    /// base fee subpool
+    ///
+    /// Holds all parked transactions that currently violate the dynamic fee requirement but could
+    /// be moved to pending if the base fee changes in their favor (decreases) in future blocks.
+    basefee_pool: ParkedPool<BasefeeOrd<T::Transaction>>,
+    /// Blob transactions in the pool that are __not pending__.
+    ///
+    /// This means they either do not satisfy the dynamic fee requirement or the blob fee
+    /// requirement. These transactions can be moved to pending if the base fee or blob fee changes
+    /// in their favor (decreases) in future blocks. The transaction may need both the base fee and
+    /// blob fee to decrease to become executable.
+    blob_pool: BlobTransactions<T::Transaction>,
+    /// All transactions in the pool.
+    all_transactions: AllTransactions<T::Transaction>,
+    /// Transaction pool metrics
+    metrics: TxPoolMetrics,
+}
+
+// === impl TxPool ===
+
+impl<T: TransactionOrdering> TxPool<T> {
+    /// Create a new graph pool instance.
+    pub fn new(ordering: T, config: PoolConfig) -> Self {
+        Self {
+            pending_pool: PendingPool::with_buffer(
+                ordering,
+                config.max_new_pending_txs_notifications,
+            ),
+            queued_pool: Default::default(),
+            basefee_pool: Default::default(),
+            blob_pool: Default::default(),
+            all_transactions: AllTransactions::new(&config),
+            config,
+            metrics: Default::default(),
+        }
+    }
+
+    /// Retrieves the highest nonce for a specific sender from the transaction pool.
+    pub fn get_highest_nonce_by_sender(&self, sender: SenderId) -> Option<u64> {
+        self.all().txs_iter(sender).last().map(|(_, tx)| tx.transaction.nonce())
+    }
+
+    /// Retrieves the highest transaction (wrapped in an `Arc`) for a specific sender from the
+    /// transaction pool.
+    pub fn get_highest_transaction_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.all().txs_iter(sender).last().map(|(_, tx)| Arc::clone(&tx.transaction))
+    }
+
+    /// Returns the transaction with the highest nonce that is executable given the on chain nonce.
+    ///
+    /// If the pool already tracks a higher nonce for the given sender, then this nonce is used
+    /// instead.
+    ///
+    /// Note: The next pending pooled transaction must have the on chain nonce.
+    pub(crate) fn get_highest_consecutive_transaction_by_sender(
+        &self,
+        mut on_chain: TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut last_consecutive_tx = None;
+
+        // ensure this operates on the most recent
+        if let Some(current) = self.all_transactions.sender_info.get(&on_chain.sender) {
+            on_chain.nonce = on_chain.nonce.max(current.state_nonce);
+        }
+
+        let mut next_expected_nonce = on_chain.nonce;
+        for (id, tx) in self.all().descendant_txs_inclusive(&on_chain) {
+            if next_expected_nonce != id.nonce {
+                break
+            }
+            next_expected_nonce = id.next_nonce();
+            last_consecutive_tx = Some(tx);
+        }
+
+        last_consecutive_tx.map(|tx| Arc::clone(&tx.transaction))
+    }
+
+    /// Returns access to the [`AllTransactions`] container.
+    pub(crate) const fn all(&self) -> &AllTransactions<T::Transaction> {
+        &self.all_transactions
+    }
+
+    /// Returns all senders in the pool
+    pub(crate) fn unique_senders(&self) -> AddressSet {
+        self.all_transactions.txs.values().map(|tx| tx.transaction.sender()).collect()
+    }
+
+    /// Returns stats about the size of pool.
+    pub fn size(&self) -> PoolSize {
+        PoolSize {
+            pending: self.pending_pool.len(),
+            pending_size: self.pending_pool.size(),
+            basefee: self.basefee_pool.len(),
+            basefee_size: self.basefee_pool.size(),
+            queued: self.queued_pool.len(),
+            queued_size: self.queued_pool.size(),
+            blob: self.blob_pool.len(),
+            blob_size: self.blob_pool.size(),
+            total: self.all_transactions.len(),
+        }
+    }
+
+    /// Returns the currently tracked block values
+    pub const fn block_info(&self) -> BlockInfo {
+        BlockInfo {
+            block_gas_limit: self.all_transactions.block_gas_limit,
+            last_seen_block_hash: self.all_transactions.last_seen_block_hash,
+            last_seen_block_number: self.all_transactions.last_seen_block_number,
+            pending_basefee: self.all_transactions.pending_fees.base_fee,
+            pending_blob_fee: Some(self.all_transactions.pending_fees.blob_fee),
+        }
+    }
+
+    /// Updates the tracked blob fee
+    fn update_blob_fee<F>(
+        &mut self,
+        mut pending_blob_fee: u128,
+        base_fee_update: Ordering,
+        mut on_promoted: F,
+    ) where
+        F: FnMut(&Arc<ValidPoolTransaction<T::Transaction>>),
+    {
+        std::mem::swap(&mut self.all_transactions.pending_fees.blob_fee, &mut pending_blob_fee);
+        match (self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee), base_fee_update)
+        {
+            (Ordering::Equal, Ordering::Equal | Ordering::Greater) => {
+                // fee unchanged, nothing to update
+            }
+            (Ordering::Greater, Ordering::Equal | Ordering::Greater) => {
+                // increased blob fee: recheck pending pool and remove all that are no longer valid
+                let removed =
+                    self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
+                for tx in removed {
+                    let to = {
+                        let tx =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+
+                        // the blob fee is too high now, unset the blob fee cap block flag
+                        tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                        tx.subpool = tx.state.into();
+                        tx.subpool
+                    };
+                    self.add_transaction_to_subpool(to, tx);
+                }
+            }
+            (Ordering::Less, _) | (_, Ordering::Less) => {
+                // decreased blob/base fee: recheck blob pool and promote all that are now valid
+                let removed =
+                    self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
+                for tx in removed {
+                    let subpool = {
+                        let tx_meta =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+                        tx_meta.state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                        tx_meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+                        tx_meta.subpool = tx_meta.state.into();
+                        tx_meta.subpool
+                    };
+
+                    if subpool == SubPool::Pending {
+                        on_promoted(&tx);
+                    }
+
+                    self.add_transaction_to_subpool(subpool, tx);
+                }
+            }
+        }
+    }
+
+    /// Updates the tracked basefee
+    ///
+    /// Depending on the change in direction of the basefee, this will promote or demote
+    /// transactions from the basefee pool.
+    fn update_basefee<F>(&mut self, mut pending_basefee: u64, mut on_promoted: F) -> Ordering
+    where
+        F: FnMut(&Arc<ValidPoolTransaction<T::Transaction>>),
+    {
+        std::mem::swap(&mut self.all_transactions.pending_fees.base_fee, &mut pending_basefee);
+        match self.all_transactions.pending_fees.base_fee.cmp(&pending_basefee) {
+            Ordering::Equal => {
+                // fee unchanged, nothing to update
+                Ordering::Equal
+            }
+            Ordering::Greater => {
+                // increased base fee: recheck pending pool and remove all that are no longer valid
+                let removed =
+                    self.pending_pool.update_base_fee(self.all_transactions.pending_fees.base_fee);
+                for tx in removed {
+                    let to = {
+                        let tx =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+                        tx.state.remove(TxState::ENOUGH_FEE_CAP_BLOCK);
+                        tx.subpool = tx.state.into();
+                        tx.subpool
+                    };
+                    self.add_transaction_to_subpool(to, tx);
+                }
+
+                Ordering::Greater
+            }
+            Ordering::Less => {
+                // Base fee decreased: recheck BaseFee and promote.
+                // Invariants:
+                // - BaseFee contains only non-blob txs (blob txs live in Blob) and they already
+                //   have ENOUGH_BLOB_FEE_CAP_BLOCK.
+                // - PENDING_POOL_BITS = BASE_FEE_POOL_BITS | ENOUGH_FEE_CAP_BLOCK |
+                //   ENOUGH_BLOB_FEE_CAP_BLOCK.
+                // With the lower base fee they gain ENOUGH_FEE_CAP_BLOCK, so we can set the bit and
+                // insert directly into Pending (skip generic routing).
+                let current_base_fee = self.all_transactions.pending_fees.base_fee;
+                self.basefee_pool.enforce_basefee_with(current_base_fee, |tx| {
+                    // Update transaction state — guaranteed Pending by the invariants above
+                    let subpool = {
+                        let meta =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+                        meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+                        meta.subpool = meta.state.into();
+                        meta.subpool
+                    };
+
+                    if subpool == SubPool::Pending {
+                        on_promoted(&tx);
+                    }
+
+                    trace!(target: "txpool", hash=%tx.transaction.hash(), pool=?subpool, "Adding transaction to a subpool");
+                    match subpool {
+                        SubPool::Queued => self.queued_pool.add_transaction(tx),
+                        SubPool::Pending => {
+                            self.pending_pool.add_transaction(tx, current_base_fee);
+                        }
+                        SubPool::Blob => {
+                            self.blob_pool.add_transaction(tx);
+                        }
+                        SubPool::BaseFee => {
+                            // This should be unreachable as transactions from BaseFee pool with decreased
+                            // basefee are guaranteed to become Pending
+                            warn!(target: "txpool", "BaseFee transactions should become Pending after basefee decrease");
+                        }
+                    }
+                });
+
+                Ordering::Less
+            }
+        }
+    }
+
+    /// Sets the current block info for the pool.
+    ///
+    /// This will also apply updates to the pool based on the new base fee and blob fee.
+    ///
+    /// Returns the outcome containing any transactions that were promoted due to fee changes.
+    pub fn set_block_info(&mut self, info: BlockInfo) -> UpdateOutcome<T::Transaction> {
+        let mut outcome = UpdateOutcome::default();
+
+        // first update the subpools based on the new values, collecting promoted transactions
+        let basefee_ordering = self.update_basefee(info.pending_basefee, |tx| {
+            outcome.promoted.push(tx.clone());
+        });
+        if let Some(blob_fee) = info.pending_blob_fee {
+            self.update_blob_fee(blob_fee, basefee_ordering, |tx| {
+                outcome.promoted.push(tx.clone());
+            })
+        }
+        // then update tracked values
+        self.all_transactions.set_block_info(info);
+
+        outcome
+    }
+
+    /// Returns an iterator that yields transactions that are ready to be included in the block with
+    /// the tracked fees.
+    pub(crate) fn best_transactions(&self) -> BestTransactions<T> {
+        self.pending_pool.best()
+    }
+
+    /// Returns an iterator that yields transactions that are ready to be included in the block with
+    /// the given base fee and optional blob fee.
+    ///
+    /// If the provided attributes differ from the currently tracked fees, this will also include
+    /// transactions that are unlocked by the new fees, or exclude transactions that are no longer
+    /// valid with the new fees.
+    pub(crate) fn best_transactions_with_attributes(
+        &self,
+        best_transactions_attributes: BestTransactionsAttributes,
+    ) -> Box<dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T::Transaction>>>>
+    {
+        // First we need to check if the given base fee is different than what's currently being
+        // tracked
+        match best_transactions_attributes.basefee.cmp(&self.all_transactions.pending_fees.base_fee)
+        {
+            Ordering::Equal => {
+                // for EIP-4844 transactions we also need to check if the blob fee is now lower than
+                // what's currently being tracked, if so we need to include transactions from the
+                // blob pool that are valid with the lower blob fee
+                let new_blob_fee = best_transactions_attributes.blob_fee.unwrap_or_default();
+                match new_blob_fee.cmp(&(self.all_transactions.pending_fees.blob_fee as u64)) {
+                    Ordering::Less => {
+                        // it's possible that this swing unlocked more blob transactions
+                        let unlocked =
+                            self.blob_pool.satisfy_attributes(best_transactions_attributes);
+                        Box::new(self.pending_pool.best_with_unlocked_and_attributes(
+                            unlocked,
+                            best_transactions_attributes.basefee,
+                            new_blob_fee,
+                        ))
+                    }
+                    Ordering::Equal => Box::new(self.pending_pool.best()),
+                    Ordering::Greater => {
+                        // no additional transactions unlocked
+                        Box::new(self.pending_pool.best_with_basefee_and_blobfee(
+                            best_transactions_attributes.basefee,
+                            best_transactions_attributes.blob_fee.unwrap_or_default(),
+                        ))
+                    }
+                }
+            }
+            Ordering::Greater => {
+                // base fee increased, we need to check how the blob fee moved
+                let new_blob_fee = best_transactions_attributes.blob_fee.unwrap_or_default();
+                match new_blob_fee.cmp(&(self.all_transactions.pending_fees.blob_fee as u64)) {
+                    Ordering::Less => {
+                        // it's possible that this swing unlocked more blob transactions
+                        let unlocked =
+                            self.blob_pool.satisfy_attributes(best_transactions_attributes);
+                        Box::new(self.pending_pool.best_with_unlocked_and_attributes(
+                            unlocked,
+                            best_transactions_attributes.basefee,
+                            new_blob_fee,
+                        ))
+                    }
+                    Ordering::Equal | Ordering::Greater => {
+                        // no additional transactions unlocked
+                        Box::new(self.pending_pool.best_with_basefee_and_blobfee(
+                            best_transactions_attributes.basefee,
+                            new_blob_fee,
+                        ))
+                    }
+                }
+            }
+            Ordering::Less => {
+                // base fee decreased, we need to move transactions from the basefee + blob pool to
+                // the pending pool that might be unlocked by the lower base fee
+                let mut unlocked = self
+                    .basefee_pool
+                    .satisfy_base_fee_transactions(best_transactions_attributes.basefee);
+
+                // also include blob pool transactions that are now unlocked
+                unlocked.extend(self.blob_pool.satisfy_attributes(best_transactions_attributes));
+
+                Box::new(self.pending_pool.best_with_unlocked_and_attributes(
+                    unlocked,
+                    best_transactions_attributes.basefee,
+                    best_transactions_attributes.blob_fee.unwrap_or_default(),
+                ))
+            }
+        }
+    }
+
+    /// Returns all transactions from the pending sub-pool
+    pub(crate) fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.pending_pool.all().collect()
+    }
+    /// Returns an iterator over all transactions from the pending sub-pool
+    pub(crate) fn pending_transactions_iter(
+        &self,
+    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T::Transaction>>> + '_ {
+        self.pending_pool.all()
+    }
+
+    /// Returns the number of transactions from the pending sub-pool
+    pub(crate) fn pending_transactions_count(&self) -> usize {
+        self.pending_pool.len()
+    }
+
+    /// Returns all pending transactions filtered by predicate
+    pub(crate) fn pending_transactions_with_predicate(
+        &self,
+        mut predicate: impl FnMut(&ValidPoolTransaction<T::Transaction>) -> bool,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.pending_transactions_iter().filter(|tx| predicate(tx)).collect()
+    }
+
+    /// Returns all pending transactions for the specified sender
+    pub(crate) fn pending_txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.pending_pool.txs_by_sender(sender)
+    }
+
+    /// Returns all transactions from parked pools
+    pub(crate) fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.basefee_pool.all().chain(self.queued_pool.all()).collect()
+    }
+
+    /// Returns the number of transactions in parked pools
+    pub(crate) fn queued_transactions_count(&self) -> usize {
+        self.basefee_pool.len() + self.queued_pool.len()
+    }
+
+    /// Returns queued and pending transactions for the specified sender
+    pub fn queued_and_pending_txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> (SmallVec<[TransactionId; TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER]>, Vec<TransactionId>) {
+        (self.queued_pool.get_txs_by_sender(sender), self.pending_pool.get_txs_by_sender(sender))
+    }
+
+    /// Returns all queued transactions for the specified sender
+    pub(crate) fn queued_txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut txs = self.basefee_pool.txs_by_sender(sender);
+        txs.extend(self.queued_pool.txs_by_sender(sender));
+        txs
+    }
+
+    /// Returns `true` if the transaction with the given hash is already included in this pool.
+    pub(crate) fn contains(&self, tx_hash: &TxHash) -> bool {
+        self.all_transactions.contains(tx_hash)
+    }
+
+    /// Returns `true` if the transaction with the given id is already included in the given subpool
+    #[cfg(test)]
+    pub(crate) fn subpool_contains(&self, subpool: SubPool, id: &TransactionId) -> bool {
+        match subpool {
+            SubPool::Queued => self.queued_pool.contains(id),
+            SubPool::Pending => self.pending_pool.contains(id),
+            SubPool::BaseFee => self.basefee_pool.contains(id),
+            SubPool::Blob => self.blob_pool.contains(id),
+        }
+    }
+
+    /// Returns `true` if the pool is over its configured limits.
+    #[inline]
+    pub(crate) fn is_exceeded(&self) -> bool {
+        self.config.is_exceeded(self.size())
+    }
+
+    /// Returns the transaction for the given hash.
+    pub(crate) fn get(
+        &self,
+        tx_hash: &TxHash,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.all_transactions.by_hash.get(tx_hash).cloned()
+    }
+
+    /// Returns transactions for the multiple given hashes, if they exist.
+    pub(crate) fn get_all(
+        &self,
+        txs: Vec<TxHash>,
+    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T::Transaction>>> + '_ {
+        txs.into_iter().filter_map(|tx| self.get(&tx))
+    }
+
+    /// Returns all transactions sent from the given sender.
+    pub(crate) fn get_transactions_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.all_transactions.txs_iter(sender).map(|(_, tx)| Arc::clone(&tx.transaction)).collect()
+    }
+
+    /// Returns a pending transaction sent by the given sender with the given nonce.
+    pub(crate) fn get_pending_transaction_by_sender_and_nonce(
+        &self,
+        sender: SenderId,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.all_transactions
+            .txs_iter(sender)
+            .find(|(id, tx)| id.nonce == nonce && tx.subpool == SubPool::Pending)
+            .map(|(_, tx)| Arc::clone(&tx.transaction))
+    }
+
+    /// Updates only the pending fees without triggering subpool updates.
+    /// Returns the previous base fee and blob fee values.
+    const fn update_pending_fees_only(
+        &mut self,
+        mut new_base_fee: u64,
+        new_blob_fee: Option<u128>,
+    ) -> (u64, u128) {
+        std::mem::swap(&mut self.all_transactions.pending_fees.base_fee, &mut new_base_fee);
+
+        let prev_blob_fee = if let Some(mut blob_fee) = new_blob_fee {
+            std::mem::swap(&mut self.all_transactions.pending_fees.blob_fee, &mut blob_fee);
+            blob_fee
+        } else {
+            self.all_transactions.pending_fees.blob_fee
+        };
+
+        (new_base_fee, prev_blob_fee)
+    }
+
+    /// Applies fee-based promotion updates based on the previous fees.
+    ///
+    /// Records promoted transactions based on fee swings.
+    ///
+    /// Caution: This expects that the fees were previously already updated via
+    /// [`Self::update_pending_fees_only`].
+    fn apply_fee_updates(
+        &mut self,
+        prev_base_fee: u64,
+        prev_blob_fee: u128,
+        outcome: &mut UpdateOutcome<T::Transaction>,
+    ) {
+        let new_base_fee = self.all_transactions.pending_fees.base_fee;
+        let new_blob_fee = self.all_transactions.pending_fees.blob_fee;
+
+        if new_base_fee == prev_base_fee && new_blob_fee == prev_blob_fee {
+            // nothing to update
+            return;
+        }
+
+        // IMPORTANT:
+        // Restore previous fees so that the update fee functions correctly handle fee swings
+        self.all_transactions.pending_fees.base_fee = prev_base_fee;
+        self.all_transactions.pending_fees.blob_fee = prev_blob_fee;
+
+        let base_fee_ordering = self.update_basefee(new_base_fee, |tx| {
+            outcome.promoted.push(tx.clone());
+        });
+
+        self.update_blob_fee(new_blob_fee, base_fee_ordering, |tx| {
+            outcome.promoted.push(tx.clone());
+        });
+    }
+
+    /// Updates the transactions for the changed senders.
+    pub(crate) fn update_accounts(
+        &mut self,
+        changed_senders: FxHashMap<SenderId, SenderInfo>,
+    ) -> UpdateOutcome<T::Transaction> {
+        // Apply the state changes to the total set of transactions which triggers sub-pool updates.
+        let updates = self.all_transactions.update(&changed_senders);
+
+        // track changed accounts
+        self.all_transactions.sender_info.extend(changed_senders);
+
+        // Process the sub-pool updates
+        let update = self.process_updates(updates);
+        // update the metrics after the update
+        self.update_size_metrics();
+        update
+    }
+
+    /// Updates the entire pool after a new block was mined.
+    ///
+    /// This removes all mined transactions, updates according to the new base fee and blob fee and
+    /// rechecks sender allowance based on the given changed sender infos.
+    pub(crate) fn on_canonical_state_change(
+        &mut self,
+        block_info: BlockInfo,
+        mined_transactions: Vec<TxHash>,
+        changed_senders: FxHashMap<SenderId, SenderInfo>,
+        _update_kind: PoolUpdateKind,
+    ) -> OnNewCanonicalStateOutcome<T::Transaction> {
+        // update block info
+        let block_hash = block_info.last_seen_block_hash;
+
+        // Remove all transaction that were included in the block
+        let mut removed_txs_count = 0;
+        for tx_hash in &mined_transactions {
+            if self.prune_transaction_by_hash(tx_hash).is_some() {
+                removed_txs_count += 1;
+            }
+        }
+
+        // Update removed transactions metric
+        self.metrics.removed_transactions.increment(removed_txs_count);
+
+        // Update fees internally first without triggering subpool updates based on fee movements
+        // This must happen before we update the changed so that all account updates use the new fee
+        // values, this way all changed accounts remain unaffected by the fee updates that are
+        // performed in next step and we don't collect promotions twice
+        let (prev_base_fee, prev_blob_fee) =
+            self.update_pending_fees_only(block_info.pending_basefee, block_info.pending_blob_fee);
+
+        // Now update accounts with the new fees already set
+        let mut outcome = self.update_accounts(changed_senders);
+
+        // Apply subpool updates based on fee changes
+        // This will record any additional promotions based on fee movements
+        self.apply_fee_updates(prev_base_fee, prev_blob_fee, &mut outcome);
+
+        // Update the rest of block info (without triggering fee updates again)
+        self.all_transactions.set_block_info(block_info);
+
+        self.update_transaction_type_metrics();
+        self.metrics.performed_state_updates.increment(1);
+
+        OnNewCanonicalStateOutcome {
+            block_hash,
+            mined: mined_transactions,
+            promoted: outcome.promoted,
+            discarded: outcome.discarded,
+        }
+    }
+
+    /// Update sub-pools size metrics.
+    pub(crate) fn update_size_metrics(&self) {
+        let stats = self.size();
+        self.metrics.pending_pool_transactions.set(stats.pending as f64);
+        self.metrics.pending_pool_size_bytes.set(stats.pending_size as f64);
+        self.metrics.basefee_pool_transactions.set(stats.basefee as f64);
+        self.metrics.basefee_pool_size_bytes.set(stats.basefee_size as f64);
+        self.metrics.queued_pool_transactions.set(stats.queued as f64);
+        self.metrics.queued_pool_size_bytes.set(stats.queued_size as f64);
+        self.metrics.blob_pool_transactions.set(stats.blob as f64);
+        self.metrics.blob_pool_size_bytes.set(stats.blob_size as f64);
+        self.metrics.total_transactions.set(stats.total as f64);
+    }
+
+    /// Updates transaction type metrics for the entire pool.
+    pub(crate) fn update_transaction_type_metrics(&self) {
+        let mut legacy_count = 0;
+        let mut eip2930_count = 0;
+        let mut eip1559_count = 0;
+        let mut eip4844_count = 0;
+        let mut eip7702_count = 0;
+        let mut other_count = 0;
+
+        for tx in self.all_transactions.transactions_iter() {
+            match tx.transaction.ty() {
+                LEGACY_TX_TYPE_ID => legacy_count += 1,
+                EIP2930_TX_TYPE_ID => eip2930_count += 1,
+                EIP1559_TX_TYPE_ID => eip1559_count += 1,
+                EIP4844_TX_TYPE_ID => eip4844_count += 1,
+                EIP7702_TX_TYPE_ID => eip7702_count += 1,
+                _ => other_count += 1,
+            }
+        }
+
+        self.metrics.total_legacy_transactions.set(legacy_count as f64);
+        self.metrics.total_eip2930_transactions.set(eip2930_count as f64);
+        self.metrics.total_eip1559_transactions.set(eip1559_count as f64);
+        self.metrics.total_eip4844_transactions.set(eip4844_count as f64);
+        self.metrics.total_eip7702_transactions.set(eip7702_count as f64);
+        self.metrics.total_other_transactions.set(other_count as f64);
+    }
+
+    pub(crate) fn add_transaction(
+        &mut self,
+        tx: ValidPoolTransaction<T::Transaction>,
+        on_chain_balance: U256,
+        on_chain_nonce: u64,
+        on_chain_code_hash: Option<B256>,
+    ) -> PoolResult<AddedTransaction<T::Transaction>> {
+        if self.contains(tx.hash()) {
+            return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported))
+        }
+
+        self.validate_auth(&tx, on_chain_nonce, on_chain_code_hash)?;
+
+        // Update sender info with balance and nonce
+        self.all_transactions
+            .sender_info
+            .entry(tx.sender_id())
+            .or_default()
+            .update(on_chain_nonce, on_chain_balance);
+
+        match self.all_transactions.insert_tx(tx, on_chain_balance, on_chain_nonce) {
+            Ok(InsertOk { transaction, move_to, replaced_tx, mut updates, state }) => {
+                // Interleave update processing and new-tx insertion so that live
+                // `BestTransactions` iterators always receive transactions in nonce order.
+                // Updates are already in nonce-ascending order, so we split them around
+                // the new transaction's nonce:
+                //  1. Promote lower-nonce txs first  (e.g. balance-unlock scenario)
+                //  2. Add the new transaction
+                //  3. Promote higher-nonce txs last   (e.g. gap-fill scenario)
+                let new_nonce = transaction.id().nonce;
+                let split = updates.iter().position(|u| u.id.nonce >= new_nonce);
+                let (promoted, discarded) = match split {
+                    // All updates are lower-nonce — promote them first, then add new tx
+                    None => {
+                        let UpdateOutcome { promoted, discarded } = self.process_updates(updates);
+                        self.add_new_transaction(transaction.clone(), replaced_tx.clone(), move_to);
+                        (promoted, discarded)
+                    }
+                    // All updates are higher-nonce — add new tx first, then promote
+                    Some(0) => {
+                        self.add_new_transaction(transaction.clone(), replaced_tx.clone(), move_to);
+                        let UpdateOutcome { promoted, discarded } = self.process_updates(updates);
+                        (promoted, discarded)
+                    }
+                    // Mixed — split and interleave
+                    Some(i) => {
+                        let after = updates.split_off(i);
+                        let mut outcome = self.process_updates(updates);
+                        self.add_new_transaction(transaction.clone(), replaced_tx.clone(), move_to);
+                        let after_outcome = self.process_updates(after);
+                        outcome.promoted.extend(after_outcome.promoted);
+                        outcome.discarded.extend(after_outcome.discarded);
+                        (outcome.promoted, outcome.discarded)
+                    }
+                };
+                self.metrics.inserted_transactions.increment(1);
+
+                let replaced = replaced_tx.map(|(tx, _)| tx);
+
+                // This transaction was moved to the pending pool.
+                let res = if move_to.is_pending() {
+                    AddedTransaction::Pending(AddedPendingTransaction {
+                        transaction,
+                        promoted,
+                        discarded,
+                        replaced,
+                    })
+                } else {
+                    // Determine the specific queued reason based on the transaction state
+                    let queued_reason = state.determine_queued_reason(move_to);
+                    AddedTransaction::Parked {
+                        transaction,
+                        subpool: move_to,
+                        replaced,
+                        queued_reason,
+                    }
+                };
+
+                // Update size metrics after adding and potentially moving transactions.
+                self.update_size_metrics();
+
+                Ok(res)
+            }
+            Err(err) => {
+                // Update invalid transactions metric
+                self.metrics.invalid_transactions.increment(1);
+                match err {
+                    InsertErr::Underpriced { existing: _, transaction } => Err(PoolError::new(
+                        *transaction.hash(),
+                        PoolErrorKind::ReplacementUnderpriced,
+                    )),
+                    InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap } => {
+                        Err(PoolError::new(
+                            *transaction.hash(),
+                            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(fee_cap),
+                        ))
+                    }
+                    InsertErr::ExceededSenderTransactionsCapacity { transaction } => {
+                        Err(PoolError::new(
+                            *transaction.hash(),
+                            PoolErrorKind::SpammerExceededCapacity(transaction.sender()),
+                        ))
+                    }
+                    InsertErr::TxGasLimitMoreThanAvailableBlockGas {
+                        transaction,
+                        block_gas_limit,
+                        tx_gas_limit,
+                    } => Err(PoolError::new(
+                        *transaction.hash(),
+                        PoolErrorKind::InvalidTransaction(
+                            InvalidPoolTransactionError::ExceedsGasLimit(
+                                tx_gas_limit,
+                                block_gas_limit,
+                            ),
+                        ),
+                    )),
+                    InsertErr::BlobTxHasNonceGap { transaction } => Err(PoolError::new(
+                        *transaction.hash(),
+                        PoolErrorKind::InvalidTransaction(
+                            Eip4844PoolTransactionError::Eip4844NonceGap.into(),
+                        ),
+                    )),
+                    InsertErr::Overdraft { transaction } => Err(PoolError::new(
+                        *transaction.hash(),
+                        PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Overdraft {
+                            cost: *transaction.cost(),
+                            balance: on_chain_balance,
+                        }),
+                    )),
+                    InsertErr::TxTypeConflict { transaction } => Err(PoolError::new(
+                        *transaction.hash(),
+                        PoolErrorKind::ExistingConflictingTransactionType(
+                            transaction.sender(),
+                            transaction.tx_type(),
+                        ),
+                    )),
+                }
+            }
+        }
+    }
+
+    /// Determines if the tx sender is delegated or has a  pending delegation, and if so, ensures
+    /// they have at most one configured amount of in-flight **executable** transactions (default at
+    /// most one), e.g. disallow stacked and nonce-gapped transactions from the account.
+    fn check_delegation_limit(
+        &self,
+        transaction: &ValidPoolTransaction<T::Transaction>,
+        on_chain_nonce: u64,
+        on_chain_code_hash: Option<B256>,
+    ) -> Result<(), PoolError> {
+        // Short circuit if the sender has neither delegation nor pending delegation.
+        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY)) &&
+            !self.all_transactions.auths.contains_key(&transaction.sender_id())
+        {
+            return Ok(())
+        }
+
+        let mut txs_by_sender =
+            self.pending_pool.iter_txs_by_sender(transaction.sender_id()).peekable();
+
+        if txs_by_sender.peek().is_none() {
+            // Transaction with gapped nonce is not supported for delegated accounts
+            // but transaction can arrive out of order if more slots are allowed
+            // by default with a slot limit of 1 this will fail if the transaction's nonce >
+            // on_chain
+            let nonce_gap_distance = transaction.nonce().saturating_sub(on_chain_nonce);
+            if nonce_gap_distance >= self.config.max_inflight_delegated_slot_limit as u64 {
+                return Err(PoolError::new(
+                    *transaction.hash(),
+                    PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
+                        Eip7702PoolTransactionError::OutOfOrderTxFromDelegated,
+                    )),
+                ))
+            }
+            return Ok(())
+        }
+
+        let mut count = 0;
+        for id in txs_by_sender {
+            if id == &transaction.transaction_id {
+                // Transaction replacement is supported
+                return Ok(())
+            }
+            count += 1;
+        }
+
+        if count < self.config.max_inflight_delegated_slot_limit {
+            // account still has an available slot
+            return Ok(())
+        }
+
+        Err(PoolError::new(
+            *transaction.hash(),
+            PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
+                Eip7702PoolTransactionError::InflightTxLimitReached,
+            )),
+        ))
+    }
+
+    /// This verifies that the transaction complies with code authorization
+    /// restrictions brought by EIP-7702 transaction type:
+    /// 1. Any account with a deployed delegation or an in-flight authorization to deploy a
+    ///    delegation will only be allowed a certain amount of transaction slots (default 1) instead
+    ///    of the standard limit. This is due to the possibility of the account being sweeped by an
+    ///    unrelated account.
+    /// 2. In case the pool is tracking a pending / queued transaction from a specific account, at
+    ///    most the configured inflight delegation slot limit of in-flight transactions is allowed;
+    ///    any additional delegated transactions from that account will be rejected.
+    fn validate_auth(
+        &self,
+        transaction: &ValidPoolTransaction<T::Transaction>,
+        on_chain_nonce: u64,
+        on_chain_code_hash: Option<B256>,
+    ) -> Result<(), PoolError> {
+        // Ensure in-flight limit for delegated accounts or those with a pending authorization.
+        self.check_delegation_limit(transaction, on_chain_nonce, on_chain_code_hash)?;
+
+        if let Some(authority_list) = &transaction.authority_ids {
+            for sender_id in authority_list {
+                // Ensure authority does not exceed the configured inflight delegation slot limit.
+                if self
+                    .all_transactions
+                    .txs_iter(*sender_id)
+                    .nth(self.config.max_inflight_delegated_slot_limit)
+                    .is_some()
+                {
+                    return Err(PoolError::new(
+                        *transaction.hash(),
+                        PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
+                            Eip7702PoolTransactionError::AuthorityReserved,
+                        )),
+                    ))
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Maintenance task to apply a series of updates.
+    ///
+    /// This will move/discard the given transaction according to the `PoolUpdate`
+    fn process_updates(&mut self, updates: Vec<PoolUpdate>) -> UpdateOutcome<T::Transaction> {
+        let mut outcome = UpdateOutcome::default();
+        let mut removed = 0;
+        for PoolUpdate { id, current, destination } in updates {
+            match destination {
+                Destination::Discard => {
+                    // remove the transaction from the pool and subpool
+                    if let Some(tx) = self.prune_transaction_by_id(&id) {
+                        outcome.discarded.push(tx);
+                    }
+                    removed += 1;
+                }
+                Destination::Pool(move_to) => {
+                    debug_assert_ne!(&move_to, &current, "destination must be different");
+                    let moved = self.move_transaction(current, move_to, &id);
+                    if matches!(move_to, SubPool::Pending) &&
+                        let Some(tx) = moved
+                    {
+                        trace!(target: "txpool", hash=%tx.transaction.hash(), "Promoted transaction to pending");
+                        outcome.promoted.push(tx);
+                    }
+                }
+            }
+        }
+
+        if removed > 0 {
+            self.metrics.removed_transactions.increment(removed);
+        }
+
+        outcome
+    }
+
+    /// Moves a transaction from one sub pool to another.
+    ///
+    /// This will remove the given transaction from one sub-pool and insert it into the other
+    /// sub-pool.
+    fn move_transaction(
+        &mut self,
+        from: SubPool,
+        to: SubPool,
+        id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let tx = self.remove_from_subpool(from, id)?;
+        self.add_transaction_to_subpool(to, tx.clone());
+        Some(tx)
+    }
+
+    /// Removes and returns all matching transactions from the pool.
+    ///
+    /// Note: this does not advance any descendants of the removed transactions and does not apply
+    /// any additional updates.
+    pub(crate) fn remove_transactions(
+        &mut self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let txs =
+            hashes.into_iter().filter_map(|hash| self.remove_transaction_by_hash(&hash)).collect();
+        self.update_size_metrics();
+        txs
+    }
+
+    /// Removes and returns all matching transactions and their descendants from the pool.
+    pub(crate) fn remove_transactions_and_descendants(
+        &mut self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut removed = Vec::new();
+        for hash in hashes {
+            if let Some(tx) = self.remove_transaction_by_hash(&hash) {
+                removed.push(tx.clone());
+                self.remove_descendants(tx.id(), &mut removed);
+            }
+        }
+        self.update_size_metrics();
+        removed
+    }
+
+    /// Removes all transactions from the given sender.
+    pub(crate) fn remove_transactions_by_sender(
+        &mut self,
+        sender_id: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut removed = Vec::new();
+        let txs = self.get_transactions_by_sender(sender_id);
+        for tx in txs {
+            if let Some(tx) = self.remove_transaction(tx.id()) {
+                removed.push(tx);
+            }
+        }
+        self.update_size_metrics();
+        removed
+    }
+
+    /// Prunes and returns all matching transactions from the pool.
+    ///
+    /// This uses [`Self::prune_transaction_by_hash`] which does **not** park descendant
+    /// transactions, so they remain in their current sub-pool and can be included in subsequent
+    /// blocks.
+    pub(crate) fn prune_transactions(
+        &mut self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let txs =
+            hashes.into_iter().filter_map(|hash| self.prune_transaction_by_hash(&hash)).collect();
+        self.update_size_metrics();
+        txs
+    }
+
+    /// Remove the transaction from the __entire__ pool.
+    ///
+    /// This includes the total set of transaction and the subpool it currently resides in.
+    fn remove_transaction(
+        &mut self,
+        id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let (tx, pool) = self.all_transactions.remove_transaction(id)?;
+        self.remove_from_subpool(pool, tx.id())
+    }
+
+    /// Remove the transaction from the entire pool via its hash. This includes the total set of
+    /// transactions and the subpool it currently resides in.
+    ///
+    /// This treats the descendants as if this transaction is discarded and removing the transaction
+    /// reduces a nonce gap.
+    fn remove_transaction_by_hash(
+        &mut self,
+        tx_hash: &B256,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let (tx, pool) = self.all_transactions.remove_transaction_by_hash(tx_hash)?;
+
+        // After a tx is removed, its descendants must become parked due to the nonce gap
+        let updates = self.all_transactions.park_descendant_transactions(tx.id());
+        self.process_updates(updates);
+        self.remove_from_subpool(pool, tx.id())
+    }
+
+    /// This removes the transaction from the pool and advances any descendant state inside the
+    /// subpool.
+    ///
+    /// This is intended to be used when a transaction is included in a block,
+    /// [`Self::on_canonical_state_change`]. So its descendants will not change from pending to
+    /// parked, just like what we do in `remove_transaction_by_hash`.
+    fn prune_transaction_by_hash(
+        &mut self,
+        tx_hash: &B256,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let (tx, pool) = self.all_transactions.remove_transaction_by_hash(tx_hash)?;
+        self.remove_from_subpool(pool, tx.id())
+    }
+    /// This removes the transaction from the pool and advances any descendant state inside the
+    /// subpool.
+    ///
+    /// This is intended to be used when we call [`Self::process_updates`].
+    fn prune_transaction_by_id(
+        &mut self,
+        tx_id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let (tx, pool) = self.all_transactions.remove_transaction_by_id(tx_id)?;
+        self.remove_from_subpool(pool, tx.id())
+    }
+
+    /// Removes the transaction from the given pool.
+    ///
+    /// Caution: this only removes the tx from the sub-pool and not from the pool itself
+    fn remove_from_subpool(
+        &mut self,
+        pool: SubPool,
+        tx: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let tx = match pool {
+            SubPool::Queued => self.queued_pool.remove_transaction(tx),
+            SubPool::Pending => self.pending_pool.remove_transaction(tx),
+            SubPool::BaseFee => self.basefee_pool.remove_transaction(tx),
+            SubPool::Blob => self.blob_pool.remove_transaction(tx),
+        };
+
+        if let Some(ref tx) = tx {
+            // We trace here instead of in subpool structs directly, because the `ParkedPool` type
+            // is generic and it would not be possible to distinguish whether a transaction is
+            // being removed from the `BaseFee` pool, or the `Queued` pool.
+            trace!(target: "txpool", hash=%tx.transaction.hash(), ?pool, "Removed transaction from a subpool");
+        }
+
+        tx
+    }
+
+    /// Removes _only_ the descendants of the given transaction from the __entire__ pool.
+    ///
+    /// All removed transactions are added to the `removed` vec.
+    fn remove_descendants(
+        &mut self,
+        tx: &TransactionId,
+        removed: &mut Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+    ) {
+        let mut id = *tx;
+
+        // this will essentially pop _all_ descendant transactions one by one
+        loop {
+            let descendant =
+                self.all_transactions.descendant_txs_exclusive(&id).map(|(id, _)| *id).next();
+            if let Some(descendant) = descendant {
+                if let Some(tx) = self.remove_transaction(&descendant) {
+                    removed.push(tx)
+                }
+                id = descendant;
+            } else {
+                return
+            }
+        }
+    }
+
+    /// Inserts the transaction into the given sub-pool.
+    fn add_transaction_to_subpool(
+        &mut self,
+        pool: SubPool,
+        tx: Arc<ValidPoolTransaction<T::Transaction>>,
+    ) {
+        // We trace here instead of in structs directly, because the `ParkedPool` type is
+        // generic and it would not be possible to distinguish whether a transaction is being
+        // added to the `BaseFee` pool, or the `Queued` pool.
+        trace!(target: "txpool", hash=%tx.transaction.hash(), ?pool, "Adding transaction to a subpool");
+        match pool {
+            SubPool::Queued => self.queued_pool.add_transaction(tx),
+            SubPool::Pending => {
+                self.pending_pool.add_transaction(tx, self.all_transactions.pending_fees.base_fee);
+            }
+            SubPool::BaseFee => {
+                self.basefee_pool.add_transaction(tx);
+            }
+            SubPool::Blob => {
+                self.blob_pool.add_transaction(tx);
+            }
+        }
+    }
+
+    /// Inserts the transaction into the given sub-pool.
+    /// Optionally, removes the replacement transaction.
+    fn add_new_transaction(
+        &mut self,
+        transaction: Arc<ValidPoolTransaction<T::Transaction>>,
+        replaced: Option<(Arc<ValidPoolTransaction<T::Transaction>>, SubPool)>,
+        pool: SubPool,
+    ) {
+        if let Some((replaced, replaced_pool)) = replaced {
+            // Remove the replaced transaction
+            self.remove_from_subpool(replaced_pool, replaced.id());
+        }
+
+        self.add_transaction_to_subpool(pool, transaction)
+    }
+
+    /// Ensures that the transactions in the sub-pools are within the given bounds.
+    ///
+    /// If the current size exceeds the given bounds, the worst transactions are evicted from the
+    /// pool and returned.
+    ///
+    /// This returns all transactions that were removed from the entire pool.
+    pub(crate) fn discard_worst(&mut self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let mut removed = Vec::new();
+
+        // Helper macro that discards the worst transactions for the pools
+        macro_rules! discard_worst {
+            ($this:ident, $removed:ident, [$($limit:ident => ($pool:ident, $metric:ident)),* $(,)*]) => {
+                $ (
+                while $this.$pool.exceeds(&$this.config.$limit)
+                    {
+                        trace!(
+                            target: "txpool",
+                            "discarding transactions from {}, limit: {:?}, curr size: {}, curr len: {}",
+                            stringify!($pool),
+                            $this.config.$limit,
+                            $this.$pool.size(),
+                            $this.$pool.len(),
+                        );
+
+                        // 1. first remove the worst transaction from the subpool
+                        let removed_from_subpool = $this.$pool.truncate_pool($this.config.$limit.clone());
+
+                        trace!(
+                            target: "txpool",
+                            "removed {} transactions from {}, limit: {:?}, curr size: {}, curr len: {}",
+                            removed_from_subpool.len(),
+                            stringify!($pool),
+                            $this.config.$limit,
+                            $this.$pool.size(),
+                            $this.$pool.len()
+                        );
+                        $this.metrics.$metric.increment(removed_from_subpool.len() as u64);
+
+                        // 2. remove all transactions from the total set
+                        for tx in removed_from_subpool {
+                            $this.all_transactions.remove_transaction(tx.id());
+
+                            let id = *tx.id();
+
+                            // keep track of removed transaction
+                            removed.push(tx);
+
+                            // 3. remove all its descendants from the entire pool
+                            $this.remove_descendants(&id, &mut $removed);
+                        }
+                    }
+
+                )*
+            };
+        }
+
+        discard_worst!(
+            self, removed, [
+                pending_limit => (pending_pool, pending_transactions_evicted),
+                basefee_limit => (basefee_pool, basefee_transactions_evicted),
+                blob_limit    => (blob_pool, blob_transactions_evicted),
+                queued_limit  => (queued_pool, queued_transactions_evicted),
+            ]
+        );
+
+        removed
+    }
+
+    /// Number of transactions in the entire pool
+    pub(crate) fn len(&self) -> usize {
+        self.all_transactions.len()
+    }
+
+    /// Whether the pool is empty
+    pub(crate) fn is_empty(&self) -> bool {
+        self.all_transactions.is_empty()
+    }
+
+    /// Asserts all invariants of the  pool's:
+    ///
+    ///  - All maps are bijections (`by_id`, `by_hash`)
+    ///  - Total size is equal to the sum of all sub-pools
+    ///
+    /// # Panics
+    /// if any invariant is violated
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn assert_invariants(&self) {
+        let size = self.size();
+        let actual = size.basefee + size.pending + size.queued + size.blob;
+        assert_eq!(
+            size.total, actual,
+            "total size must be equal to the sum of all sub-pools, basefee:{}, pending:{}, queued:{}, blob:{}",
+            size.basefee, size.pending, size.queued, size.blob
+        );
+        self.all_transactions.assert_invariants();
+        self.pending_pool.assert_invariants();
+        self.basefee_pool.assert_invariants();
+        self.queued_pool.assert_invariants();
+        self.blob_pool.assert_invariants();
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl TxPool<crate::test_utils::MockOrdering> {
+    /// Creates a mock instance for testing.
+    pub fn mock() -> Self {
+        Self::new(crate::test_utils::MockOrdering::default(), PoolConfig::default())
+    }
+}
+
+#[cfg(test)]
+impl<T: TransactionOrdering> Drop for TxPool<T> {
+    fn drop(&mut self) {
+        self.assert_invariants();
+    }
+}
+
+impl<T: TransactionOrdering> TxPool<T> {
+    /// Pending subpool
+    pub const fn pending(&self) -> &PendingPool<T> {
+        &self.pending_pool
+    }
+
+    /// Base fee subpool
+    pub const fn base_fee(&self) -> &ParkedPool<BasefeeOrd<T::Transaction>> {
+        &self.basefee_pool
+    }
+
+    /// Queued sub pool
+    pub const fn queued(&self) -> &ParkedPool<QueuedOrd<T::Transaction>> {
+        &self.queued_pool
+    }
+}
+
+impl<T: TransactionOrdering> fmt::Debug for TxPool<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TxPool").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+/// Container for _all_ transaction in the pool.
+///
+/// This is the sole entrypoint that's guarding all sub-pools, all sub-pool actions are always
+/// derived from this set. Updates returned from this type must be applied to the sub-pools.
+pub(crate) struct AllTransactions<T: PoolTransaction> {
+    /// Minimum base fee required by the protocol.
+    ///
+    /// Transactions with a lower base fee will never be included by the chain
+    minimal_protocol_basefee: u64,
+    /// The max gas limit of the block
+    block_gas_limit: u64,
+    /// Max number of executable transaction slots guaranteed per account
+    max_account_slots: usize,
+    /// _All_ transactions identified by their hash.
+    by_hash: B256Map<Arc<ValidPoolTransaction<T>>>,
+    /// _All_ transaction in the pool sorted by their sender and nonce pair.
+    txs: BTreeMap<TransactionId, PoolInternalTransaction<T>>,
+    /// Contains the currently known information about the senders.
+    sender_info: FxHashMap<SenderId, SenderInfo>,
+    /// Tracks the number of transactions by sender that are currently in the pool.
+    tx_counter: FxHashMap<SenderId, usize>,
+    /// The current block number the pool keeps track of.
+    last_seen_block_number: u64,
+    /// The current block hash the pool keeps track of.
+    last_seen_block_hash: B256,
+    /// Expected blob and base fee for the pending block.
+    pending_fees: PendingFees,
+    /// Configured price bump settings for replacements
+    price_bumps: PriceBumpConfig,
+    /// How to handle [`TransactionOrigin::Local`](crate::TransactionOrigin) transactions.
+    local_transactions_config: LocalTransactionConfig,
+    /// All accounts with a pooled authorization
+    auths: FxHashMap<SenderId, B256Set>,
+    /// All Transactions metrics
+    metrics: AllTransactionsMetrics,
+}
+
+impl<T: PoolTransaction> AllTransactions<T> {
+    /// Create a new instance
+    fn new(config: &PoolConfig) -> Self {
+        Self {
+            max_account_slots: config.max_account_slots,
+            price_bumps: config.price_bumps,
+            local_transactions_config: config.local_transactions_config.clone(),
+            minimal_protocol_basefee: config.minimal_protocol_basefee,
+            block_gas_limit: config.gas_limit,
+            ..Default::default()
+        }
+    }
+
+    /// Returns an iterator over all _unique_ hashes in the pool
+    #[expect(dead_code)]
+    pub(crate) fn hashes_iter(&self) -> impl Iterator<Item = TxHash> + '_ {
+        self.by_hash.keys().copied()
+    }
+
+    /// Returns an iterator over all transactions in the pool
+    pub(crate) fn transactions_iter(
+        &self,
+    ) -> impl Iterator<Item = &Arc<ValidPoolTransaction<T>>> + '_ {
+        self.by_hash.values()
+    }
+
+    /// Returns if the transaction for the given hash is already included in this pool
+    pub(crate) fn contains(&self, tx_hash: &TxHash) -> bool {
+        self.by_hash.contains_key(tx_hash)
+    }
+
+    /// Returns the internal transaction with additional metadata
+    pub(crate) fn get(&self, id: &TransactionId) -> Option<&PoolInternalTransaction<T>> {
+        self.txs.get(id)
+    }
+
+    /// Increments the transaction counter for the sender
+    pub(crate) fn tx_inc(&mut self, sender: SenderId) {
+        let count = self.tx_counter.entry(sender).or_default();
+        *count += 1;
+        self.metrics.all_transactions_by_all_senders.increment(1.0);
+    }
+
+    /// Decrements the transaction counter for the sender
+    pub(crate) fn tx_decr(&mut self, sender: SenderId) {
+        if let hash_map::Entry::Occupied(mut entry) = self.tx_counter.entry(sender) {
+            let count = entry.get_mut();
+            if *count == 1 {
+                entry.remove();
+                self.sender_info.remove(&sender);
+                self.metrics.all_transactions_by_all_senders.decrement(1.0);
+                return
+            }
+            *count -= 1;
+            self.metrics.all_transactions_by_all_senders.decrement(1.0);
+        }
+    }
+
+    /// Updates the block specific info
+    fn set_block_info(&mut self, block_info: BlockInfo) {
+        let BlockInfo {
+            block_gas_limit,
+            last_seen_block_hash,
+            last_seen_block_number,
+            pending_basefee,
+            pending_blob_fee,
+        } = block_info;
+        self.last_seen_block_number = last_seen_block_number;
+        self.last_seen_block_hash = last_seen_block_hash;
+
+        self.pending_fees.base_fee = pending_basefee;
+        self.metrics.base_fee.set(pending_basefee as f64);
+
+        self.block_gas_limit = block_gas_limit;
+
+        if let Some(pending_blob_fee) = pending_blob_fee {
+            self.pending_fees.blob_fee = pending_blob_fee;
+            self.metrics.blob_base_fee.set(pending_blob_fee as f64);
+        }
+    }
+
+    /// Updates the size metrics
+    pub(crate) fn update_size_metrics(&self) {
+        self.metrics.all_transactions_by_hash.set(self.by_hash.len() as f64);
+        self.metrics.all_transactions_by_id.set(self.txs.len() as f64);
+    }
+
+    /// Rechecks all transactions in the pool against the changes.
+    ///
+    /// Possible changes are:
+    ///
+    /// For all transactions:
+    ///   - decreased basefee: promotes from `basefee` to `pending` sub-pool.
+    ///   - increased basefee: demotes from `pending` to `basefee` sub-pool.
+    ///
+    /// Individually:
+    ///   - decreased sender allowance: demote from (`basefee`|`pending`) to `queued`.
+    ///   - increased sender allowance: promote from `queued` to
+    ///       - `pending` if basefee condition is met.
+    ///       - `basefee` if basefee condition is _not_ met.
+    ///
+    /// Additionally, this will also update the `cumulative_gas_used` for transactions of a sender
+    /// that got transaction included in the block.
+    pub(crate) fn update(
+        &mut self,
+        changed_accounts: &FxHashMap<SenderId, SenderInfo>,
+    ) -> Vec<PoolUpdate> {
+        // pre-allocate a few updates
+        let mut updates = Vec::with_capacity(64);
+
+        let mut iter = self.txs.iter_mut().peekable();
+
+        // Loop over all individual senders and update all affected transactions.
+        // One sender may have up to `max_account_slots` transactions here, which means, worst case
+        // `max_accounts_slots` need to be updated, for example if the first transaction is blocked
+        // due to too low base fee.
+        // However, we don't have to necessarily check every transaction of a sender. If no updates
+        // are possible (nonce gap) then we can skip to the next sender.
+
+        // The `unique_sender` loop will process the first transaction of all senders, update its
+        // state and internally update all consecutive transactions
+        'transactions: while let Some((id, tx)) = iter.next() {
+            macro_rules! next_sender {
+                ($iter:ident) => {
+                    'this: while let Some((peek, _)) = iter.peek() {
+                        if peek.sender != id.sender {
+                            break 'this
+                        }
+                        iter.next();
+                    }
+                };
+            }
+
+            // track the balance if the sender was changed in the block
+            // check if this is a changed account
+            let changed_balance = if let Some(info) = changed_accounts.get(&id.sender) {
+                // discard all transactions with a nonce lower than the current state nonce
+                if id.nonce < info.state_nonce {
+                    updates.push(PoolUpdate {
+                        id: *tx.transaction.id(),
+                        current: tx.subpool,
+                        destination: Destination::Discard,
+                    });
+                    continue 'transactions
+                }
+
+                let ancestor = TransactionId::ancestor(id.nonce, info.state_nonce, id.sender);
+                // If there's no ancestor then this is the next transaction.
+                if ancestor.is_none() {
+                    tx.state.insert(TxState::NO_NONCE_GAPS);
+                    tx.state.insert(TxState::NO_PARKED_ANCESTORS);
+                    tx.cumulative_cost = U256::ZERO;
+                    if *tx.transaction.cost() + tx.transaction.extra_balance_cost() >
+                        info.balance
+                    {
+                        // sender lacks sufficient funds to pay for this transaction
+                        tx.state.remove(TxState::ENOUGH_BALANCE);
+                    } else {
+                        tx.state.insert(TxState::ENOUGH_BALANCE);
+                    }
+                }
+
+                Some(&info.balance)
+            } else {
+                None
+            };
+
+            // If there's a nonce gap, we can shortcircuit, because there's nothing to update yet.
+            if tx.state.has_nonce_gap() {
+                next_sender!(iter);
+                continue 'transactions
+            }
+
+            // Since this is the first transaction of the sender, it has no parked ancestors
+            tx.state.insert(TxState::NO_PARKED_ANCESTORS);
+
+            // Update the first transaction of this sender.
+            Self::update_tx_base_fee(self.pending_fees.base_fee, tx);
+            // Track if the transaction's sub-pool changed.
+            Self::record_subpool_update(&mut updates, tx);
+
+            // Track blocking transactions.
+            let mut has_parked_ancestor = !tx.state.is_pending();
+
+            let mut cumulative_cost = tx.next_cumulative_cost();
+
+            // the next expected nonce after this transaction: nonce + 1
+            let mut next_nonce_in_line = tx.transaction.nonce().saturating_add(1);
+
+            // Update all consecutive transaction of this sender
+            while let Some((peek, tx)) = iter.peek_mut() {
+                if peek.sender != id.sender {
+                    // Found the next sender we need to check
+                    continue 'transactions
+                }
+
+                if tx.transaction.nonce() == next_nonce_in_line {
+                    // no longer nonce gapped
+                    tx.state.insert(TxState::NO_NONCE_GAPS);
+                } else {
+                    // can short circuit if there's still a nonce gap
+                    next_sender!(iter);
+                    continue 'transactions
+                }
+
+                // update for next iteration of this sender's loop
+                next_nonce_in_line = next_nonce_in_line.saturating_add(1);
+
+                // update cumulative cost
+                tx.cumulative_cost = cumulative_cost;
+                // Update for next transaction
+                cumulative_cost = tx.next_cumulative_cost();
+
+                // If the account changed in the block, check the balance.
+                if let Some(changed_balance) = changed_balance {
+                    if &cumulative_cost > changed_balance {
+                        // sender lacks sufficient funds to pay for this transaction
+                        tx.state.remove(TxState::ENOUGH_BALANCE);
+                    } else {
+                        tx.state.insert(TxState::ENOUGH_BALANCE);
+                    }
+                }
+
+                // Update ancestor condition.
+                if has_parked_ancestor {
+                    tx.state.remove(TxState::NO_PARKED_ANCESTORS);
+                } else {
+                    tx.state.insert(TxState::NO_PARKED_ANCESTORS);
+                }
+                has_parked_ancestor = !tx.state.is_pending();
+
+                // Update and record sub-pool changes.
+                Self::update_tx_base_fee(self.pending_fees.base_fee, tx);
+                Self::record_subpool_update(&mut updates, tx);
+
+                // Advance iterator
+                iter.next();
+            }
+        }
+
+        updates
+    }
+
+    /// This will update the transaction's `subpool` based on its state.
+    ///
+    /// If the sub-pool derived from the state differs from the current pool, it will record a
+    /// `PoolUpdate` for this transaction to move it to the new sub-pool.
+    fn record_subpool_update(updates: &mut Vec<PoolUpdate>, tx: &mut PoolInternalTransaction<T>) {
+        let current_pool = tx.subpool;
+        tx.subpool = tx.state.into();
+        if current_pool != tx.subpool {
+            updates.push(PoolUpdate {
+                id: *tx.transaction.id(),
+                current: current_pool,
+                destination: tx.subpool.into(),
+            })
+        }
+    }
+
+    /// Rechecks the transaction's dynamic fee condition.
+    fn update_tx_base_fee(pending_block_base_fee: u64, tx: &mut PoolInternalTransaction<T>) {
+        // Recheck dynamic fee condition.
+        match tx.transaction.max_fee_per_gas().cmp(&(pending_block_base_fee as u128)) {
+            Ordering::Greater | Ordering::Equal => {
+                tx.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+            }
+            Ordering::Less => {
+                tx.state.remove(TxState::ENOUGH_FEE_CAP_BLOCK);
+            }
+        }
+    }
+
+    /// Returns an iterator over all transactions for the given sender, starting with the lowest
+    /// nonce
+    pub(crate) fn txs_iter(
+        &self,
+        sender: SenderId,
+    ) -> impl Iterator<Item = (&TransactionId, &PoolInternalTransaction<T>)> + '_ {
+        self.txs
+            .range((sender.start_bound(), Unbounded))
+            .take_while(move |(other, _)| sender == other.sender)
+    }
+
+    /// Returns a mutable iterator over all transactions for the given sender, starting with the
+    /// lowest nonce
+    #[cfg(test)]
+    #[expect(dead_code)]
+    pub(crate) fn txs_iter_mut(
+        &mut self,
+        sender: SenderId,
+    ) -> impl Iterator<Item = (&TransactionId, &mut PoolInternalTransaction<T>)> + '_ {
+        self.txs
+            .range_mut((sender.start_bound(), Unbounded))
+            .take_while(move |(other, _)| sender == other.sender)
+    }
+
+    /// Returns all transactions that _follow_ after the given id and have the same sender.
+    ///
+    /// NOTE: The range is _exclusive_
+    pub(crate) fn descendant_txs_exclusive<'a, 'b: 'a>(
+        &'a self,
+        id: &'b TransactionId,
+    ) -> impl Iterator<Item = (&'a TransactionId, &'a PoolInternalTransaction<T>)> + 'a {
+        self.txs.range((Excluded(id), Unbounded)).take_while(|(other, _)| id.sender == other.sender)
+    }
+
+    /// Returns all transactions that _follow_ after the given id but have the same sender.
+    ///
+    /// NOTE: The range is _inclusive_: if the transaction that belongs to `id` it will be the
+    /// first value.
+    pub(crate) fn descendant_txs_inclusive<'a, 'b: 'a>(
+        &'a self,
+        id: &'b TransactionId,
+    ) -> impl Iterator<Item = (&'a TransactionId, &'a PoolInternalTransaction<T>)> + 'a {
+        self.txs.range(id..).take_while(|(other, _)| id.sender == other.sender)
+    }
+
+    /// Returns all mutable transactions that _follow_ after the given id but have the same sender.
+    ///
+    /// NOTE: The range is _inclusive_: if the transaction that belongs to `id` it field be the
+    /// first value.
+    pub(crate) fn descendant_txs_mut<'a, 'b: 'a>(
+        &'a mut self,
+        id: &'b TransactionId,
+    ) -> impl Iterator<Item = (&'a TransactionId, &'a mut PoolInternalTransaction<T>)> + 'a {
+        self.txs.range_mut(id..).take_while(|(other, _)| id.sender == other.sender)
+    }
+
+    /// Removes a transaction from the set using its hash.
+    pub(crate) fn remove_transaction_by_hash(
+        &mut self,
+        tx_hash: &B256,
+    ) -> Option<(Arc<ValidPoolTransaction<T>>, SubPool)> {
+        let tx = self.by_hash.remove(tx_hash)?;
+        let internal = self.txs.remove(&tx.transaction_id)?;
+        self.remove_auths(&internal);
+        // decrement the counter for the sender.
+        self.tx_decr(tx.sender_id());
+        Some((tx, internal.subpool))
+    }
+
+    /// Removes a transaction from the set using its id.
+    ///
+    /// This is intended for processing updates after state changes.
+    pub(crate) fn remove_transaction_by_id(
+        &mut self,
+        tx_id: &TransactionId,
+    ) -> Option<(Arc<ValidPoolTransaction<T>>, SubPool)> {
+        let internal = self.txs.remove(tx_id)?;
+        let tx = self.by_hash.remove(internal.transaction.hash())?;
+        self.remove_auths(&internal);
+        // decrement the counter for the sender.
+        self.tx_decr(tx.sender_id());
+        Some((tx, internal.subpool))
+    }
+
+    /// If a tx is removed (_not_ mined), all descendants are set to parked due to the nonce gap
+    pub(crate) fn park_descendant_transactions(
+        &mut self,
+        tx_id: &TransactionId,
+    ) -> Vec<PoolUpdate> {
+        let mut updates = Vec::new();
+
+        for (id, tx) in self.descendant_txs_mut(tx_id) {
+            let current_pool = tx.subpool;
+
+            tx.state.remove(TxState::NO_NONCE_GAPS);
+
+            // update the pool based on the state.
+            tx.subpool = tx.state.into();
+
+            // check if anything changed.
+            if current_pool != tx.subpool {
+                updates.push(PoolUpdate {
+                    id: *id,
+                    current: current_pool,
+                    destination: tx.subpool.into(),
+                })
+            }
+        }
+
+        updates
+    }
+
+    /// Removes a transaction from the set.
+    ///
+    /// This will _not_ trigger additional updates, because descendants without nonce gaps are
+    /// already in the pending pool, and this transaction will be the first transaction of the
+    /// sender in this pool.
+    pub(crate) fn remove_transaction(
+        &mut self,
+        id: &TransactionId,
+    ) -> Option<(Arc<ValidPoolTransaction<T>>, SubPool)> {
+        let internal = self.txs.remove(id)?;
+
+        // decrement the counter for the sender.
+        self.tx_decr(internal.transaction.sender_id());
+
+        let result =
+            self.by_hash.remove(internal.transaction.hash()).map(|tx| (tx, internal.subpool));
+
+        self.remove_auths(&internal);
+
+        result
+    }
+
+    /// Removes any pending auths for the given transaction.
+    ///
+    /// This is a noop for non EIP-7702 transactions.
+    fn remove_auths(&mut self, tx: &PoolInternalTransaction<T>) {
+        let Some(auths) = &tx.transaction.authority_ids else { return };
+
+        let tx_hash = tx.transaction.hash();
+        for auth in auths {
+            if let Some(list) = self.auths.get_mut(auth) {
+                list.remove(tx_hash);
+                if list.is_empty() {
+                    self.auths.remove(auth);
+                }
+            }
+        }
+    }
+
+    /// Checks if the given transaction's type conflicts with an existing transaction.
+    ///
+    /// See also [`ValidPoolTransaction::tx_type_conflicts_with`].
+    ///
+    /// Caution: This assumes that mutually exclusive invariant is always true for the same sender.
+    #[inline]
+    fn contains_conflicting_transaction(&self, tx: &ValidPoolTransaction<T>) -> bool {
+        self.txs_iter(tx.transaction_id.sender)
+            .next()
+            .is_some_and(|(_, existing)| tx.tx_type_conflicts_with(&existing.transaction))
+    }
+
+    /// Additional checks for a new transaction.
+    ///
+    /// This will enforce all additional rules in the context of this pool, such as:
+    ///   - Spam protection: reject new non-local transaction from a sender that exhausted its slot
+    ///     capacity.
+    ///   - Gas limit: reject transactions if they exceed a block's maximum gas.
+    ///   - Ensures transaction types are not conflicting for the sender: blob vs normal
+    ///     transactions are mutually exclusive for the same sender.
+    fn ensure_valid(
+        &self,
+        transaction: ValidPoolTransaction<T>,
+        on_chain_nonce: u64,
+    ) -> Result<ValidPoolTransaction<T>, InsertErr<T>> {
+        if !self.local_transactions_config.is_local(transaction.origin, transaction.sender_ref()) {
+            let current_txs =
+                self.tx_counter.get(&transaction.sender_id()).copied().unwrap_or_default();
+
+            // Reject transactions if sender's capacity is exceeded.
+            // If transaction's nonce matches on-chain nonce always let it through
+            if current_txs >= self.max_account_slots && transaction.nonce() > on_chain_nonce {
+                return Err(InsertErr::ExceededSenderTransactionsCapacity {
+                    transaction: Arc::new(transaction),
+                })
+            }
+        }
+        if transaction.gas_limit() > self.block_gas_limit {
+            return Err(InsertErr::TxGasLimitMoreThanAvailableBlockGas {
+                block_gas_limit: self.block_gas_limit,
+                tx_gas_limit: transaction.gas_limit(),
+                transaction: Arc::new(transaction),
+            })
+        }
+
+        if self.contains_conflicting_transaction(&transaction) {
+            // blob vs non blob transactions are mutually exclusive for the same sender
+            return Err(InsertErr::TxTypeConflict { transaction: Arc::new(transaction) })
+        }
+
+        Ok(transaction)
+    }
+
+    /// Enforces additional constraints for blob transactions before attempting to insert:
+    ///    - new blob transactions must not have any nonce gaps
+    ///    - blob transactions cannot go into overdraft
+    ///    - replacement blob transaction with a higher fee must not shift an already propagated
+    ///      descending blob transaction into overdraft
+    fn ensure_valid_blob_transaction(
+        &self,
+        new_blob_tx: ValidPoolTransaction<T>,
+        on_chain_balance: U256,
+        ancestor: Option<TransactionId>,
+    ) -> Result<ValidPoolTransaction<T>, InsertErr<T>> {
+        if let Some(ancestor) = ancestor {
+            let Some(ancestor_tx) = self.txs.get(&ancestor) else {
+                // ancestor tx is missing, so we can't insert the new blob
+                self.metrics.blob_transactions_nonce_gaps.increment(1);
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+            };
+            if ancestor_tx.state.has_nonce_gap() {
+                // the ancestor transaction already has a nonce gap, so we can't insert the new
+                // blob
+                self.metrics.blob_transactions_nonce_gaps.increment(1);
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+            }
+
+            // the max cost executing this transaction requires
+            let mut cumulative_cost = ancestor_tx.next_cumulative_cost() +
+                new_blob_tx.cost() +
+                new_blob_tx.extra_balance_cost();
+
+            // check if the new blob would go into overdraft
+            if cumulative_cost > on_chain_balance {
+                // the transaction would go into overdraft
+                return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+            }
+
+            // ensure that a replacement would not shift already propagated blob transactions into
+            // overdraft
+            let id = new_blob_tx.transaction_id;
+            let mut descendants = self.descendant_txs_inclusive(&id).peekable();
+            if let Some((maybe_replacement, _)) = descendants.peek() &&
+                **maybe_replacement == new_blob_tx.transaction_id
+            {
+                // replacement transaction
+                descendants.next();
+
+                // check if any of descendant blob transactions should be shifted into overdraft
+                for (_, tx) in descendants {
+                    cumulative_cost += *tx.transaction.cost() + tx.transaction.extra_balance_cost();
+                    if tx.transaction.is_eip4844() && cumulative_cost > on_chain_balance {
+                        // the transaction would shift
+                        return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+                    }
+                }
+            }
+        } else if *new_blob_tx.cost() + new_blob_tx.extra_balance_cost() > on_chain_balance {
+            // the transaction would go into overdraft
+            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+        }
+
+        Ok(new_blob_tx)
+    }
+
+    /// Inserts a new _valid_ transaction into the pool.
+    ///
+    /// If the transaction already exists, it will be replaced if not underpriced.
+    /// Returns info to which sub-pool the transaction should be moved.
+    /// Also returns a set of pool updates triggered by this insert, that need to be handled by the
+    /// caller.
+    ///
+    /// These can include:
+    ///      - closing nonce gaps of descendant transactions
+    ///      - enough balance updates
+    ///
+    /// Note: For EIP-4844 blob transactions additional constraints are enforced:
+    ///      - new blob transactions must not have any nonce gaps
+    ///      - blob transactions cannot go into overdraft
+    ///
+    /// ## Transaction type Exclusivity
+    ///
+    /// The pool enforces exclusivity of eip-4844 blob vs non-blob transactions on a per sender
+    /// basis:
+    ///  - If the pool already includes a blob transaction from the `transaction`'s sender, then the
+    ///    `transaction` must also be a blob transaction
+    ///  - If the pool already includes a non-blob transaction from the `transaction`'s sender, then
+    ///    the `transaction` must _not_ be a blob transaction.
+    ///
+    /// In other words, the presence of blob transactions exclude non-blob transactions and vice
+    /// versa.
+    ///
+    /// ## Replacements
+    ///
+    /// The replacement candidate must satisfy given price bump constraints: replacement candidate
+    /// must not be underpriced
+    pub(crate) fn insert_tx(
+        &mut self,
+        transaction: ValidPoolTransaction<T>,
+        on_chain_balance: U256,
+        on_chain_nonce: u64,
+    ) -> InsertResult<T> {
+        assert!(on_chain_nonce <= transaction.nonce(), "Invalid transaction");
+
+        let mut transaction = self.ensure_valid(transaction, on_chain_nonce)?;
+
+        let inserted_tx_id = *transaction.id();
+        let mut state = TxState::default();
+        let mut cumulative_cost = U256::ZERO;
+        let mut updates = Vec::new();
+
+        // Current tx does not exceed block gas limit after ensure_valid check
+        state.insert(TxState::NOT_TOO_MUCH_GAS);
+
+        // identifier of the ancestor transaction, will be None if the transaction is the next tx of
+        // the sender
+        let ancestor = TransactionId::ancestor(
+            transaction.transaction.nonce(),
+            on_chain_nonce,
+            inserted_tx_id.sender,
+        );
+
+        // before attempting to insert a blob transaction, we need to ensure that additional
+        // constraints are met that only apply to blob transactions
+        if transaction.is_eip4844() {
+            state.insert(TxState::BLOB_TRANSACTION);
+
+            transaction =
+                self.ensure_valid_blob_transaction(transaction, on_chain_balance, ancestor)?;
+            let blob_fee_cap = transaction.transaction.max_fee_per_blob_gas().unwrap_or_default();
+            if blob_fee_cap >= self.pending_fees.blob_fee {
+                state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+            }
+        } else {
+            // Non-EIP4844 transaction always satisfy the blob fee cap condition
+            state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+        }
+
+        let transaction = Arc::new(transaction);
+
+        // If there's no ancestor tx then this is the next transaction.
+        if ancestor.is_none() {
+            state.insert(TxState::NO_NONCE_GAPS);
+            state.insert(TxState::NO_PARKED_ANCESTORS);
+        }
+
+        // Check dynamic fee
+        let fee_cap = transaction.max_fee_per_gas();
+
+        if fee_cap < self.minimal_protocol_basefee as u128 {
+            return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap })
+        }
+        if fee_cap >= self.pending_fees.base_fee as u128 {
+            state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+        }
+
+        // placeholder for the replaced transaction, if any
+        let mut replaced_tx = None;
+
+        let pool_tx = PoolInternalTransaction {
+            transaction: Arc::clone(&transaction),
+            subpool: state.into(),
+            state,
+            cumulative_cost,
+        };
+
+        // try to insert the transaction
+        match self.txs.entry(*transaction.id()) {
+            Entry::Vacant(entry) => {
+                // Insert the transaction in both maps
+                self.by_hash.insert(*pool_tx.transaction.hash(), pool_tx.transaction.clone());
+                entry.insert(pool_tx);
+            }
+            Entry::Occupied(mut entry) => {
+                // Transaction with the same nonce already exists: replacement candidate
+                let existing_transaction = entry.get().transaction.as_ref();
+                let maybe_replacement = transaction.as_ref();
+
+                // Ensure the new transaction is not underpriced
+                if existing_transaction.is_underpriced(maybe_replacement, &self.price_bumps) {
+                    return Err(InsertErr::Underpriced {
+                        transaction: pool_tx.transaction,
+                        existing: *entry.get().transaction.hash(),
+                    })
+                }
+                let new_hash = *pool_tx.transaction.hash();
+                let new_transaction = pool_tx.transaction.clone();
+                let replaced = entry.insert(pool_tx);
+                self.by_hash.remove(replaced.transaction.hash());
+                self.by_hash.insert(new_hash, new_transaction);
+
+                self.remove_auths(&replaced);
+
+                // also remove the hash
+                replaced_tx = Some((replaced.transaction, replaced.subpool));
+            }
+        }
+
+        if let Some(auths) = &transaction.authority_ids {
+            let tx_hash = transaction.hash();
+            for auth in auths {
+                self.auths.entry(*auth).or_default().insert(*tx_hash);
+            }
+        }
+
+        // The next transaction of this sender
+        let on_chain_id = TransactionId::new(transaction.sender_id(), on_chain_nonce);
+        {
+            // Tracks the next nonce we expect if the transactions are gapless
+            let mut next_nonce = on_chain_id.nonce;
+
+            // We need to find out if the next transaction of the sender is considered pending
+            // The direct descendant has _no_ parked ancestors because the `on_chain_nonce` is
+            // pending, so we can set this to `false`
+            let mut has_parked_ancestor = false;
+
+            // Traverse all future transactions of the sender starting with the on chain nonce, and
+            // update existing transactions: `[on_chain_nonce,..]`
+            for (id, tx) in self.descendant_txs_mut(&on_chain_id) {
+                let current_pool = tx.subpool;
+
+                // If there's a nonce gap, we can shortcircuit
+                if next_nonce != id.nonce {
+                    break
+                }
+
+                // close the nonce gap
+                tx.state.insert(TxState::NO_NONCE_GAPS);
+
+                // set cumulative cost
+                tx.cumulative_cost = cumulative_cost;
+
+                // Update for next transaction
+                cumulative_cost = tx.next_cumulative_cost();
+
+                if cumulative_cost > on_chain_balance {
+                    // sender lacks sufficient funds to pay for this transaction
+                    tx.state.remove(TxState::ENOUGH_BALANCE);
+                } else {
+                    tx.state.insert(TxState::ENOUGH_BALANCE);
+                }
+
+                // Update ancestor condition.
+                if has_parked_ancestor {
+                    tx.state.remove(TxState::NO_PARKED_ANCESTORS);
+                } else {
+                    tx.state.insert(TxState::NO_PARKED_ANCESTORS);
+                }
+                has_parked_ancestor = !tx.state.is_pending();
+
+                // update the pool based on the state
+                tx.subpool = tx.state.into();
+
+                if inserted_tx_id.eq(id) {
+                    // if it is the new transaction, track its updated state
+                    state = tx.state;
+                } else {
+                    // check if anything changed
+                    if current_pool != tx.subpool {
+                        updates.push(PoolUpdate {
+                            id: *id,
+                            current: current_pool,
+                            destination: tx.subpool.into(),
+                        })
+                    }
+                }
+
+                // increment for next iteration
+                next_nonce = id.next_nonce();
+            }
+        }
+
+        // If this wasn't a replacement transaction we need to update the counter.
+        if replaced_tx.is_none() {
+            self.tx_inc(inserted_tx_id.sender);
+        }
+
+        self.update_size_metrics();
+
+        Ok(InsertOk { transaction, move_to: state.into(), state, replaced_tx, updates })
+    }
+
+    /// Number of transactions in the entire pool
+    pub(crate) fn len(&self) -> usize {
+        self.txs.len()
+    }
+
+    /// Whether the pool is empty
+    pub(crate) fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
+
+    /// Asserts that the bijection between `by_hash` and `txs` is valid.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub(crate) fn assert_invariants(&self) {
+        assert_eq!(self.by_hash.len(), self.txs.len(), "by_hash.len() != txs.len()");
+        assert!(self.auths.len() <= self.txs.len(), "auths.len() > txs.len()");
+    }
+}
+
+#[cfg(test)]
+impl<T: PoolTransaction> AllTransactions<T> {
+    /// This function retrieves the number of transactions stored in the pool for a specific sender.
+    ///
+    /// If there are no transactions for the given sender, it returns zero by default.
+    pub(crate) fn tx_count(&self, sender: SenderId) -> usize {
+        self.tx_counter.get(&sender).copied().unwrap_or_default()
+    }
+}
+
+impl<T: PoolTransaction> Default for AllTransactions<T> {
+    fn default() -> Self {
+        Self {
+            max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            by_hash: Default::default(),
+            txs: Default::default(),
+            sender_info: Default::default(),
+            tx_counter: Default::default(),
+            last_seen_block_number: Default::default(),
+            last_seen_block_hash: Default::default(),
+            pending_fees: Default::default(),
+            price_bumps: Default::default(),
+            local_transactions_config: Default::default(),
+            auths: Default::default(),
+            metrics: Default::default(),
+        }
+    }
+}
+
+/// Represents updated fees for the pending block.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingFees {
+    /// The pending base fee
+    pub(crate) base_fee: u64,
+    /// The pending blob fee
+    pub(crate) blob_fee: u128,
+}
+
+impl Default for PendingFees {
+    fn default() -> Self {
+        Self { base_fee: Default::default(), blob_fee: BLOB_TX_MIN_BLOB_GASPRICE }
+    }
+}
+
+/// Result type for inserting a transaction
+pub(crate) type InsertResult<T> = Result<InsertOk<T>, InsertErr<T>>;
+
+/// Err variant of `InsertResult`
+#[derive(Debug)]
+pub(crate) enum InsertErr<T: PoolTransaction> {
+    /// Attempted to replace existing transaction, but was underpriced
+    Underpriced {
+        transaction: Arc<ValidPoolTransaction<T>>,
+        #[expect(dead_code)]
+        existing: TxHash,
+    },
+    /// Attempted to insert a blob transaction with a nonce gap
+    BlobTxHasNonceGap { transaction: Arc<ValidPoolTransaction<T>> },
+    /// Attempted to insert a transaction that would overdraft the sender's balance at the time of
+    /// insertion.
+    Overdraft { transaction: Arc<ValidPoolTransaction<T>> },
+    /// The transactions feeCap is lower than the chain's minimum fee requirement.
+    ///
+    /// See also [`MIN_PROTOCOL_BASE_FEE`]
+    FeeCapBelowMinimumProtocolFeeCap { transaction: Arc<ValidPoolTransaction<T>>, fee_cap: u128 },
+    /// Sender currently exceeds the configured limit for max account slots.
+    ///
+    /// The sender can be considered a spammer at this point.
+    ExceededSenderTransactionsCapacity { transaction: Arc<ValidPoolTransaction<T>> },
+    /// Transaction gas limit exceeds block's gas limit
+    TxGasLimitMoreThanAvailableBlockGas {
+        transaction: Arc<ValidPoolTransaction<T>>,
+        block_gas_limit: u64,
+        tx_gas_limit: u64,
+    },
+    /// Thrown if the mutual exclusivity constraint (blob vs normal transaction) is violated.
+    TxTypeConflict { transaction: Arc<ValidPoolTransaction<T>> },
+}
+
+/// Transaction was successfully inserted into the pool
+#[derive(Debug)]
+pub(crate) struct InsertOk<T: PoolTransaction> {
+    /// Ref to the inserted transaction.
+    transaction: Arc<ValidPoolTransaction<T>>,
+    /// Where to move the transaction to.
+    move_to: SubPool,
+    /// Current state of the inserted tx.
+    state: TxState,
+    /// The transaction that was replaced by this.
+    replaced_tx: Option<(Arc<ValidPoolTransaction<T>>, SubPool)>,
+    /// Additional updates to transactions affected by this change.
+    updates: Vec<PoolUpdate>,
+}
+
+/// The internal transaction typed used by `AllTransactions` which also additional info used for
+/// determining the current state of the transaction.
+#[derive(Debug)]
+pub(crate) struct PoolInternalTransaction<T: PoolTransaction> {
+    /// The actual transaction object.
+    pub(crate) transaction: Arc<ValidPoolTransaction<T>>,
+    /// The `SubPool` that currently contains this transaction.
+    pub(crate) subpool: SubPool,
+    /// Keeps track of the current state of the transaction and therefore in which subpool it
+    /// should reside
+    pub(crate) state: TxState,
+    /// The total cost all transactions before this transaction.
+    ///
+    /// This is the combined `cost` of all transactions from the same sender that currently
+    /// come before this transaction.
+    pub(crate) cumulative_cost: U256,
+}
+
+// === impl PoolInternalTransaction ===
+
+impl<T: PoolTransaction> PoolInternalTransaction<T> {
+    fn next_cumulative_cost(&self) -> U256 {
+        // [MANTLE PATCH] + extra_balance_cost (L1 + operator fee)
+        self.cumulative_cost + self.transaction.cost() + self.transaction.extra_balance_cost()
+    }
+}
+
+/// Stores relevant context about a sender.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SenderInfo {
+    /// current nonce of the sender.
+    pub(crate) state_nonce: u64,
+    /// Balance of the sender at the current point.
+    pub(crate) balance: U256,
+}
+
+// === impl SenderInfo ===
+
+impl SenderInfo {
+    /// Updates the info with the new values.
+    const fn update(&mut self, state_nonce: u64, balance: U256) {
+        *self = Self { state_nonce, balance };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_utils::{MockOrdering, MockTransaction, MockTransactionFactory, MockTransactionSet},
+        traits::TransactionOrigin,
+        SubPoolLimit,
+    };
+    use alloy_consensus::{Transaction, TxType};
+    use alloy_primitives::address;
+
+    #[test]
+    fn test_insert_blob() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+        let valid_tx = f.validated(tx);
+        let InsertOk { updates, replaced_tx, move_to, state, .. } =
+            pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(updates.is_empty());
+        assert!(replaced_tx.is_none());
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert!(state.contains(TxState::ENOUGH_BALANCE));
+        assert!(state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(move_to, SubPool::Pending);
+
+        let inserted = pool.txs.get(&valid_tx.transaction_id).unwrap();
+        assert_eq!(inserted.subpool, SubPool::Pending);
+    }
+
+    #[test]
+    fn test_insert_blob_not_enough_blob_fee() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions {
+            pending_fees: PendingFees { blob_fee: 10_000_000, ..Default::default() },
+            ..Default::default()
+        };
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+        pool.pending_fees.blob_fee = tx.max_fee_per_blob_gas().unwrap() + 1;
+        let valid_tx = f.validated(tx);
+        let InsertOk { state, .. } =
+            pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert!(!state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+
+        let _ = pool.txs.get(&valid_tx.transaction_id).unwrap();
+    }
+
+    #[test]
+    fn test_valid_tx_with_decreasing_blob_fee() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions {
+            pending_fees: PendingFees { blob_fee: 10_000_000, ..Default::default() },
+            ..Default::default()
+        };
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+
+        pool.pending_fees.blob_fee = tx.max_fee_per_blob_gas().unwrap() + 1;
+        let valid_tx = f.validated(tx.clone());
+        let InsertOk { state, .. } =
+            pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert!(!state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+
+        let _ = pool.txs.get(&valid_tx.transaction_id).unwrap();
+        pool.remove_transaction(&valid_tx.transaction_id);
+
+        pool.pending_fees.blob_fee = tx.max_fee_per_blob_gas().unwrap();
+        let InsertOk { state, .. } =
+            pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert!(state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn test_demote_valid_tx_with_increasing_blob_fee() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+
+        // set block info so the tx is initially underpriced w.r.t. blob fee
+        let mut block_info = pool.block_info();
+        block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap());
+        pool.set_block_info(block_info);
+
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        // assert pool lengths
+        assert!(pool.blob_pool.is_empty());
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        // check tx state and derived subpool
+        let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
+        assert!(internal_tx.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(internal_tx.subpool, SubPool::Pending);
+
+        // set block info so the pools are updated
+        block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap() + 1);
+        pool.set_block_info(block_info);
+
+        // check that the tx is promoted
+        let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
+        assert!(!internal_tx.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(internal_tx.subpool, SubPool::Blob);
+
+        // make sure the blob transaction was promoted into the pending pool
+        assert_eq!(pool.blob_pool.len(), 1);
+        assert!(pool.pending_pool.is_empty());
+    }
+
+    #[test]
+    fn test_promote_valid_tx_with_decreasing_blob_fee() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+
+        // set block info so the tx is initially underpriced w.r.t. blob fee
+        let mut block_info = pool.block_info();
+        block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap() + 1);
+        pool.set_block_info(block_info);
+
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        // assert pool lengths
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.blob_pool.len(), 1);
+
+        // check tx state and derived subpool
+        let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
+        assert!(!internal_tx.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(internal_tx.subpool, SubPool::Blob);
+
+        // set block info so the pools are updated
+        block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap());
+        pool.set_block_info(block_info);
+
+        // check that the tx is promoted
+        let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
+        assert!(internal_tx.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(internal_tx.subpool, SubPool::Pending);
+
+        // make sure the blob transaction was promoted into the pending pool
+        assert_eq!(pool.pending_pool.len(), 1);
+        assert!(pool.blob_pool.is_empty());
+    }
+
+    /// A struct representing a txpool promotion test instance
+    #[derive(Debug, PartialEq, Eq, Clone, Hash)]
+    struct PromotionTest {
+        /// The basefee at the start of the test
+        basefee: u64,
+        /// The blobfee at the start of the test
+        blobfee: u128,
+        /// The subpool at the start of the test
+        subpool: SubPool,
+        /// The basefee update
+        basefee_update: u64,
+        /// The blobfee update
+        blobfee_update: u128,
+        /// The subpool after the update
+        new_subpool: SubPool,
+    }
+
+    impl PromotionTest {
+        /// Returns the test case for the opposite update
+        const fn opposite(&self) -> Self {
+            Self {
+                basefee: self.basefee_update,
+                blobfee: self.blobfee_update,
+                subpool: self.new_subpool,
+                blobfee_update: self.blobfee,
+                basefee_update: self.basefee,
+                new_subpool: self.subpool,
+            }
+        }
+
+        fn assert_subpool_lengths<T: TransactionOrdering>(
+            &self,
+            pool: &TxPool<T>,
+            failure_message: String,
+            check_subpool: SubPool,
+        ) {
+            match check_subpool {
+                SubPool::Blob => {
+                    assert_eq!(pool.blob_pool.len(), 1, "{failure_message}");
+                    assert!(pool.pending_pool.is_empty(), "{failure_message}");
+                    assert!(pool.basefee_pool.is_empty(), "{failure_message}");
+                    assert!(pool.queued_pool.is_empty(), "{failure_message}");
+                }
+                SubPool::Pending => {
+                    assert!(pool.blob_pool.is_empty(), "{failure_message}");
+                    assert_eq!(pool.pending_pool.len(), 1, "{failure_message}");
+                    assert!(pool.basefee_pool.is_empty(), "{failure_message}");
+                    assert!(pool.queued_pool.is_empty(), "{failure_message}");
+                }
+                SubPool::BaseFee => {
+                    assert!(pool.blob_pool.is_empty(), "{failure_message}");
+                    assert!(pool.pending_pool.is_empty(), "{failure_message}");
+                    assert_eq!(pool.basefee_pool.len(), 1, "{failure_message}");
+                    assert!(pool.queued_pool.is_empty(), "{failure_message}");
+                }
+                SubPool::Queued => {
+                    assert!(pool.blob_pool.is_empty(), "{failure_message}");
+                    assert!(pool.pending_pool.is_empty(), "{failure_message}");
+                    assert!(pool.basefee_pool.is_empty(), "{failure_message}");
+                    assert_eq!(pool.queued_pool.len(), 1, "{failure_message}");
+                }
+            }
+        }
+
+        /// Runs an assertion on the provided pool, ensuring that the transaction is in the correct
+        /// subpool based on the starting condition of the test, assuming the pool contains only a
+        /// single transaction.
+        fn assert_single_tx_starting_subpool<T: TransactionOrdering>(&self, pool: &TxPool<T>) {
+            self.assert_subpool_lengths(
+                pool,
+                format!("pool length check failed at start of test: {self:?}"),
+                self.subpool,
+            );
+        }
+
+        /// Runs an assertion on the provided pool, ensuring that the transaction is in the correct
+        /// subpool based on the ending condition of the test, assuming the pool contains only a
+        /// single transaction.
+        fn assert_single_tx_ending_subpool<T: TransactionOrdering>(&self, pool: &TxPool<T>) {
+            self.assert_subpool_lengths(
+                pool,
+                format!("pool length check failed at end of test: {self:?}"),
+                self.new_subpool,
+            );
+        }
+    }
+
+    #[test]
+    fn test_promote_blob_tx_with_both_pending_fee_updates() {
+        // this exhaustively tests all possible promotion scenarios for a single transaction moving
+        // between the blob and pending pool
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+
+        let max_fee_per_blob_gas = tx.max_fee_per_blob_gas().unwrap();
+        let max_fee_per_gas = tx.max_fee_per_gas() as u64;
+
+        // These are all _promotion_ tests or idempotent tests.
+        let mut expected_promotions = vec![
+            PromotionTest {
+                blobfee: max_fee_per_blob_gas + 1,
+                basefee: max_fee_per_gas + 1,
+                subpool: SubPool::Blob,
+                blobfee_update: max_fee_per_blob_gas + 1,
+                basefee_update: max_fee_per_gas + 1,
+                new_subpool: SubPool::Blob,
+            },
+            PromotionTest {
+                blobfee: max_fee_per_blob_gas + 1,
+                basefee: max_fee_per_gas + 1,
+                subpool: SubPool::Blob,
+                blobfee_update: max_fee_per_blob_gas,
+                basefee_update: max_fee_per_gas + 1,
+                new_subpool: SubPool::Blob,
+            },
+            PromotionTest {
+                blobfee: max_fee_per_blob_gas + 1,
+                basefee: max_fee_per_gas + 1,
+                subpool: SubPool::Blob,
+                blobfee_update: max_fee_per_blob_gas + 1,
+                basefee_update: max_fee_per_gas,
+                new_subpool: SubPool::Blob,
+            },
+            PromotionTest {
+                blobfee: max_fee_per_blob_gas + 1,
+                basefee: max_fee_per_gas + 1,
+                subpool: SubPool::Blob,
+                blobfee_update: max_fee_per_blob_gas,
+                basefee_update: max_fee_per_gas,
+                new_subpool: SubPool::Pending,
+            },
+            PromotionTest {
+                blobfee: max_fee_per_blob_gas,
+                basefee: max_fee_per_gas + 1,
+                subpool: SubPool::Blob,
+                blobfee_update: max_fee_per_blob_gas,
+                basefee_update: max_fee_per_gas,
+                new_subpool: SubPool::Pending,
+            },
+            PromotionTest {
+                blobfee: max_fee_per_blob_gas + 1,
+                basefee: max_fee_per_gas,
+                subpool: SubPool::Blob,
+                blobfee_update: max_fee_per_blob_gas,
+                basefee_update: max_fee_per_gas,
+                new_subpool: SubPool::Pending,
+            },
+            PromotionTest {
+                blobfee: max_fee_per_blob_gas,
+                basefee: max_fee_per_gas,
+                subpool: SubPool::Pending,
+                blobfee_update: max_fee_per_blob_gas,
+                basefee_update: max_fee_per_gas,
+                new_subpool: SubPool::Pending,
+            },
+        ];
+
+        // extend the test cases with reversed updates - this will add all _demotion_ tests
+        let reversed = expected_promotions.iter().map(|test| test.opposite()).collect::<Vec<_>>();
+        expected_promotions.extend(reversed);
+
+        // dedup the test cases
+        let expected_promotions = expected_promotions.into_iter().collect::<HashSet<_>>();
+
+        for promotion_test in &expected_promotions {
+            let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+            // set block info so the tx is initially underpriced w.r.t. blob fee
+            let mut block_info = pool.block_info();
+
+            block_info.pending_blob_fee = Some(promotion_test.blobfee);
+            block_info.pending_basefee = promotion_test.basefee;
+            pool.set_block_info(block_info);
+
+            let validated = f.validated(tx.clone());
+            let id = *validated.id();
+            pool.add_transaction(validated, on_chain_balance, on_chain_nonce, None).unwrap();
+
+            // assert pool lengths
+            promotion_test.assert_single_tx_starting_subpool(&pool);
+
+            // check tx state and derived subpool, it should not move into the blob pool
+            let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
+            assert_eq!(
+                internal_tx.subpool, promotion_test.subpool,
+                "Subpools do not match at start of test: {promotion_test:?}"
+            );
+
+            // set block info with new base fee
+            block_info.pending_basefee = promotion_test.basefee_update;
+            block_info.pending_blob_fee = Some(promotion_test.blobfee_update);
+            pool.set_block_info(block_info);
+
+            // check tx state and derived subpool, it should not move into the blob pool
+            let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
+            assert_eq!(
+                internal_tx.subpool, promotion_test.new_subpool,
+                "Subpools do not match at end of test: {promotion_test:?}"
+            );
+
+            // assert new pool lengths
+            promotion_test.assert_single_tx_ending_subpool(&pool);
+        }
+    }
+
+    #[test]
+    fn test_insert_pending() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip1559().inc_price().inc_limit();
+        let valid_tx = f.validated(tx);
+        let InsertOk { updates, replaced_tx, move_to, state, .. } =
+            pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(updates.is_empty());
+        assert!(replaced_tx.is_none());
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert!(state.contains(TxState::ENOUGH_BALANCE));
+        assert_eq!(move_to, SubPool::Pending);
+
+        let inserted = pool.txs.get(&valid_tx.transaction_id).unwrap();
+        assert_eq!(inserted.subpool, SubPool::Pending);
+    }
+
+    #[test]
+    fn test_simple_insert() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let mut tx = MockTransaction::eip1559().inc_price().inc_limit();
+        tx.set_priority_fee(100);
+        tx.set_max_fee(100);
+        let valid_tx = f.validated(tx.clone());
+        let InsertOk { updates, replaced_tx, move_to, state, .. } =
+            pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(updates.is_empty());
+        assert!(replaced_tx.is_none());
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert!(!state.contains(TxState::ENOUGH_BALANCE));
+        assert_eq!(move_to, SubPool::Queued);
+
+        assert_eq!(pool.len(), 1);
+        assert!(pool.contains(valid_tx.hash()));
+        let expected_state = TxState::ENOUGH_FEE_CAP_BLOCK | TxState::NO_NONCE_GAPS;
+        let inserted = pool.get(valid_tx.id()).unwrap();
+        assert!(inserted.state.intersects(expected_state));
+
+        // insert the same tx again
+        let res = pool.insert_tx(valid_tx, on_chain_balance, on_chain_nonce);
+        res.unwrap_err();
+        assert_eq!(pool.len(), 1);
+
+        let valid_tx = f.validated(tx.next());
+        let InsertOk { updates, replaced_tx, move_to, state, .. } =
+            pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
+
+        assert!(updates.is_empty());
+        assert!(replaced_tx.is_none());
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert!(!state.contains(TxState::ENOUGH_BALANCE));
+        assert_eq!(move_to, SubPool::Queued);
+
+        assert!(pool.contains(valid_tx.hash()));
+        assert_eq!(pool.len(), 2);
+        let inserted = pool.get(valid_tx.id()).unwrap();
+        assert!(inserted.state.intersects(expected_state));
+    }
+
+    #[test]
+    // Test that on_canonical_state_change doesn't double-process transactions
+    // when both fee and account updates would affect the same transaction
+    fn test_on_canonical_state_change_no_double_processing() {
+        let mut tx_factory = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // Setup: Create a sender with a transaction in basefee pool
+        let tx = MockTransaction::eip1559().with_gas_price(50).with_gas_limit(30_000);
+        let sender = tx.sender();
+
+        // Set high base fee initially
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = 100;
+        pool.set_block_info(block_info);
+
+        let validated = tx_factory.validated(tx);
+        pool.add_transaction(validated, U256::from(10_000_000), 0, None).unwrap();
+
+        // Get sender_id after the transaction has been added
+        let sender_id = tx_factory.ids.sender_id(&sender).unwrap();
+
+        assert_eq!(pool.basefee_pool.len(), 1);
+        assert_eq!(pool.pending_pool.len(), 0);
+
+        // Now simulate a canonical state change with:
+        // 1. Lower base fee (would promote tx)
+        // 2. Account balance update (would also evaluate tx)
+        block_info.pending_basefee = 40;
+
+        let mut changed_senders = FxHashMap::default();
+        changed_senders.insert(
+            sender_id,
+            SenderInfo {
+                state_nonce: 0,
+                balance: U256::from(20_000_000), // Increased balance
+            },
+        );
+
+        let outcome = pool.on_canonical_state_change(
+            block_info,
+            vec![], // no mined transactions
+            changed_senders,
+            PoolUpdateKind::Commit,
+        );
+
+        // Transaction should be promoted exactly once
+        assert_eq!(pool.pending_pool.len(), 1, "Transaction should be in pending pool");
+        assert_eq!(pool.basefee_pool.len(), 0, "Transaction should not be in basefee pool");
+        assert_eq!(outcome.promoted.len(), 1, "Should report exactly one promotion");
+    }
+
+    #[test]
+    // Regression test: ensure we don't double-count promotions when base fee
+    // decreases and account is updated. This test would fail before the fix.
+    fn test_canonical_state_change_with_basefee_update_regression() {
+        let mut tx_factory = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // Create transactions from different senders to test independently
+        let sender_balance = U256::from(100_000_000);
+
+        // Sender 1: tx will be promoted (gas price 60 > new base fee 50)
+        let tx1 =
+            MockTransaction::eip1559().with_gas_price(60).with_gas_limit(21_000).with_nonce(0);
+        let sender1 = tx1.sender();
+
+        // Sender 2: tx will be promoted (gas price 55 > new base fee 50)
+        let tx2 =
+            MockTransaction::eip1559().with_gas_price(55).with_gas_limit(21_000).with_nonce(0);
+        let sender2 = tx2.sender();
+
+        // Sender 3: tx will NOT be promoted (gas price 45 < new base fee 50)
+        let tx3 =
+            MockTransaction::eip1559().with_gas_price(45).with_gas_limit(21_000).with_nonce(0);
+        let sender3 = tx3.sender();
+
+        // Set high initial base fee (all txs will go to basefee pool)
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = 70;
+        pool.set_block_info(block_info);
+
+        // Add all transactions
+        let validated1 = tx_factory.validated(tx1);
+        let validated2 = tx_factory.validated(tx2);
+        let validated3 = tx_factory.validated(tx3);
+
+        pool.add_transaction(validated1, sender_balance, 0, None).unwrap();
+        pool.add_transaction(validated2, sender_balance, 0, None).unwrap();
+        pool.add_transaction(validated3, sender_balance, 0, None).unwrap();
+
+        let sender1_id = tx_factory.ids.sender_id(&sender1).unwrap();
+        let sender2_id = tx_factory.ids.sender_id(&sender2).unwrap();
+        let sender3_id = tx_factory.ids.sender_id(&sender3).unwrap();
+
+        // All should be in basefee pool initially
+        assert_eq!(pool.basefee_pool.len(), 3, "All txs should be in basefee pool");
+        assert_eq!(pool.pending_pool.len(), 0, "No txs should be in pending pool");
+
+        // Now decrease base fee to 50 - this should promote tx1 and tx2 (prices 60 and 55)
+        // but not tx3 (price 45)
+        block_info.pending_basefee = 50;
+
+        // Update all senders' balances (simulating account state changes)
+        let mut changed_senders = FxHashMap::default();
+        changed_senders.insert(
+            sender1_id,
+            SenderInfo { state_nonce: 0, balance: sender_balance + U256::from(1000) },
+        );
+        changed_senders.insert(
+            sender2_id,
+            SenderInfo { state_nonce: 0, balance: sender_balance + U256::from(1000) },
+        );
+        changed_senders.insert(
+            sender3_id,
+            SenderInfo { state_nonce: 0, balance: sender_balance + U256::from(1000) },
+        );
+
+        let outcome = pool.on_canonical_state_change(
+            block_info,
+            vec![],
+            changed_senders,
+            PoolUpdateKind::Commit,
+        );
+
+        // Check final state
+        assert_eq!(pool.pending_pool.len(), 2, "tx1 and tx2 should be promoted");
+        assert_eq!(pool.basefee_pool.len(), 1, "tx3 should remain in basefee");
+
+        // CRITICAL: Should report exactly 2 promotions, not 4 (which would happen with
+        // double-processing)
+        assert_eq!(
+            outcome.promoted.len(),
+            2,
+            "Should report exactly 2 promotions, not double-counted"
+        );
+
+        // Verify the correct transactions were promoted
+        let promoted_prices: Vec<u128> =
+            outcome.promoted.iter().map(|tx| tx.max_fee_per_gas()).collect();
+        assert!(promoted_prices.contains(&60));
+        assert!(promoted_prices.contains(&55));
+    }
+
+    #[test]
+    fn test_basefee_decrease_with_empty_senders() {
+        // Test that fee promotions still occur when basefee decreases
+        // even with no changed_senders
+        let mut tx_factory = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // Create transaction that will be promoted when fee drops
+        let tx = MockTransaction::eip1559().with_gas_price(60).with_gas_limit(21_000);
+
+        // Set high initial base fee
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = 100;
+        pool.set_block_info(block_info);
+
+        // Add transaction - should go to basefee pool
+        let validated = tx_factory.validated(tx);
+        pool.add_transaction(validated, U256::from(10_000_000), 0, None).unwrap();
+
+        assert_eq!(pool.basefee_pool.len(), 1);
+        assert_eq!(pool.pending_pool.len(), 0);
+
+        // Decrease base fee with NO changed senders
+        block_info.pending_basefee = 50;
+        let outcome = pool.on_canonical_state_change(
+            block_info,
+            vec![],
+            FxHashMap::default(), // Empty changed_senders!
+            PoolUpdateKind::Commit,
+        );
+
+        // Transaction should still be promoted by fee-driven logic
+        assert_eq!(pool.pending_pool.len(), 1, "Fee decrease should promote tx");
+        assert_eq!(pool.basefee_pool.len(), 0);
+        assert_eq!(outcome.promoted.len(), 1, "Should report promotion from fee update");
+    }
+
+    #[test]
+    fn test_basefee_decrease_account_makes_unfundable() {
+        // Test that when basefee decreases but account update makes tx unfundable,
+        // we don't get transient promote-then-discard double counting
+        let mut tx_factory = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx = MockTransaction::eip1559().with_gas_price(60).with_gas_limit(21_000);
+        let sender = tx.sender();
+
+        // High initial base fee
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = 100;
+        pool.set_block_info(block_info);
+
+        let validated = tx_factory.validated(tx);
+        pool.add_transaction(validated, U256::from(10_000_000), 0, None).unwrap();
+        let sender_id = tx_factory.ids.sender_id(&sender).unwrap();
+
+        assert_eq!(pool.basefee_pool.len(), 1);
+
+        // Decrease base fee (would normally promote) but also drain account
+        block_info.pending_basefee = 50;
+        let mut changed_senders = FxHashMap::default();
+        changed_senders.insert(
+            sender_id,
+            SenderInfo {
+                state_nonce: 0,
+                balance: U256::from(100), // Too low to pay for gas!
+            },
+        );
+
+        let outcome = pool.on_canonical_state_change(
+            block_info,
+            vec![],
+            changed_senders,
+            PoolUpdateKind::Commit,
+        );
+
+        // With insufficient balance, transaction goes to queued pool
+        assert_eq!(pool.pending_pool.len(), 0, "Unfunded tx should not be in pending");
+        assert_eq!(pool.basefee_pool.len(), 0, "Tx no longer in basefee pool");
+        assert_eq!(pool.queued_pool.len(), 1, "Unfunded tx should be in queued pool");
+
+        // Transaction is not removed, just moved to queued
+        let tx_count = pool.all_transactions.txs.len();
+        assert_eq!(tx_count, 1, "Transaction should still be in pool (in queued)");
+
+        assert_eq!(outcome.promoted.len(), 0, "Should not report promotion");
+        assert_eq!(outcome.discarded.len(), 0, "Queued tx is not reported as discarded");
+    }
+
+    #[test]
+    fn insert_already_imported() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+        let tx = MockTransaction::eip1559().inc_price().inc_limit();
+        let tx = f.validated(tx);
+        pool.add_transaction(tx.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        match pool.add_transaction(tx, on_chain_balance, on_chain_nonce, None).unwrap_err().kind {
+            PoolErrorKind::AlreadyImported => {}
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn insert_replace() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip1559().inc_price().inc_limit();
+        let first = f.validated(tx.clone());
+        let _ = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        let replacement = f.validated(tx.rng_hash().inc_price());
+        let InsertOk { updates, replaced_tx, .. } =
+            pool.insert_tx(replacement.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(updates.is_empty());
+        let replaced = replaced_tx.unwrap();
+        assert_eq!(replaced.0.hash(), first.hash());
+
+        // ensure replaced tx is fully removed
+        assert!(!pool.contains(first.hash()));
+        assert!(pool.contains(replacement.hash()));
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn insert_replace_txpool() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::mock();
+
+        let tx = MockTransaction::eip1559().inc_price().inc_limit();
+        let first = f.validated(tx.clone());
+        let first_added =
+            pool.add_transaction(first, on_chain_balance, on_chain_nonce, None).unwrap();
+        let replacement = f.validated(tx.rng_hash().inc_price());
+        let replacement_added = pool
+            .add_transaction(replacement.clone(), on_chain_balance, on_chain_nonce, None)
+            .unwrap();
+
+        // // ensure replaced tx removed
+        assert!(!pool.contains(first_added.hash()));
+        // but the replacement is still there
+        assert!(pool.subpool_contains(replacement_added.subpool(), replacement_added.id()));
+
+        assert!(pool.contains(replacement.hash()));
+        let size = pool.size();
+        assert_eq!(size.total, 1);
+        size.assert_invariants();
+    }
+
+    #[test]
+    fn insert_replace_underpriced() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip1559().inc_price().inc_limit();
+        let first = f.validated(tx.clone());
+        let _res = pool.insert_tx(first, on_chain_balance, on_chain_nonce);
+        let mut replacement = f.validated(tx.rng_hash());
+        replacement.transaction = replacement.transaction.decr_price();
+        let err = pool.insert_tx(replacement, on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::Underpriced { .. }));
+    }
+
+    #[test]
+    fn insert_replace_underpriced_not_enough_bump() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let mut tx = MockTransaction::eip1559().inc_price().inc_limit();
+        tx.set_priority_fee(100);
+        tx.set_max_fee(100);
+        let first = f.validated(tx.clone());
+        let _ = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        let mut replacement = f.validated(tx.rng_hash().inc_price());
+
+        // a price bump of 9% is not enough for a default min price bump of 10%
+        replacement.transaction.set_priority_fee(109);
+        replacement.transaction.set_max_fee(109);
+        let err =
+            pool.insert_tx(replacement.clone(), on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::Underpriced { .. }));
+        // ensure first tx is not removed
+        assert!(pool.contains(first.hash()));
+        assert_eq!(pool.len(), 1);
+
+        // should also fail if the bump in max fee is not enough
+        replacement.transaction.set_priority_fee(110);
+        replacement.transaction.set_max_fee(109);
+        let err =
+            pool.insert_tx(replacement.clone(), on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::Underpriced { .. }));
+        assert!(pool.contains(first.hash()));
+        assert_eq!(pool.len(), 1);
+
+        // should also fail if the bump in priority fee is not enough
+        replacement.transaction.set_priority_fee(109);
+        replacement.transaction.set_max_fee(110);
+        let err = pool.insert_tx(replacement, on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::Underpriced { .. }));
+        assert!(pool.contains(first.hash()));
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn insert_replace_underpriced_rounds_up_minimum_bump() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions { minimal_protocol_basefee: 0, ..Default::default() };
+        let mut tx = MockTransaction::eip1559().inc_price().inc_limit();
+        tx.set_priority_fee(1);
+        tx.set_max_fee(1);
+
+        let first = f.validated(tx.clone());
+        let _ = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce).unwrap();
+
+        let mut replacement = f.validated(tx.rng_hash().inc_price());
+        replacement.transaction.set_priority_fee(1);
+        replacement.transaction.set_max_fee(2);
+        let err =
+            pool.insert_tx(replacement.clone(), on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::Underpriced { .. }));
+        assert!(pool.contains(first.hash()));
+        assert_eq!(pool.len(), 1);
+
+        replacement.transaction.set_priority_fee(2);
+        replacement.transaction.set_max_fee(2);
+        let replaced = pool.insert_tx(replacement, on_chain_balance, on_chain_nonce).unwrap();
+        assert!(replaced.replaced_tx.is_some());
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn insert_conflicting_type_normal_to_blob() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip1559().inc_price().inc_limit();
+        let first = f.validated(tx.clone());
+        pool.insert_tx(first, on_chain_balance, on_chain_nonce).unwrap();
+        let tx = MockTransaction::eip4844().set_sender(tx.sender()).inc_price_by(100).inc_limit();
+        let blob = f.validated(tx);
+        let err = pool.insert_tx(blob, on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::TxTypeConflict { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn insert_conflicting_type_blob_to_normal() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+        let first = f.validated(tx.clone());
+        pool.insert_tx(first, on_chain_balance, on_chain_nonce).unwrap();
+        let tx = MockTransaction::eip1559().set_sender(tx.sender()).inc_price_by(100).inc_limit();
+        let tx = f.validated(tx);
+        let err = pool.insert_tx(tx, on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::TxTypeConflict { .. }), "{err:?}");
+    }
+
+    // insert nonce then nonce - 1
+    #[test]
+    fn insert_previous() {
+        let on_chain_balance = U256::ZERO;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip1559().inc_nonce().inc_price().inc_limit();
+        let first = f.validated(tx.clone());
+        let _res = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce);
+
+        let first_in_pool = pool.get(first.id()).unwrap();
+
+        // has nonce gap
+        assert!(!first_in_pool.state.contains(TxState::NO_NONCE_GAPS));
+
+        let prev = f.validated(tx.prev());
+        let InsertOk { updates, replaced_tx, state, move_to, .. } =
+            pool.insert_tx(prev, on_chain_balance, on_chain_nonce).unwrap();
+
+        // no updates since still in queued pool
+        assert!(updates.is_empty());
+        assert!(replaced_tx.is_none());
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert_eq!(move_to, SubPool::Queued);
+
+        let first_in_pool = pool.get(first.id()).unwrap();
+        // has non nonce gap
+        assert!(first_in_pool.state.contains(TxState::NO_NONCE_GAPS));
+    }
+
+    // insert nonce then nonce - 1
+    #[test]
+    fn insert_with_updates() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        let tx = MockTransaction::eip1559().inc_nonce().set_gas_price(100).inc_limit();
+        let first = f.validated(tx.clone());
+        let _res = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce).unwrap();
+
+        let first_in_pool = pool.get(first.id()).unwrap();
+        // has nonce gap
+        assert!(!first_in_pool.state.contains(TxState::NO_NONCE_GAPS));
+        assert_eq!(SubPool::Queued, first_in_pool.subpool);
+
+        let prev = f.validated(tx.prev());
+        let InsertOk { updates, replaced_tx, state, move_to, .. } =
+            pool.insert_tx(prev, on_chain_balance, on_chain_nonce).unwrap();
+
+        // updated previous tx
+        assert_eq!(updates.len(), 1);
+        assert!(replaced_tx.is_none());
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert_eq!(move_to, SubPool::Pending);
+
+        let first_in_pool = pool.get(first.id()).unwrap();
+        // has non nonce gap
+        assert!(first_in_pool.state.contains(TxState::NO_NONCE_GAPS));
+        assert_eq!(SubPool::Pending, first_in_pool.subpool);
+    }
+
+    #[test]
+    fn insert_previous_blocking() {
+        let on_chain_balance = U256::from(1_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+        pool.pending_fees.base_fee = pool.minimal_protocol_basefee.checked_add(1).unwrap();
+        let tx = MockTransaction::eip1559().inc_nonce().inc_limit();
+        let first = f.validated(tx.clone());
+
+        let _res = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce);
+
+        let first_in_pool = pool.get(first.id()).unwrap();
+
+        assert!(tx.get_gas_price() < pool.pending_fees.base_fee as u128);
+        // has nonce gap
+        assert!(!first_in_pool.state.contains(TxState::NO_NONCE_GAPS));
+
+        let prev = f.validated(tx.prev());
+        let InsertOk { updates, replaced_tx, state, move_to, .. } =
+            pool.insert_tx(prev, on_chain_balance, on_chain_nonce).unwrap();
+
+        assert!(!state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+        // no updates since still in queued pool
+        assert!(updates.is_empty());
+        assert!(replaced_tx.is_none());
+        assert!(state.contains(TxState::NO_NONCE_GAPS));
+        assert_eq!(move_to, SubPool::BaseFee);
+
+        let first_in_pool = pool.get(first.id()).unwrap();
+        // has non nonce gap
+        assert!(first_in_pool.state.contains(TxState::NO_NONCE_GAPS));
+    }
+
+    #[test]
+    fn rejects_spammer() {
+        let on_chain_balance = U256::from(1_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+
+        let mut tx = MockTransaction::eip1559();
+        let unblocked_tx = tx.clone();
+        for _ in 0..pool.max_account_slots {
+            tx = tx.next();
+            pool.insert_tx(f.validated(tx.clone()), on_chain_balance, on_chain_nonce).unwrap();
+        }
+
+        assert_eq!(
+            pool.max_account_slots,
+            pool.tx_count(f.ids.sender_id(tx.get_sender()).unwrap())
+        );
+
+        let err =
+            pool.insert_tx(f.validated(tx.next()), on_chain_balance, on_chain_nonce).unwrap_err();
+        assert!(matches!(err, InsertErr::ExceededSenderTransactionsCapacity { .. }));
+
+        assert!(pool
+            .insert_tx(f.validated(unblocked_tx), on_chain_balance, on_chain_nonce)
+            .is_ok());
+    }
+
+    #[test]
+    fn allow_local_spamming() {
+        let on_chain_balance = U256::from(1_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+
+        let mut tx = MockTransaction::eip1559();
+        for _ in 0..pool.max_account_slots {
+            tx = tx.next();
+            pool.insert_tx(
+                f.validated_with_origin(TransactionOrigin::Local, tx.clone()),
+                on_chain_balance,
+                on_chain_nonce,
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            pool.max_account_slots,
+            pool.tx_count(f.ids.sender_id(tx.get_sender()).unwrap())
+        );
+
+        pool.insert_tx(
+            f.validated_with_origin(TransactionOrigin::Local, tx.next()),
+            on_chain_balance,
+            on_chain_nonce,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn reject_tx_over_gas_limit() {
+        let on_chain_balance = U256::from(1_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+
+        let tx = MockTransaction::eip1559().with_gas_limit(30_000_001);
+
+        assert!(matches!(
+            pool.insert_tx(f.validated(tx), on_chain_balance, on_chain_nonce),
+            Err(InsertErr::TxGasLimitMoreThanAvailableBlockGas { .. })
+        ));
+    }
+
+    #[test]
+    fn test_tx_equal_gas_limit() {
+        let on_chain_balance = U256::from(1_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+
+        let tx = MockTransaction::eip1559().with_gas_limit(30_000_000);
+
+        let InsertOk { state, .. } =
+            pool.insert_tx(f.validated(tx), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(state.contains(TxState::NOT_TOO_MUCH_GAS));
+    }
+
+    #[test]
+    fn update_basefee_subpools() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx = MockTransaction::eip1559().inc_price_by(10);
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        pool.update_basefee((tx.max_fee_per_gas() + 1) as u64, |_| {});
+
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.basefee_pool.len(), 1);
+
+        assert_eq!(pool.all_transactions.txs.get(&id).unwrap().subpool, SubPool::BaseFee)
+    }
+
+    #[test]
+    fn update_basefee_subpools_setting_block_info() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx = MockTransaction::eip1559().inc_price_by(10);
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        // use set_block_info for the basefee update
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = (tx.max_fee_per_gas() + 1) as u64;
+        pool.set_block_info(block_info);
+
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.basefee_pool.len(), 1);
+
+        assert_eq!(pool.all_transactions.txs.get(&id).unwrap().subpool, SubPool::BaseFee)
+    }
+
+    #[test]
+    fn basefee_decrease_promotes_affordable_and_keeps_unaffordable() {
+        use alloy_primitives::address;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // Create transactions that will be in basefee pool (can't afford initial high fee)
+        // Use different senders to avoid nonce gap issues
+        let sender_a = address!("0x000000000000000000000000000000000000000a");
+        let sender_b = address!("0x000000000000000000000000000000000000000b");
+        let sender_c = address!("0x000000000000000000000000000000000000000c");
+
+        let tx1 = MockTransaction::eip1559()
+            .set_sender(sender_a)
+            .set_nonce(0)
+            .set_max_fee(500)
+            .inc_limit();
+        let tx2 = MockTransaction::eip1559()
+            .set_sender(sender_b)
+            .set_nonce(0)
+            .set_max_fee(600)
+            .inc_limit();
+        let tx3 = MockTransaction::eip1559()
+            .set_sender(sender_c)
+            .set_nonce(0)
+            .set_max_fee(400)
+            .inc_limit();
+
+        // Set high initial basefee so transactions go to basefee pool
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = 700;
+        pool.set_block_info(block_info);
+
+        let validated1 = f.validated(tx1);
+        let validated2 = f.validated(tx2);
+        let validated3 = f.validated(tx3);
+        let id1 = *validated1.id();
+        let id2 = *validated2.id();
+        let id3 = *validated3.id();
+
+        // Add transactions - they should go to basefee pool due to high basefee
+        // All transactions have nonce 0 from different senders, so on_chain_nonce should be 0 for
+        // all
+        pool.add_transaction(validated1, U256::from(10_000), 0, None).unwrap();
+        pool.add_transaction(validated2, U256::from(10_000), 0, None).unwrap();
+        pool.add_transaction(validated3, U256::from(10_000), 0, None).unwrap();
+
+        // Debug: Check where transactions ended up
+        println!("Basefee pool len: {}", pool.basefee_pool.len());
+        println!("Pending pool len: {}", pool.pending_pool.len());
+        println!("tx1 subpool: {:?}", pool.all_transactions.txs.get(&id1).unwrap().subpool);
+        println!("tx2 subpool: {:?}", pool.all_transactions.txs.get(&id2).unwrap().subpool);
+        println!("tx3 subpool: {:?}", pool.all_transactions.txs.get(&id3).unwrap().subpool);
+
+        // Verify they're in basefee pool
+        assert_eq!(pool.basefee_pool.len(), 3);
+        assert_eq!(pool.pending_pool.len(), 0);
+        assert_eq!(pool.all_transactions.txs.get(&id1).unwrap().subpool, SubPool::BaseFee);
+        assert_eq!(pool.all_transactions.txs.get(&id2).unwrap().subpool, SubPool::BaseFee);
+        assert_eq!(pool.all_transactions.txs.get(&id3).unwrap().subpool, SubPool::BaseFee);
+
+        // Now decrease basefee to trigger the zero-allocation optimization
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = 450; // tx1 (500) and tx2 (600) can now afford it, tx3 (400) cannot
+        pool.set_block_info(block_info);
+
+        // Verify the optimization worked correctly:
+        // - tx1 and tx2 should be promoted to pending (mathematical certainty)
+        // - tx3 should remain in basefee pool
+        // - All state transitions should be correct
+        assert_eq!(pool.basefee_pool.len(), 1);
+        assert_eq!(pool.pending_pool.len(), 2);
+
+        // tx3 should still be in basefee pool (fee 400 < basefee 450)
+        assert_eq!(pool.all_transactions.txs.get(&id3).unwrap().subpool, SubPool::BaseFee);
+
+        // tx1 and tx2 should be in pending pool with correct state bits
+        let tx1_meta = pool.all_transactions.txs.get(&id1).unwrap();
+        let tx2_meta = pool.all_transactions.txs.get(&id2).unwrap();
+        assert_eq!(tx1_meta.subpool, SubPool::Pending);
+        assert_eq!(tx2_meta.subpool, SubPool::Pending);
+        assert!(tx1_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+        assert!(tx2_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+
+        // Verify that best_transactions returns the promoted transactions
+        let best: Vec<_> = pool.best_transactions().take(3).collect();
+        assert_eq!(best.len(), 2); // Only tx1 and tx2 should be returned
+        assert!(best.iter().any(|tx| tx.id() == &id1));
+        assert!(best.iter().any(|tx| tx.id() == &id2));
+    }
+
+    #[test]
+    fn apply_fee_updates_records_promotions_after_basefee_drop() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx = MockTransaction::eip1559()
+            .with_gas_limit(21_000)
+            .with_max_fee(500)
+            .with_priority_fee(1);
+        let validated = f.validated(tx);
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        // Raise base fee beyond the transaction's cap so it gets parked in BaseFee pool.
+        pool.update_basefee(600, |_| {});
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.basefee_pool.len(), 1);
+
+        let prev_base_fee = 600;
+        let prev_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+
+        // Simulate the canonical state path updating pending fees before applying promotions.
+        pool.all_transactions.pending_fees.base_fee = 400;
+
+        let mut outcome = UpdateOutcome::default();
+        pool.apply_fee_updates(prev_base_fee, prev_blob_fee, &mut outcome);
+
+        assert_eq!(pool.pending_pool.len(), 1);
+        assert!(pool.basefee_pool.is_empty());
+        assert_eq!(outcome.promoted.len(), 1);
+        assert_eq!(outcome.promoted[0].id(), &id);
+        assert_eq!(pool.all_transactions.pending_fees.base_fee, 400);
+        assert_eq!(pool.all_transactions.pending_fees.blob_fee, prev_blob_fee);
+
+        let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
+        assert_eq!(tx_meta.subpool, SubPool::Pending);
+        assert!(tx_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn apply_fee_updates_records_promotions_after_blob_fee_drop() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let initial_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+
+        let tx = MockTransaction::eip4844().with_blob_fee(initial_blob_fee + 100);
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        // Raise blob fee beyond the transaction's cap so it gets parked in Blob pool.
+        let increased_blob_fee = tx.max_fee_per_blob_gas().unwrap() + 200;
+        pool.update_blob_fee(increased_blob_fee, Ordering::Equal, |_| {});
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.blob_pool.len(), 1);
+
+        let prev_base_fee = pool.all_transactions.pending_fees.base_fee;
+        let prev_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+
+        // Simulate the canonical state path updating pending fees before applying promotions.
+        pool.all_transactions.pending_fees.blob_fee = tx.max_fee_per_blob_gas().unwrap();
+
+        let mut outcome = UpdateOutcome::default();
+        pool.apply_fee_updates(prev_base_fee, prev_blob_fee, &mut outcome);
+
+        assert_eq!(pool.pending_pool.len(), 1);
+        assert!(pool.blob_pool.is_empty());
+        assert_eq!(outcome.promoted.len(), 1);
+        assert_eq!(outcome.promoted[0].id(), &id);
+        assert_eq!(pool.all_transactions.pending_fees.base_fee, prev_base_fee);
+        assert_eq!(pool.all_transactions.pending_fees.blob_fee, tx.max_fee_per_blob_gas().unwrap());
+
+        let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
+        assert_eq!(tx_meta.subpool, SubPool::Pending);
+        assert!(tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert!(tx_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn apply_fee_updates_promotes_blob_after_basefee_drop() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let initial_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+
+        let tx = MockTransaction::eip4844()
+            .with_max_fee(500)
+            .with_priority_fee(1)
+            .with_blob_fee(initial_blob_fee + 100);
+        let validated = f.validated(tx);
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        // Raise base fee beyond the transaction's cap so it gets parked in Blob pool.
+        let high_base_fee = 600;
+        pool.update_basefee(high_base_fee, |_| {});
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.blob_pool.len(), 1);
+
+        let prev_base_fee = high_base_fee;
+        let prev_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+
+        // Simulate applying a lower base fee while keeping blob fee unchanged.
+        pool.all_transactions.pending_fees.base_fee = 400;
+
+        let mut outcome = UpdateOutcome::default();
+        pool.apply_fee_updates(prev_base_fee, prev_blob_fee, &mut outcome);
+
+        assert_eq!(pool.pending_pool.len(), 1);
+        assert!(pool.blob_pool.is_empty());
+        assert_eq!(outcome.promoted.len(), 1);
+        assert_eq!(outcome.promoted[0].id(), &id);
+        assert_eq!(pool.all_transactions.pending_fees.base_fee, 400);
+        assert_eq!(pool.all_transactions.pending_fees.blob_fee, prev_blob_fee);
+
+        let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
+        assert_eq!(tx_meta.subpool, SubPool::Pending);
+        assert!(tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert!(tx_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn apply_fee_updates_demotes_after_basefee_rise() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx = MockTransaction::eip1559()
+            .with_gas_limit(21_000)
+            .with_max_fee(400)
+            .with_priority_fee(1);
+        let validated = f.validated(tx);
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        let prev_base_fee = pool.all_transactions.pending_fees.base_fee;
+        let prev_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+
+        // Simulate canonical path raising the base fee beyond the transaction's cap.
+        let new_base_fee = prev_base_fee + 1_000;
+        pool.all_transactions.pending_fees.base_fee = new_base_fee;
+
+        let mut outcome = UpdateOutcome::default();
+        pool.apply_fee_updates(prev_base_fee, prev_blob_fee, &mut outcome);
+
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.basefee_pool.len(), 1);
+        assert!(outcome.promoted.is_empty());
+        assert_eq!(pool.all_transactions.pending_fees.base_fee, new_base_fee);
+        assert_eq!(pool.all_transactions.pending_fees.blob_fee, prev_blob_fee);
+
+        let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
+        assert_eq!(tx_meta.subpool, SubPool::BaseFee);
+        assert!(!tx_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn get_highest_transaction_by_sender_and_nonce() {
+        // Set up a mock transaction factory and a new transaction pool.
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // Create a mock transaction and add it to the pool.
+        let tx = MockTransaction::eip1559();
+        pool.add_transaction(f.validated(tx.clone()), U256::from(1_000), 0, None).unwrap();
+
+        // Create another mock transaction with an incremented price.
+        let tx1 = tx.inc_price().next();
+
+        // Validate the second mock transaction and add it to the pool.
+        let tx1_validated = f.validated(tx1.clone());
+        pool.add_transaction(tx1_validated, U256::from(1_000), 0, None).unwrap();
+
+        // Ensure that the calculated next nonce for the sender matches the expected value.
+        assert_eq!(
+            pool.get_highest_nonce_by_sender(f.ids.sender_id(&tx.sender()).unwrap()),
+            Some(1)
+        );
+
+        // Retrieve the highest transaction by sender.
+        let highest_tx = pool
+            .get_highest_transaction_by_sender(f.ids.sender_id(&tx.sender()).unwrap())
+            .expect("Failed to retrieve highest transaction");
+
+        // Validate that the retrieved highest transaction matches the expected transaction.
+        assert_eq!(highest_tx.as_ref().transaction, tx1);
+    }
+
+    #[test]
+    fn get_highest_consecutive_transaction_by_sender() {
+        // Set up a mock transaction factory and a new transaction pool.
+        let mut pool = TxPool::new(MockOrdering::default(), PoolConfig::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Create transactions with nonces 0, 1, 2, 4, 5.
+        let sender = Address::random();
+        let txs: Vec<_> = vec![0, 1, 2, 4, 5, 8, 9];
+        for nonce in txs {
+            let mut mock_tx = MockTransaction::eip1559();
+            mock_tx.set_sender(sender);
+            mock_tx.set_nonce(nonce);
+
+            let validated_tx = f.validated(mock_tx);
+            pool.add_transaction(validated_tx, U256::from(1000), 0, None).unwrap();
+        }
+
+        // Get last consecutive transaction
+        let sender_id = f.ids.sender_id(&sender).unwrap();
+        let next_tx =
+            pool.get_highest_consecutive_transaction_by_sender(sender_id.into_transaction_id(0));
+        assert_eq!(next_tx.map(|tx| tx.nonce()), Some(2), "Expected nonce 2 for on-chain nonce 0");
+
+        let next_tx =
+            pool.get_highest_consecutive_transaction_by_sender(sender_id.into_transaction_id(4));
+        assert_eq!(next_tx.map(|tx| tx.nonce()), Some(5), "Expected nonce 5 for on-chain nonce 4");
+
+        let next_tx =
+            pool.get_highest_consecutive_transaction_by_sender(sender_id.into_transaction_id(5));
+        assert_eq!(next_tx.map(|tx| tx.nonce()), Some(5), "Expected nonce 5 for on-chain nonce 5");
+
+        // update the tracked nonce
+        let mut info = SenderInfo::default();
+        info.update(8, U256::ZERO);
+        pool.all_transactions.sender_info.insert(sender_id, info);
+        let next_tx =
+            pool.get_highest_consecutive_transaction_by_sender(sender_id.into_transaction_id(5));
+        assert_eq!(next_tx.map(|tx| tx.nonce()), Some(9), "Expected nonce 9 for on-chain nonce 8");
+    }
+
+    #[test]
+    fn discard_nonce_too_low() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx = MockTransaction::eip1559().inc_price_by(10);
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+
+        let next = tx.next();
+        let validated = f.validated(next.clone());
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 2);
+
+        let mut changed_senders = HashMap::default();
+        changed_senders.insert(
+            id.sender,
+            SenderInfo { state_nonce: next.nonce(), balance: U256::from(1_000) },
+        );
+        let outcome = pool.update_accounts(changed_senders);
+        assert_eq!(outcome.discarded.len(), 1);
+        assert_eq!(pool.pending_pool.len(), 1);
+    }
+
+    #[test]
+    fn discard_with_large_blob_txs() {
+        // init tracing
+        reth_tracing::init_test_tracing();
+
+        // this test adds large txs to the parked pool, then attempting to discard worst
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+        let default_limits = pool.config.blob_limit;
+
+        // create a chain of transactions by sender A
+        // make sure they are all one over half the limit
+        let a_sender = address!("0x000000000000000000000000000000000000000a");
+
+        // set the base fee of the pool
+        let mut block_info = pool.block_info();
+        block_info.pending_blob_fee = Some(100);
+        block_info.pending_basefee = 100;
+
+        // update
+        pool.set_block_info(block_info);
+
+        // 2 txs, that should put the pool over the size limit but not max txs
+        let a_txs = MockTransactionSet::dependent(a_sender, 0, 2, TxType::Eip4844)
+            .into_iter()
+            .map(|mut tx| {
+                tx.set_size(default_limits.max_size / 2 + 1);
+                tx.set_max_fee((block_info.pending_basefee - 1).into());
+                tx
+            })
+            .collect::<Vec<_>>();
+
+        // add all the transactions to the parked pool
+        for tx in a_txs {
+            pool.add_transaction(f.validated(tx), U256::from(1_000), 0, None).unwrap();
+        }
+
+        // truncate the pool, it should remove at least one transaction
+        let removed = pool.discard_worst();
+        assert_eq!(removed.len(), 1);
+    }
+
+    #[test]
+    fn discard_with_parked_large_txs() {
+        // init tracing
+        reth_tracing::init_test_tracing();
+
+        // this test adds large txs to the parked pool, then attempting to discard worst
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+        let default_limits = pool.config.queued_limit;
+
+        // create a chain of transactions by sender A
+        // make sure they are all one over half the limit
+        let a_sender = address!("0x000000000000000000000000000000000000000a");
+
+        // set the base fee of the pool
+        let pool_base_fee = 100;
+        pool.update_basefee(pool_base_fee, |_| {});
+
+        // 2 txs, that should put the pool over the size limit but not max txs
+        let a_txs = MockTransactionSet::dependent(a_sender, 0, 3, TxType::Eip1559)
+            .into_iter()
+            .map(|mut tx| {
+                tx.set_size(default_limits.max_size / 2 + 1);
+                tx.set_max_fee((pool_base_fee - 1).into());
+                tx
+            })
+            .collect::<Vec<_>>();
+
+        // add all the transactions to the parked pool
+        for tx in a_txs {
+            pool.add_transaction(f.validated(tx), U256::from(1_000), 0, None).unwrap();
+        }
+
+        // truncate the pool, it should remove at least one transaction
+        let removed = pool.discard_worst();
+        assert_eq!(removed.len(), 1);
+    }
+
+    #[test]
+    fn discard_at_capacity() {
+        let mut f = MockTransactionFactory::default();
+        let queued_limit = SubPoolLimit::new(1000, usize::MAX);
+        let mut pool =
+            TxPool::new(MockOrdering::default(), PoolConfig { queued_limit, ..Default::default() });
+
+        // insert a bunch of transactions into the queued pool
+        for _ in 0..queued_limit.max_txs {
+            let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
+            let validated = f.validated(tx.clone());
+            let _id = *validated.id();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+        }
+
+        let size = pool.size();
+        assert_eq!(size.queued, queued_limit.max_txs);
+
+        for _ in 0..queued_limit.max_txs {
+            let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
+            let validated = f.validated(tx.clone());
+            let _id = *validated.id();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+
+            pool.discard_worst();
+            pool.assert_invariants();
+            assert!(pool.size().queued <= queued_limit.max_txs);
+        }
+    }
+
+    #[test]
+    fn discard_blobs_at_capacity() {
+        let mut f = MockTransactionFactory::default();
+        let blob_limit = SubPoolLimit::new(1000, usize::MAX);
+        let mut pool =
+            TxPool::new(MockOrdering::default(), PoolConfig { blob_limit, ..Default::default() });
+        pool.all_transactions.pending_fees.blob_fee = 10000;
+        // insert a bunch of transactions into the queued pool
+        for _ in 0..blob_limit.max_txs {
+            let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
+            let validated = f.validated(tx.clone());
+            let _id = *validated.id();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+        }
+
+        let size = pool.size();
+        assert_eq!(size.blob, blob_limit.max_txs);
+
+        for _ in 0..blob_limit.max_txs {
+            let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
+            let validated = f.validated(tx.clone());
+            let _id = *validated.id();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
+
+            pool.discard_worst();
+            pool.assert_invariants();
+            assert!(pool.size().blob <= blob_limit.max_txs);
+        }
+    }
+
+    #[test]
+    fn account_updates_sender_balance() {
+        let mut on_chain_balance = U256::from(100);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = tx_1.next();
+
+        // Create 3 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        // The sender does not have enough balance to put all txs into pending.
+        assert_eq!(1, pool.pending_transactions().len());
+        assert_eq!(2, pool.queued_transactions().len());
+
+        // Simulate new block arrival - and chain balance increase.
+        let mut updated_accounts = HashMap::default();
+        on_chain_balance = U256::from(300);
+        updated_accounts.insert(
+            v0.sender_id(),
+            SenderInfo { state_nonce: on_chain_nonce, balance: on_chain_balance },
+        );
+        pool.update_accounts(updated_accounts.clone());
+
+        assert_eq!(3, pool.pending_transactions().len());
+        assert!(pool.queued_transactions().is_empty());
+
+        // Simulate new block arrival - and chain balance decrease.
+        updated_accounts.entry(v0.sender_id()).and_modify(|v| v.balance = U256::from(1));
+        pool.update_accounts(updated_accounts);
+
+        assert!(pool.pending_transactions().is_empty());
+        assert_eq!(3, pool.queued_transactions().len());
+    }
+
+    #[test]
+    fn account_updates_nonce_gap() {
+        let on_chain_balance = U256::from(10_000);
+        let mut on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = tx_1.next();
+
+        // Create 3 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+
+        // Add first 2 to the pool
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert!(pool.queued_transactions().is_empty());
+        assert_eq!(2, pool.pending_transactions().len());
+
+        // Remove first (nonce 0)
+        pool.remove_transaction_by_hash(v0.hash());
+
+        // Now add transaction with nonce 2
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        // v1 and v2 should both be in the queue now.
+        assert_eq!(2, pool.queued_transactions().len());
+        assert!(pool.pending_transactions().is_empty());
+
+        // Simulate new block arrival - and chain nonce increasing.
+        let mut updated_accounts = HashMap::default();
+        on_chain_nonce += 1;
+        updated_accounts.insert(
+            v0.sender_id(),
+            SenderInfo { state_nonce: on_chain_nonce, balance: on_chain_balance },
+        );
+        pool.update_accounts(updated_accounts);
+
+        // 'pending' now).
+        assert!(pool.queued_transactions().is_empty());
+        assert_eq!(2, pool.pending_transactions().len());
+    }
+    #[test]
+    fn test_transaction_removal() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+
+        // Create 2 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+
+        // Add them to the pool
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(2, pool.pending_transactions().len());
+
+        // Remove first (nonce 0) - simulating that it was taken to be a part of the block.
+        pool.remove_transaction(v0.id());
+        // assert the second transaction is really at the top of the queue
+        let pool_txs = pool.best_transactions().map(|x| x.id().nonce).collect::<Vec<_>>();
+        assert_eq!(vec![v1.nonce()], pool_txs);
+    }
+    #[test]
+    fn test_remove_transactions() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_3 = tx_2.next();
+
+        // Create 4 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+        let v3 = f.validated(tx_3);
+
+        // Add them to the pool
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v3.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(4, pool.pending_transactions().len());
+
+        pool.remove_transactions(vec![*v0.hash(), *v2.hash()]);
+
+        assert_eq!(2, pool.queued_transactions().len());
+        assert!(pool.pending_transactions().is_empty());
+        assert!(pool.contains(v1.hash()));
+        assert!(pool.contains(v3.hash()));
+    }
+
+    #[test]
+    fn test_remove_transactions_middle_pending_hash() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = tx_1.next();
+        let tx_3 = tx_2.next();
+
+        // Create 4 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+        let v3 = f.validated(tx_3);
+
+        // Add them to the pool
+        let _res = pool.add_transaction(v0, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(4, pool.pending_transactions().len());
+
+        let mut removed_txs = pool.remove_transactions(vec![*v1.hash()]);
+        assert_eq!(1, removed_txs.len());
+
+        assert_eq!(2, pool.queued_transactions().len());
+        assert_eq!(1, pool.pending_transactions().len());
+
+        // reinsert
+        let removed_tx = removed_txs.pop().unwrap();
+        let v1 = f.validated(removed_tx.transaction.clone());
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(4, pool.pending_transactions().len());
+    }
+
+    #[test]
+    fn test_remove_transactions_and_descendants() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_3 = tx_2.next();
+        let tx_4 = tx_3.next();
+
+        // Create 5 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+        let v3 = f.validated(tx_3);
+        let v4 = f.validated(tx_4);
+
+        // Add them to the pool
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v4, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(5, pool.pending_transactions().len());
+
+        pool.remove_transactions_and_descendants(vec![*v0.hash(), *v2.hash()]);
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(0, pool.pending_transactions().len());
+    }
+    #[test]
+    fn test_remove_descendants() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = tx_1.next();
+        let tx_3 = tx_2.next();
+
+        // Create 4 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+        let v3 = f.validated(tx_3);
+
+        // Add them to the  pool
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(4, pool.pending_transactions().len());
+
+        let mut removed = Vec::new();
+        pool.remove_transaction(v0.id());
+        pool.remove_descendants(v0.id(), &mut removed);
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(0, pool.pending_transactions().len());
+        assert_eq!(3, removed.len());
+    }
+    #[test]
+    fn test_remove_transactions_by_sender() {
+        let on_chain_balance = U256::from(10_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_3 = tx_2.next();
+        let tx_4 = tx_3.next();
+
+        // Create 5 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+        let v3 = f.validated(tx_3);
+        let v4 = f.validated(tx_4);
+
+        // Add them to the pool
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v4, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(5, pool.pending_transactions().len());
+
+        pool.remove_transactions_by_sender(v2.sender_id());
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(2, pool.pending_transactions().len());
+        assert!(pool.contains(v0.hash()));
+        assert!(pool.contains(v1.hash()));
+    }
+    #[test]
+    fn wrong_best_order_of_transactions() {
+        let on_chain_balance = U256::from(10_000);
+        let mut on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+        let tx_2 = tx_1.next();
+        let tx_3 = tx_2.next();
+
+        // Create 4 transactions
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+        let v2 = f.validated(tx_2);
+        let v3 = f.validated(tx_3);
+
+        // Add first 2 to the pool
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(2, pool.pending_transactions().len());
+
+        // Remove first (nonce 0) - simulating that it was taken to be a part of the block.
+        pool.remove_transaction(v0.id());
+
+        // Now add transaction with nonce 2
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        // v2 is in the queue now. v1 is still in 'pending'.
+        assert_eq!(1, pool.queued_transactions().len());
+        assert_eq!(1, pool.pending_transactions().len());
+
+        // Simulate new block arrival - and chain nonce increasing.
+        let mut updated_accounts = HashMap::default();
+        on_chain_nonce += 1;
+        updated_accounts.insert(
+            v0.sender_id(),
+            SenderInfo { state_nonce: on_chain_nonce, balance: on_chain_balance },
+        );
+        pool.update_accounts(updated_accounts);
+
+        // Transactions are not changed (IMHO - this is a bug, as transaction v2 should be in the
+        // 'pending' now).
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(2, pool.pending_transactions().len());
+
+        // Add transaction v3 - it 'unclogs' everything.
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
+        assert_eq!(0, pool.queued_transactions().len());
+        assert_eq!(3, pool.pending_transactions().len());
+
+        // It should have returned transactions in order (v1, v2, v3 - as there is nothing blocking
+        // them).
+        assert_eq!(
+            pool.best_transactions().map(|x| x.id().nonce).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn test_best_with_attributes() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let base_fee: u128 = 100;
+        let blob_fee: u128 = 100;
+
+        // set base fee and blob fee.
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = base_fee as u64;
+        block_info.pending_blob_fee = Some(blob_fee);
+        pool.set_block_info(block_info);
+
+        // Insert transactions with varying max_fee_per_gas and max_fee_per_blob_gas.
+        let tx1 = MockTransaction::eip4844()
+            .with_sender(Address::with_last_byte(1))
+            .with_max_fee(base_fee + 10)
+            .with_blob_fee(blob_fee + 10);
+        let tx2 = MockTransaction::eip4844()
+            .with_sender(Address::with_last_byte(2))
+            .with_max_fee(base_fee + 10)
+            .with_blob_fee(blob_fee);
+        let tx3 = MockTransaction::eip4844()
+            .with_sender(Address::with_last_byte(3))
+            .with_max_fee(base_fee)
+            .with_blob_fee(blob_fee + 10);
+        let tx4 = MockTransaction::eip4844()
+            .with_sender(Address::with_last_byte(4))
+            .with_max_fee(base_fee)
+            .with_blob_fee(blob_fee);
+        let tx5 = MockTransaction::eip4844()
+            .with_sender(Address::with_last_byte(5))
+            .with_max_fee(base_fee)
+            .with_blob_fee(blob_fee - 10);
+        let tx6 = MockTransaction::eip4844()
+            .with_sender(Address::with_last_byte(6))
+            .with_max_fee(base_fee - 10)
+            .with_blob_fee(blob_fee);
+        let tx7 = MockTransaction::eip4844()
+            .with_sender(Address::with_last_byte(7))
+            .with_max_fee(base_fee - 10)
+            .with_blob_fee(blob_fee - 10);
+
+        for tx in vec![
+            tx1.clone(),
+            tx2.clone(),
+            tx3.clone(),
+            tx4.clone(),
+            tx5.clone(),
+            tx6.clone(),
+            tx7.clone(),
+        ] {
+            pool.add_transaction(f.validated(tx.clone()), on_chain_balance, on_chain_nonce, None)
+                .unwrap();
+        }
+
+        let base_fee = base_fee as u64;
+        let blob_fee = blob_fee as u64;
+
+        let cases = vec![
+            // 1. Base fee increase, blob fee increase
+            (BestTransactionsAttributes::new(base_fee + 5, Some(blob_fee + 5)), vec![tx1.clone()]),
+            // 2. Base fee increase, blob fee not change
+            (
+                BestTransactionsAttributes::new(base_fee + 5, Some(blob_fee)),
+                vec![tx1.clone(), tx2.clone()],
+            ),
+            // 3. Base fee increase, blob fee decrease
+            (
+                BestTransactionsAttributes::new(base_fee + 5, Some(blob_fee - 5)),
+                vec![tx1.clone(), tx2.clone()],
+            ),
+            // 4. Base fee not change, blob fee increase
+            (
+                BestTransactionsAttributes::new(base_fee, Some(blob_fee + 5)),
+                vec![tx1.clone(), tx3.clone()],
+            ),
+            // 5. Base fee not change, blob fee not change
+            (
+                BestTransactionsAttributes::new(base_fee, Some(blob_fee)),
+                vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()],
+            ),
+            // 6. Base fee not change, blob fee decrease
+            (
+                BestTransactionsAttributes::new(base_fee, Some(blob_fee - 10)),
+                vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone(), tx5.clone()],
+            ),
+            // 7. Base fee decrease, blob fee increase
+            (
+                BestTransactionsAttributes::new(base_fee - 5, Some(blob_fee + 5)),
+                vec![tx1.clone(), tx3.clone()],
+            ),
+            // 8. Base fee decrease, blob fee not change
+            (
+                BestTransactionsAttributes::new(base_fee - 10, Some(blob_fee)),
+                vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone(), tx6.clone()],
+            ),
+            // 9. Base fee decrease, blob fee decrease
+            (
+                BestTransactionsAttributes::new(base_fee - 10, Some(blob_fee - 10)),
+                vec![tx1, tx2, tx5, tx3, tx4, tx6, tx7],
+            ),
+        ];
+
+        for (idx, (attribute, expected)) in cases.into_iter().enumerate() {
+            let mut best = pool.best_transactions_with_attributes(attribute);
+
+            for (tx_idx, expected_tx) in expected.into_iter().enumerate() {
+                let tx = best.next().expect("Transaction should be returned");
+                assert_eq!(
+                    tx.transaction,
+                    expected_tx,
+                    "Failed tx {} in case {}",
+                    tx_idx + 1,
+                    idx + 1
+                );
+            }
+
+            // No more transactions should be returned
+            assert!(best.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_pending_ordering() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let tx_0 = MockTransaction::eip1559().with_nonce(1).set_gas_price(100).inc_limit();
+        let tx_1 = tx_0.next();
+
+        let v0 = f.validated(tx_0);
+        let v1 = f.validated(tx_1);
+
+        // nonce gap, tx should be queued
+        pool.add_transaction(v0.clone(), U256::MAX, 0, None).unwrap();
+        assert_eq!(1, pool.queued_transactions().len());
+
+        // nonce gap is closed on-chain, both transactions should be moved to pending
+        pool.add_transaction(v1, U256::MAX, 1, None).unwrap();
+
+        assert_eq!(2, pool.pending_transactions().len());
+        assert_eq!(0, pool.queued_transactions().len());
+
+        assert_eq!(
+            pool.pending_pool.independent().get(&v0.sender_id()).unwrap().transaction.nonce(),
+            v0.nonce()
+        );
+    }
+
+    // <https://github.com/paradigmxyz/reth/issues/12286>
+    #[test]
+    fn one_sender_one_independent_transaction() {
+        let mut on_chain_balance = U256::from(4_999); // only enough for 4 txs
+        let mut on_chain_nonce = 40;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::mock();
+        let mut submitted_txs = Vec::new();
+
+        // We use a "template" because we want all txs to have the same sender.
+        let template =
+            MockTransaction::eip1559().inc_price().inc_limit().with_value(U256::from(1_001));
+
+        // Add 8 txs. Because the balance is only sufficient for 4, so the last 4 will be
+        // Queued.
+        for tx_nonce in 40..48 {
+            let tx = f.validated(template.clone().with_nonce(tx_nonce).rng_hash());
+            submitted_txs.push(*tx.id());
+            pool.add_transaction(tx, on_chain_balance, on_chain_nonce, None).unwrap();
+        }
+
+        // A block is mined with two txs (so nonce is changed from 40 to 42).
+        // Now the balance gets so high that it's enough to execute alltxs.
+        on_chain_balance = U256::from(999_999);
+        on_chain_nonce = 42;
+        pool.remove_transaction(&submitted_txs[0]);
+        pool.remove_transaction(&submitted_txs[1]);
+
+        // Add 4 txs.
+        for tx_nonce in 48..52 {
+            pool.add_transaction(
+                f.validated(template.clone().with_nonce(tx_nonce).rng_hash()),
+                on_chain_balance,
+                on_chain_nonce,
+                None,
+            )
+            .unwrap();
+        }
+
+        let best_txs: Vec<_> = pool.pending().best().map(|tx| *tx.id()).collect();
+        assert_eq!(best_txs.len(), 10); // 8 - 2 + 4 = 10
+
+        assert_eq!(pool.pending_pool.independent().len(), 1);
+    }
+
+    #[test]
+    fn test_insertion_disorder() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let sender = address!("0x1234567890123456789012345678901234567890");
+        let tx0 = f.validated_arc(
+            MockTransaction::legacy().with_sender(sender).with_nonce(0).with_gas_price(10),
+        );
+        let tx1 = f.validated_arc(
+            MockTransaction::eip1559()
+                .with_sender(sender)
+                .with_nonce(1)
+                .with_gas_limit(1000)
+                .with_gas_price(10),
+        );
+        let tx2 = f.validated_arc(
+            MockTransaction::legacy().with_sender(sender).with_nonce(2).with_gas_price(10),
+        );
+        let tx3 = f.validated_arc(
+            MockTransaction::legacy().with_sender(sender).with_nonce(3).with_gas_price(10),
+        );
+
+        // tx0 should be put in the pending subpool
+        pool.add_transaction((*tx0).clone(), U256::from(1000), 0, None).unwrap();
+        let mut best = pool.best_transactions();
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        // tx1 should be put in the queued subpool due to insufficient sender balance
+        pool.add_transaction((*tx1).clone(), U256::from(1000), 0, None).unwrap();
+        let mut best = pool.best_transactions();
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        assert!(best.next().is_none());
+
+        // tx2 should be put in the pending subpool, and tx1 should be promoted to pending
+        pool.add_transaction((*tx2).clone(), U256::MAX, 0, None).unwrap();
+
+        let mut best = pool.best_transactions();
+
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        let t1 = best.next().expect("tx1 should be put in the pending subpool");
+        let t2 = best.next().expect("tx2 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        assert_eq!(t1.id(), tx1.id());
+        assert_eq!(t2.id(), tx2.id());
+
+        // tx3 should be put in the pending subpool,
+        pool.add_transaction((*tx3).clone(), U256::MAX, 0, None).unwrap();
+        let mut best = pool.best_transactions();
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        let t1 = best.next().expect("tx1 should be put in the pending subpool");
+        let t2 = best.next().expect("tx2 should be put in the pending subpool");
+        let t3 = best.next().expect("tx3 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        assert_eq!(t1.id(), tx1.id());
+        assert_eq!(t2.id(), tx2.id());
+        assert_eq!(t3.id(), tx3.id());
+    }
+
+    #[test]
+    fn test_non_4844_blob_fee_bit_invariant() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let non_4844_tx = MockTransaction::eip1559().set_max_fee(200).inc_limit();
+        let validated = f.validated(non_4844_tx.clone());
+
+        assert!(!non_4844_tx.is_eip4844());
+        pool.add_transaction(validated.clone(), U256::from(10_000), 0, None).unwrap();
+
+        // Core invariant: Non-4844 transactions must ALWAYS have ENOUGH_BLOB_FEE_CAP_BLOCK bit
+        let tx_meta = pool.all_transactions.txs.get(validated.id()).unwrap();
+        assert!(tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(tx_meta.subpool, SubPool::Pending);
+    }
+
+    #[test]
+    fn test_blob_fee_enforcement_only_applies_to_eip4844() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // Set blob fee higher than EIP-4844 tx can afford
+        let mut block_info = pool.block_info();
+        block_info.pending_blob_fee = Some(160);
+        block_info.pending_basefee = 100;
+        pool.set_block_info(block_info);
+
+        let eip4844_tx = MockTransaction::eip4844()
+            .with_sender(address!("0x000000000000000000000000000000000000000a"))
+            .with_max_fee(200)
+            .with_blob_fee(150) // Less than block blob fee (160)
+            .inc_limit();
+
+        let non_4844_tx = MockTransaction::eip1559()
+            .with_sender(address!("0x000000000000000000000000000000000000000b"))
+            .set_max_fee(200)
+            .inc_limit();
+
+        let validated_4844 = f.validated(eip4844_tx);
+        let validated_non_4844 = f.validated(non_4844_tx);
+
+        pool.add_transaction(validated_4844.clone(), U256::from(10_000), 0, None).unwrap();
+        pool.add_transaction(validated_non_4844.clone(), U256::from(10_000), 0, None).unwrap();
+
+        let tx_4844_meta = pool.all_transactions.txs.get(validated_4844.id()).unwrap();
+        let tx_non_4844_meta = pool.all_transactions.txs.get(validated_non_4844.id()).unwrap();
+
+        // EIP-4844: blob fee enforcement applies - insufficient blob fee removes bit
+        assert!(!tx_4844_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(tx_4844_meta.subpool, SubPool::Blob);
+
+        // Non-4844: blob fee enforcement does NOT apply - bit always remains true
+        assert!(tx_non_4844_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(tx_non_4844_meta.subpool, SubPool::Pending);
+    }
+
+    #[test]
+    fn test_basefee_decrease_preserves_non_4844_blob_fee_bit() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        // Create non-4844 transaction with fee that initially can't afford high basefee
+        let non_4844_tx = MockTransaction::eip1559()
+            .with_sender(address!("0x000000000000000000000000000000000000000a"))
+            .set_max_fee(500) // Can't afford basefee of 600
+            .inc_limit();
+
+        // Set high basefee so transaction goes to BaseFee pool initially
+        pool.update_basefee(600, |_| {});
+
+        let validated = f.validated(non_4844_tx);
+        let tx_id = *validated.id();
+        pool.add_transaction(validated, U256::from(10_000), 0, None).unwrap();
+
+        // Initially should be in BaseFee pool but STILL have blob fee bit (critical invariant)
+        let tx_meta = pool.all_transactions.txs.get(&tx_id).unwrap();
+        assert_eq!(tx_meta.subpool, SubPool::BaseFee);
+        assert!(
+            tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK),
+            "Non-4844 tx in BaseFee pool must retain ENOUGH_BLOB_FEE_CAP_BLOCK bit"
+        );
+
+        // Decrease basefee - transaction should be promoted to Pending
+        // This is where PR #18215 bug would manifest: blob fee bit incorrectly removed
+        pool.update_basefee(400, |_| {});
+
+        // After basefee decrease: should be promoted to Pending with blob fee bit preserved
+        let tx_meta = pool.all_transactions.txs.get(&tx_id).unwrap();
+        assert_eq!(
+            tx_meta.subpool,
+            SubPool::Pending,
+            "Non-4844 tx should be promoted from BaseFee to Pending after basefee decrease"
+        );
+        assert!(
+            tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK),
+            "Non-4844 tx must NEVER lose ENOUGH_BLOB_FEE_CAP_BLOCK bit during basefee promotion"
+        );
+        assert!(
+            tx_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK),
+            "Non-4844 tx should gain ENOUGH_FEE_CAP_BLOCK bit after basefee decrease"
+        );
+    }
+
+    /// Test for <https://github.com/paradigmxyz/reth/issues/17701>
+    ///
+    /// When a new transaction is added and its `updates` contain a same-sender transaction with
+    /// a lower nonce, the lower-nonce tx must be added to the pending subpool *before* the
+    /// higher-nonce tx. Otherwise, live `BestTransactions` iterators receive them out of order.
+    #[test]
+    fn best_transactions_nonce_order_on_balance_unlock() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let sender = Address::random();
+        let on_chain_balance = U256::from(10_000);
+
+        // tx0: nonce 0, cheap — will go straight to pending
+        let tx0 = MockTransaction::eip1559().with_sender(sender).set_gas_price(100).inc_limit();
+        // tx1: nonce 1, very expensive — cumulative cost (tx0 + tx1) will exceed balance
+        let tx1 = tx0.next().inc_limit().with_value(U256::from(on_chain_balance));
+        // tx2: nonce 2
+        let tx2 = tx1.next().inc_limit().with_value(U256::ZERO);
+
+        let v0 = f.validated(tx0);
+        let v1 = f.validated(tx1);
+        let v2 = f.validated(tx2);
+
+        // Add tx0 with limited balance — goes to pending (tx0 cost is small: 1 * 100 = 100)
+        pool.add_transaction(v0, on_chain_balance, 0, None).unwrap();
+
+        // Create a live BestTransactions iterator that will receive new pending txs
+        let mut best = pool.best_transactions();
+
+        // Drain tx0 from the iterator
+        let first = best.next().expect("should yield tx0");
+        assert_eq!(first.id().nonce, 0);
+
+        // Add tx1 with the same limited balance — cumulative cost exceeds balance, goes to
+        // queued
+        pool.add_transaction(v1, on_chain_balance, 0, None).unwrap();
+
+        // tx1 should be queued, nothing new in best
+        assert!(best.next().is_none(), "tx1 should be queued, not pending");
+
+        // Now add tx2 with U256::MAX balance — tx2 goes to pending AND tx1 gets promoted.
+        // The bug: tx2 was added to pending *before* tx1, so BestTransactions yielded tx2
+        // first, violating nonce ordering.
+        pool.add_transaction(v2, U256::MAX, 0, None).unwrap();
+
+        let t1 = best.next().expect("should yield a transaction");
+        let t2 = best.next().expect("should yield a transaction");
+
+        // Correct order: tx1 (nonce 1) before tx2 (nonce 2)
+        assert_eq!(
+            t1.id().nonce,
+            1,
+            "first yielded tx should be nonce 1, got nonce {}",
+            t1.id().nonce
+        );
+        assert_eq!(
+            t2.id().nonce,
+            2,
+            "second yielded tx should be nonce 2, got nonce {}",
+            t2.id().nonce
+        );
+    }
+
+    /// Gap-fill scenario: inserting a low-nonce transaction promotes a queued higher-nonce
+    /// transaction. The new (lower-nonce) tx must appear before the promoted (higher-nonce)
+    /// tx in the `BestTransactions` iterator.
+    #[test]
+    fn best_transactions_nonce_order_on_gap_fill() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let sender = Address::random();
+        let balance = U256::MAX;
+
+        // tx0: nonce 0
+        let tx0 = MockTransaction::eip1559().with_sender(sender).set_gas_price(100).inc_limit();
+        // tx1: nonce 1
+        let tx1 = tx0.next().inc_limit();
+
+        let v0 = f.validated(tx0);
+        let v1 = f.validated(tx1);
+
+        // Add tx1 first — goes to queued because nonce 0 is missing (nonce gap)
+        pool.add_transaction(v1, balance, 0, None).unwrap();
+
+        // Create a live BestTransactions iterator (currently empty — nothing pending)
+        let mut best = pool.best_transactions();
+        assert!(best.next().is_none(), "pool should have no pending txs yet");
+
+        // Add tx0 — fills the gap, tx1 gets promoted
+        pool.add_transaction(v0, balance, 0, None).unwrap();
+
+        let t0 = best.next().expect("should yield a transaction");
+        let t1 = best.next().expect("should yield a transaction");
+
+        assert_eq!(t0.id().nonce, 0, "first yielded tx should be nonce 0, got {}", t0.id().nonce);
+        assert_eq!(t1.id().nonce, 1, "second yielded tx should be nonce 1, got {}", t1.id().nonce);
+    }
+
+    /// Mixed scenario: inserting a mid-nonce transaction promotes both a lower-nonce tx
+    /// (via balance update) and a higher-nonce tx (via gap fill). All three must appear
+    /// in nonce order in `BestTransactions`.
+    #[test]
+    fn best_transactions_nonce_order_mixed_promotions() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let sender = Address::random();
+        let low_balance = U256::from(10_000);
+
+        // tx0: nonce 0, cheap
+        let tx0 = MockTransaction::eip1559().with_sender(sender).set_gas_price(100).inc_limit();
+        // tx1: nonce 1, very expensive — will exceed balance
+        let tx1 = tx0.next().inc_limit().with_value(U256::from(low_balance));
+        // tx2: nonce 2
+        let tx2 = tx1.next().inc_limit().with_value(U256::ZERO);
+        // tx3: nonce 3
+        let tx3 = tx2.next().inc_limit().with_value(U256::ZERO);
+
+        let v0 = f.validated(tx0);
+        let v1 = f.validated(tx1);
+        let v2 = f.validated(tx2);
+        let v3 = f.validated(tx3);
+
+        // Add tx0 — goes to pending
+        pool.add_transaction(v0, low_balance, 0, None).unwrap();
+
+        // Add tx1 — queued (cumulative cost exceeds balance)
+        pool.add_transaction(v1, low_balance, 0, None).unwrap();
+
+        // Add tx3 — queued (nonce gap: tx2 is missing)
+        pool.add_transaction(v3, low_balance, 0, None).unwrap();
+
+        let mut best = pool.best_transactions();
+
+        // Drain tx0
+        let first = best.next().expect("should yield tx0");
+        assert_eq!(first.id().nonce, 0);
+        assert!(best.next().is_none(), "only tx0 should be pending");
+
+        // Add tx2 with U256::MAX balance — this should:
+        //  - promote tx1 (lower-nonce, was queued due to balance)
+        //  - add tx2 itself to pending
+        //  - promote tx3 (higher-nonce, was queued due to nonce gap)
+        pool.add_transaction(v2, U256::MAX, 0, None).unwrap();
+
+        let t1 = best.next().expect("should yield nonce 1");
+        let t2 = best.next().expect("should yield nonce 2");
+        let t3 = best.next().expect("should yield nonce 3");
+
+        assert_eq!(t1.id().nonce, 1, "expected nonce 1, got {}", t1.id().nonce);
+        assert_eq!(t2.id().nonce, 2, "expected nonce 2, got {}", t2.id().nonce);
+        assert_eq!(t3.id().nonce, 3, "expected nonce 3, got {}", t3.id().nonce);
+    }
+}

--- a/patches/reth-transaction-pool/src/pool/update.rs
+++ b/patches/reth-transaction-pool/src/pool/update.rs
@@ -1,0 +1,49 @@
+//! Support types for updating the pool.
+
+use crate::{
+    identifier::TransactionId, pool::state::SubPool, PoolTransaction, ValidPoolTransaction,
+};
+use std::sync::Arc;
+
+/// A change of the transaction's location
+///
+/// NOTE: this guarantees that `current` and `destination` differ.
+#[derive(Debug)]
+pub(crate) struct PoolUpdate {
+    /// Internal tx id.
+    pub(crate) id: TransactionId,
+    /// Where the transaction is currently held.
+    pub(crate) current: SubPool,
+    /// Where to move the transaction to.
+    pub(crate) destination: Destination,
+}
+
+/// Where to move an existing transaction.
+#[derive(Debug)]
+pub(crate) enum Destination {
+    /// Discard the transaction.
+    Discard,
+    /// Move transaction to pool
+    Pool(SubPool),
+}
+
+impl From<SubPool> for Destination {
+    fn from(sub_pool: SubPool) -> Self {
+        Self::Pool(sub_pool)
+    }
+}
+
+/// Tracks the result after updating the pool
+#[derive(Debug)]
+pub struct UpdateOutcome<T: PoolTransaction> {
+    /// transactions promoted to the pending pool
+    pub promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+    /// transaction that failed and were discarded
+    pub discarded: Vec<Arc<ValidPoolTransaction<T>>>,
+}
+
+impl<T: PoolTransaction> Default for UpdateOutcome<T> {
+    fn default() -> Self {
+        Self { promoted: vec![], discarded: vec![] }
+    }
+}

--- a/patches/reth-transaction-pool/src/test_utils/mock.rs
+++ b/patches/reth-transaction-pool/src/test_utils/mock.rs
@@ -1,0 +1,1891 @@
+//! Mock types.
+
+use crate::{
+    identifier::{SenderIdentifiers, TransactionId},
+    pool::txpool::TxPool,
+    traits::TransactionOrigin,
+    CoinbaseTipOrdering, EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction,
+    ValidPoolTransaction,
+};
+use alloy_consensus::{
+    constants::{
+        EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+        LEGACY_TX_TYPE_ID,
+    },
+    EthereumTxEnvelope, Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702,
+    TxLegacy, TxType, Typed2718,
+};
+use alloy_eips::{
+    eip1559::MIN_PROTOCOL_BASE_FEE,
+    eip2930::AccessList,
+    eip4844::{BlobTransactionSidecar, BlobTransactionValidationError, DATA_GAS_PER_BLOB},
+    eip7594::BlobTransactionSidecarVariant,
+    eip7702::SignedAuthorization,
+};
+use alloy_primitives::{Address, Bytes, ChainId, Signature, TxHash, TxKind, B256, U256};
+use paste::paste;
+use rand::{distr::Uniform, prelude::Distribution};
+use reth_ethereum_primitives::{PooledTransactionVariant, Transaction, TransactionSigned};
+use reth_primitives_traits::{
+    transaction::error::TryFromRecoveredTransactionError, InMemorySize, Recovered,
+    SignedTransaction,
+};
+
+use alloy_consensus::error::ValueError;
+use alloy_eips::eip4844::env_settings::KzgSettings;
+use rand::distr::weighted::WeightedIndex;
+use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
+
+/// A transaction pool implementation using [`MockOrdering`] for transaction ordering.
+///
+/// This type is an alias for [`TxPool<MockOrdering>`].
+pub type MockTxPool = TxPool<MockOrdering>;
+
+/// A validated transaction in the transaction pool, using [`MockTransaction`] as the transaction
+/// type.
+///
+/// This type is an alias for [`ValidPoolTransaction<MockTransaction>`].
+pub type MockValidTx = ValidPoolTransaction<MockTransaction>;
+
+/// Create an empty `TxPool`
+pub fn mock_tx_pool() -> MockTxPool {
+    MockTxPool::new(Default::default(), Default::default())
+}
+
+/// Sets the value for the field
+macro_rules! set_value {
+    // For mutable references
+    (&mut $this:expr => $field:ident) => {{
+        let new_value = $field;
+        match $this {
+            MockTransaction::Legacy { $field, .. } => {
+                *$field = new_value;
+            }
+            MockTransaction::Eip1559 { $field, .. } => {
+                *$field = new_value;
+            }
+            MockTransaction::Eip4844 { $field, .. } => {
+                *$field = new_value;
+            }
+            MockTransaction::Eip2930 { $field, .. } => {
+                *$field = new_value;
+            }
+            MockTransaction::Eip7702 { $field, .. } => {
+                *$field = new_value;
+            }
+        }
+        // Ensure the tx cost is always correct after each mutation.
+        $this.update_cost();
+    }};
+    // For owned values
+    ($this:expr => $field:ident) => {{
+        let new_value = $field;
+        match $this {
+            MockTransaction::Legacy { ref mut $field, .. } |
+            MockTransaction::Eip1559 { ref mut $field, .. } |
+            MockTransaction::Eip4844 { ref mut $field, .. } |
+            MockTransaction::Eip2930 { ref mut $field, .. } |
+            MockTransaction::Eip7702 { ref mut $field, .. } => {
+                *$field = new_value;
+            }
+        }
+        // Ensure the tx cost is always correct after each mutation.
+        $this.update_cost();
+    }};
+}
+
+/// Gets the value for the field
+macro_rules! get_value {
+    ($this:tt => $field:ident) => {
+        match $this {
+            MockTransaction::Legacy { $field, .. } |
+            MockTransaction::Eip1559 { $field, .. } |
+            MockTransaction::Eip4844 { $field, .. } |
+            MockTransaction::Eip2930 { $field, .. } |
+            MockTransaction::Eip7702 { $field, .. } => $field,
+        }
+    };
+}
+
+// Generates all setters and getters
+macro_rules! make_setters_getters {
+    ($($name:ident => $t:ty);*) => {
+        paste! {$(
+            /// Sets the value of the specified field.
+            pub fn [<set_ $name>](&mut self, $name: $t) -> &mut Self {
+                set_value!(&mut self => $name);
+                self
+            }
+
+            /// Sets the value of the specified field using a fluent interface.
+            pub fn [<with_ $name>](mut self, $name: $t) -> Self {
+                set_value!(self => $name);
+                self
+            }
+
+            /// Gets the value of the specified field.
+            pub const fn [<get_ $name>](&self) -> &$t {
+                get_value!(self => $name)
+            }
+        )*}
+    };
+}
+
+/// A Bare transaction type used for testing.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum MockTransaction {
+    /// Legacy transaction type.
+    Legacy {
+        /// The chain id of the transaction.
+        chain_id: Option<ChainId>,
+        /// The hash of the transaction.
+        hash: B256,
+        /// The sender's address.
+        sender: Address,
+        /// The transaction nonce.
+        nonce: u64,
+        /// The gas price for the transaction.
+        gas_price: u128,
+        /// The gas limit for the transaction.
+        gas_limit: u64,
+        /// The transaction's destination.
+        to: TxKind,
+        /// The value of the transaction.
+        value: U256,
+        /// The transaction input data.
+        input: Bytes,
+        /// The size of the transaction, returned in the implementation of [`PoolTransaction`].
+        size: usize,
+        /// The cost of the transaction, returned in the implementation of [`PoolTransaction`].
+        cost: U256,
+    },
+    /// EIP-2930 transaction type.
+    Eip2930 {
+        /// The chain id of the transaction.
+        chain_id: ChainId,
+        /// The hash of the transaction.
+        hash: B256,
+        /// The sender's address.
+        sender: Address,
+        /// The transaction nonce.
+        nonce: u64,
+        /// The transaction's destination.
+        to: TxKind,
+        /// The gas limit for the transaction.
+        gas_limit: u64,
+        /// The transaction input data.
+        input: Bytes,
+        /// The value of the transaction.
+        value: U256,
+        /// The gas price for the transaction.
+        gas_price: u128,
+        /// The access list associated with the transaction.
+        access_list: AccessList,
+        /// The size of the transaction, returned in the implementation of [`PoolTransaction`].
+        size: usize,
+        /// The cost of the transaction, returned in the implementation of [`PoolTransaction`].
+        cost: U256,
+    },
+    /// EIP-1559 transaction type.
+    Eip1559 {
+        /// The chain id of the transaction.
+        chain_id: ChainId,
+        /// The hash of the transaction.
+        hash: B256,
+        /// The sender's address.
+        sender: Address,
+        /// The transaction nonce.
+        nonce: u64,
+        /// The maximum fee per gas for the transaction.
+        max_fee_per_gas: u128,
+        /// The maximum priority fee per gas for the transaction.
+        max_priority_fee_per_gas: u128,
+        /// The gas limit for the transaction.
+        gas_limit: u64,
+        /// The transaction's destination.
+        to: TxKind,
+        /// The value of the transaction.
+        value: U256,
+        /// The access list associated with the transaction.
+        access_list: AccessList,
+        /// The transaction input data.
+        input: Bytes,
+        /// The size of the transaction, returned in the implementation of [`PoolTransaction`].
+        size: usize,
+        /// The cost of the transaction, returned in the implementation of [`PoolTransaction`].
+        cost: U256,
+    },
+    /// EIP-4844 transaction type.
+    Eip4844 {
+        /// The chain id of the transaction.
+        chain_id: ChainId,
+        /// The hash of the transaction.
+        hash: B256,
+        /// The sender's address.
+        sender: Address,
+        /// The transaction nonce.
+        nonce: u64,
+        /// The maximum fee per gas for the transaction.
+        max_fee_per_gas: u128,
+        /// The maximum priority fee per gas for the transaction.
+        max_priority_fee_per_gas: u128,
+        /// The maximum fee per blob gas for the transaction.
+        max_fee_per_blob_gas: u128,
+        /// The gas limit for the transaction.
+        gas_limit: u64,
+        /// The transaction's destination.
+        to: Address,
+        /// The value of the transaction.
+        value: U256,
+        /// The access list associated with the transaction.
+        access_list: AccessList,
+        /// The transaction input data.
+        input: Bytes,
+        /// The sidecar information for the transaction.
+        sidecar: BlobTransactionSidecarVariant,
+        /// The blob versioned hashes for the transaction.
+        blob_versioned_hashes: Vec<B256>,
+        /// The size of the transaction, returned in the implementation of [`PoolTransaction`].
+        size: usize,
+        /// The cost of the transaction, returned in the implementation of [`PoolTransaction`].
+        cost: U256,
+    },
+    /// EIP-7702 transaction type.
+    Eip7702 {
+        /// The chain id of the transaction.
+        chain_id: ChainId,
+        /// The hash of the transaction.
+        hash: B256,
+        /// The sender's address.
+        sender: Address,
+        /// The transaction nonce.
+        nonce: u64,
+        /// The maximum fee per gas for the transaction.
+        max_fee_per_gas: u128,
+        /// The maximum priority fee per gas for the transaction.
+        max_priority_fee_per_gas: u128,
+        /// The gas limit for the transaction.
+        gas_limit: u64,
+        /// The transaction's destination.
+        to: Address,
+        /// The value of the transaction.
+        value: U256,
+        /// The access list associated with the transaction.
+        access_list: AccessList,
+        /// The authorization list associated with the transaction.
+        authorization_list: Vec<SignedAuthorization>,
+        /// The transaction input data.
+        input: Bytes,
+        /// The size of the transaction, returned in the implementation of [`PoolTransaction`].
+        size: usize,
+        /// The cost of the transaction, returned in the implementation of [`PoolTransaction`].
+        cost: U256,
+    },
+}
+
+// === impl MockTransaction ===
+
+impl MockTransaction {
+    make_setters_getters! {
+        nonce => u64;
+        hash => B256;
+        sender => Address;
+        gas_limit => u64;
+        value => U256;
+        input => Bytes;
+        size => usize
+    }
+
+    /// Returns a new legacy transaction with random address and hash and empty values
+    pub fn legacy() -> Self {
+        Self::Legacy {
+            chain_id: Some(1),
+            hash: B256::random(),
+            sender: Address::random(),
+            nonce: 0,
+            gas_price: 0,
+            gas_limit: 0,
+            to: Address::random().into(),
+            value: Default::default(),
+            input: Default::default(),
+            size: Default::default(),
+            cost: U256::ZERO,
+        }
+    }
+
+    /// Returns a new EIP2930 transaction with random address and hash and empty values
+    pub fn eip2930() -> Self {
+        Self::Eip2930 {
+            chain_id: 1,
+            hash: B256::random(),
+            sender: Address::random(),
+            nonce: 0,
+            to: Address::random().into(),
+            gas_limit: 0,
+            input: Bytes::new(),
+            value: Default::default(),
+            gas_price: 0,
+            access_list: Default::default(),
+            size: Default::default(),
+            cost: U256::ZERO,
+        }
+    }
+
+    /// Returns a new EIP1559 transaction with random address and hash and empty values
+    pub fn eip1559() -> Self {
+        Self::Eip1559 {
+            chain_id: 1,
+            hash: B256::random(),
+            sender: Address::random(),
+            nonce: 0,
+            max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
+            max_priority_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
+            gas_limit: 0,
+            to: Address::random().into(),
+            value: Default::default(),
+            input: Bytes::new(),
+            access_list: Default::default(),
+            size: Default::default(),
+            cost: U256::ZERO,
+        }
+    }
+
+    /// Returns a new EIP7702 transaction with random address and hash and empty values
+    pub fn eip7702() -> Self {
+        Self::Eip7702 {
+            chain_id: 1,
+            hash: B256::random(),
+            sender: Address::random(),
+            nonce: 0,
+            max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
+            max_priority_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
+            gas_limit: 0,
+            to: Address::random(),
+            value: Default::default(),
+            input: Bytes::new(),
+            access_list: Default::default(),
+            authorization_list: vec![],
+            size: Default::default(),
+            cost: U256::ZERO,
+        }
+    }
+
+    /// Returns a new EIP4844 transaction with random address and hash and empty values
+    pub fn eip4844() -> Self {
+        Self::Eip4844 {
+            chain_id: 1,
+            hash: B256::random(),
+            sender: Address::random(),
+            nonce: 0,
+            max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
+            max_priority_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
+            max_fee_per_blob_gas: DATA_GAS_PER_BLOB as u128,
+            gas_limit: 0,
+            to: Address::random(),
+            value: Default::default(),
+            input: Bytes::new(),
+            access_list: Default::default(),
+            sidecar: BlobTransactionSidecarVariant::Eip4844(Default::default()),
+            blob_versioned_hashes: Default::default(),
+            size: Default::default(),
+            cost: U256::ZERO,
+        }
+    }
+
+    /// Returns a new EIP4844 transaction with a provided sidecar
+    pub fn eip4844_with_sidecar(sidecar: BlobTransactionSidecarVariant) -> Self {
+        let mut transaction = Self::eip4844();
+        if let Self::Eip4844 { sidecar: existing_sidecar, blob_versioned_hashes, .. } =
+            &mut transaction
+        {
+            *blob_versioned_hashes = sidecar.versioned_hashes().collect();
+            *existing_sidecar = sidecar;
+        }
+        transaction
+    }
+
+    /// Creates a new transaction with the given [`TxType`].
+    ///
+    /// See the default constructors for each of the transaction types:
+    ///
+    /// * [`MockTransaction::legacy`]
+    /// * [`MockTransaction::eip2930`]
+    /// * [`MockTransaction::eip1559`]
+    /// * [`MockTransaction::eip4844`]
+    pub fn new_from_type(tx_type: TxType) -> Self {
+        match tx_type {
+            TxType::Legacy => Self::legacy(),
+            TxType::Eip2930 => Self::eip2930(),
+            TxType::Eip1559 => Self::eip1559(),
+            TxType::Eip4844 => Self::eip4844(),
+            TxType::Eip7702 => Self::eip7702(),
+        }
+    }
+
+    /// Sets the max fee per blob gas for EIP-4844 transactions,
+    pub const fn with_blob_fee(mut self, val: u128) -> Self {
+        self.set_blob_fee(val);
+        self
+    }
+
+    /// Sets the number of blob versioned hashes for EIP-4844 transactions.
+    pub fn with_blob_hashes(mut self, count: usize) -> Self {
+        if let Self::Eip4844 { blob_versioned_hashes, .. } = &mut self {
+            *blob_versioned_hashes = (0..count).map(|_| B256::random()).collect();
+        }
+        self
+    }
+
+    /// Sets the max fee per blob gas for EIP-4844 transactions,
+    pub const fn set_blob_fee(&mut self, val: u128) -> &mut Self {
+        if let Self::Eip4844 { max_fee_per_blob_gas, .. } = self {
+            *max_fee_per_blob_gas = val;
+        }
+        self
+    }
+
+    /// Sets the priority fee for dynamic fee transactions (EIP-1559 and EIP-4844)
+    pub const fn set_priority_fee(&mut self, val: u128) -> &mut Self {
+        if let Self::Eip1559 { max_priority_fee_per_gas, .. } |
+        Self::Eip4844 { max_priority_fee_per_gas, .. } = self
+        {
+            *max_priority_fee_per_gas = val;
+        }
+        self
+    }
+
+    /// Sets the priority fee for dynamic fee transactions (EIP-1559 and EIP-4844)
+    pub const fn with_priority_fee(mut self, val: u128) -> Self {
+        self.set_priority_fee(val);
+        self
+    }
+
+    /// Gets the priority fee for dynamic fee transactions (EIP-1559 and EIP-4844)
+    pub const fn get_priority_fee(&self) -> Option<u128> {
+        match self {
+            Self::Eip1559 { max_priority_fee_per_gas, .. } |
+            Self::Eip4844 { max_priority_fee_per_gas, .. } |
+            Self::Eip7702 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
+            _ => None,
+        }
+    }
+
+    /// Sets the max fee for dynamic fee transactions (EIP-1559 and EIP-4844)
+    pub const fn set_max_fee(&mut self, val: u128) -> &mut Self {
+        if let Self::Eip1559 { max_fee_per_gas, .. } |
+        Self::Eip4844 { max_fee_per_gas, .. } |
+        Self::Eip7702 { max_fee_per_gas, .. } = self
+        {
+            *max_fee_per_gas = val;
+        }
+        self
+    }
+
+    /// Sets the max fee for dynamic fee transactions (EIP-1559 and EIP-4844)
+    pub const fn with_max_fee(mut self, val: u128) -> Self {
+        self.set_max_fee(val);
+        self
+    }
+
+    /// Gets the max fee for dynamic fee transactions (EIP-1559 and EIP-4844)
+    pub const fn get_max_fee(&self) -> Option<u128> {
+        match self {
+            Self::Eip1559 { max_fee_per_gas, .. } |
+            Self::Eip4844 { max_fee_per_gas, .. } |
+            Self::Eip7702 { max_fee_per_gas, .. } => Some(*max_fee_per_gas),
+            _ => None,
+        }
+    }
+
+    /// Sets the access list for transactions supporting EIP-1559, EIP-4844, and EIP-2930.
+    pub fn set_accesslist(&mut self, list: AccessList) -> &mut Self {
+        match self {
+            Self::Legacy { .. } => {}
+            Self::Eip1559 { access_list: accesslist, .. } |
+            Self::Eip4844 { access_list: accesslist, .. } |
+            Self::Eip2930 { access_list: accesslist, .. } |
+            Self::Eip7702 { access_list: accesslist, .. } => {
+                *accesslist = list;
+            }
+        }
+        self
+    }
+
+    /// Sets the authorization list for EIP-7702 transactions.
+    pub fn set_authorization_list(&mut self, list: Vec<SignedAuthorization>) -> &mut Self {
+        if let Self::Eip7702 { authorization_list, .. } = self {
+            *authorization_list = list;
+        }
+
+        self
+    }
+
+    /// Sets the gas price for the transaction.
+    pub const fn set_gas_price(&mut self, val: u128) -> &mut Self {
+        match self {
+            Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => {
+                *gas_price = val;
+            }
+            Self::Eip1559 { max_fee_per_gas, max_priority_fee_per_gas, .. } |
+            Self::Eip4844 { max_fee_per_gas, max_priority_fee_per_gas, .. } |
+            Self::Eip7702 { max_fee_per_gas, max_priority_fee_per_gas, .. } => {
+                *max_fee_per_gas = val;
+                *max_priority_fee_per_gas = val;
+            }
+        }
+        self
+    }
+
+    /// Sets the gas price for the transaction.
+    pub const fn with_gas_price(mut self, val: u128) -> Self {
+        match self {
+            Self::Legacy { ref mut gas_price, .. } | Self::Eip2930 { ref mut gas_price, .. } => {
+                *gas_price = val;
+            }
+            Self::Eip1559 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } |
+            Self::Eip4844 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } |
+            Self::Eip7702 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } => {
+                *max_fee_per_gas = val;
+                *max_priority_fee_per_gas = val;
+            }
+        }
+        self
+    }
+
+    /// Gets the gas price for the transaction.
+    pub const fn get_gas_price(&self) -> u128 {
+        match self {
+            Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => *gas_price,
+            Self::Eip1559 { max_fee_per_gas, .. } |
+            Self::Eip4844 { max_fee_per_gas, .. } |
+            Self::Eip7702 { max_fee_per_gas, .. } => *max_fee_per_gas,
+        }
+    }
+
+    /// Returns a clone with a decreased nonce
+    pub fn prev(&self) -> Self {
+        self.clone().with_hash(B256::random()).with_nonce(self.get_nonce() - 1)
+    }
+
+    /// Returns a clone with an increased nonce
+    pub fn next(&self) -> Self {
+        self.clone().with_hash(B256::random()).with_nonce(self.get_nonce() + 1)
+    }
+
+    /// Returns a clone with an increased nonce
+    pub fn skip(&self, skip: u64) -> Self {
+        self.clone().with_hash(B256::random()).with_nonce(self.get_nonce() + skip + 1)
+    }
+
+    /// Returns a clone with incremented nonce
+    pub fn inc_nonce(self) -> Self {
+        let nonce = self.get_nonce() + 1;
+        self.with_nonce(nonce)
+    }
+
+    /// Sets a new random hash
+    pub fn rng_hash(self) -> Self {
+        self.with_hash(B256::random())
+    }
+
+    /// Returns a new transaction with a higher gas price +1
+    pub fn inc_price(&self) -> Self {
+        self.inc_price_by(1)
+    }
+
+    /// Returns a new transaction with a higher gas price
+    pub fn inc_price_by(&self, value: u128) -> Self {
+        self.clone().with_gas_price(self.get_gas_price().checked_add(value).unwrap())
+    }
+
+    /// Returns a new transaction with a lower gas price -1
+    pub fn decr_price(&self) -> Self {
+        self.decr_price_by(1)
+    }
+
+    /// Returns a new transaction with a lower gas price
+    pub fn decr_price_by(&self, value: u128) -> Self {
+        self.clone().with_gas_price(self.get_gas_price().checked_sub(value).unwrap())
+    }
+
+    /// Returns a new transaction with a higher value
+    pub fn inc_value(&self) -> Self {
+        self.clone().with_value(self.get_value().checked_add(U256::from(1)).unwrap())
+    }
+
+    /// Returns a new transaction with a higher gas limit
+    pub fn inc_limit(&self) -> Self {
+        self.clone().with_gas_limit(self.get_gas_limit() + 1)
+    }
+
+    /// Returns a new transaction with a higher blob fee +1
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn inc_blob_fee(&self) -> Self {
+        self.inc_blob_fee_by(1)
+    }
+
+    /// Returns a new transaction with a higher blob fee
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn inc_blob_fee_by(&self, value: u128) -> Self {
+        let mut this = self.clone();
+        if let Self::Eip4844 { max_fee_per_blob_gas, .. } = &mut this {
+            *max_fee_per_blob_gas = max_fee_per_blob_gas.checked_add(value).unwrap();
+        }
+        this
+    }
+
+    /// Returns a new transaction with a lower blob fee -1
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn decr_blob_fee(&self) -> Self {
+        self.decr_price_by(1)
+    }
+
+    /// Returns a new transaction with a lower blob fee
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn decr_blob_fee_by(&self, value: u128) -> Self {
+        let mut this = self.clone();
+        if let Self::Eip4844 { max_fee_per_blob_gas, .. } = &mut this {
+            *max_fee_per_blob_gas = max_fee_per_blob_gas.checked_sub(value).unwrap();
+        }
+        this
+    }
+
+    /// Returns the transaction type identifier associated with the current [`MockTransaction`].
+    pub const fn tx_type(&self) -> u8 {
+        match self {
+            Self::Legacy { .. } => LEGACY_TX_TYPE_ID,
+            Self::Eip1559 { .. } => EIP1559_TX_TYPE_ID,
+            Self::Eip4844 { .. } => EIP4844_TX_TYPE_ID,
+            Self::Eip2930 { .. } => EIP2930_TX_TYPE_ID,
+            Self::Eip7702 { .. } => EIP7702_TX_TYPE_ID,
+        }
+    }
+
+    /// Checks if the transaction is of the legacy type.
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self, Self::Legacy { .. })
+    }
+
+    /// Checks if the transaction is of the EIP-1559 type.
+    pub const fn is_eip1559(&self) -> bool {
+        matches!(self, Self::Eip1559 { .. })
+    }
+
+    /// Checks if the transaction is of the EIP-4844 type.
+    pub const fn is_eip4844(&self) -> bool {
+        matches!(self, Self::Eip4844 { .. })
+    }
+
+    /// Checks if the transaction is of the EIP-2930 type.
+    pub const fn is_eip2930(&self) -> bool {
+        matches!(self, Self::Eip2930 { .. })
+    }
+
+    /// Checks if the transaction is of the EIP-7702 type.
+    pub const fn is_eip7702(&self) -> bool {
+        matches!(self, Self::Eip7702 { .. })
+    }
+
+    fn update_cost(&mut self) {
+        match self {
+            Self::Legacy { cost, gas_limit, gas_price, value, .. } |
+            Self::Eip2930 { cost, gas_limit, gas_price, value, .. } => {
+                *cost = U256::from(*gas_limit) * U256::from(*gas_price) + *value
+            }
+            Self::Eip1559 { cost, gas_limit, max_fee_per_gas, value, .. } |
+            Self::Eip4844 { cost, gas_limit, max_fee_per_gas, value, .. } |
+            Self::Eip7702 { cost, gas_limit, max_fee_per_gas, value, .. } => {
+                *cost = U256::from(*gas_limit) * U256::from(*max_fee_per_gas) + *value
+            }
+        };
+    }
+}
+
+impl PoolTransaction for MockTransaction {
+    type TryFromConsensusError = ValueError<EthereumTxEnvelope<TxEip4844>>;
+
+    type Consensus = TransactionSigned;
+
+    type Pooled = PooledTransactionVariant;
+
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+        unimplemented!("mock transaction does not wrap a consensus transaction")
+    }
+
+    fn into_consensus(self) -> Recovered<Self::Consensus> {
+        self.into()
+    }
+
+    fn from_pooled(pooled: Recovered<Self::Pooled>) -> Self {
+        pooled.into()
+    }
+
+    fn hash(&self) -> &TxHash {
+        self.get_hash()
+    }
+
+    fn sender(&self) -> Address {
+        *self.get_sender()
+    }
+
+    fn sender_ref(&self) -> &Address {
+        self.get_sender()
+    }
+
+    // Having `get_cost` from `make_setters_getters` would be cleaner but we didn't
+    // want to also generate the error-prone cost setters. For now cost should be
+    // correct at construction and auto-updated per field update via `update_cost`,
+    // not to be manually set.
+    fn cost(&self) -> &U256 {
+        match self {
+            Self::Legacy { cost, .. } |
+            Self::Eip2930 { cost, .. } |
+            Self::Eip1559 { cost, .. } |
+            Self::Eip4844 { cost, .. } |
+            Self::Eip7702 { cost, .. } => cost,
+        }
+    }
+
+    /// Returns the encoded length of the transaction.
+    fn encoded_length(&self) -> usize {
+        self.size()
+    }
+}
+
+impl InMemorySize for MockTransaction {
+    fn size(&self) -> usize {
+        *self.get_size()
+    }
+}
+
+impl Typed2718 for MockTransaction {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Legacy { .. } => TxType::Legacy.into(),
+            Self::Eip1559 { .. } => TxType::Eip1559.into(),
+            Self::Eip4844 { .. } => TxType::Eip4844.into(),
+            Self::Eip2930 { .. } => TxType::Eip2930.into(),
+            Self::Eip7702 { .. } => TxType::Eip7702.into(),
+        }
+    }
+}
+
+impl alloy_consensus::Transaction for MockTransaction {
+    fn chain_id(&self) -> Option<u64> {
+        match self {
+            Self::Legacy { chain_id, .. } => *chain_id,
+            Self::Eip1559 { chain_id, .. } |
+            Self::Eip4844 { chain_id, .. } |
+            Self::Eip2930 { chain_id, .. } |
+            Self::Eip7702 { chain_id, .. } => Some(*chain_id),
+        }
+    }
+
+    fn nonce(&self) -> u64 {
+        *self.get_nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        *self.get_gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        match self {
+            Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => Some(*gas_price),
+            _ => None,
+        }
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        match self {
+            Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => *gas_price,
+            Self::Eip1559 { max_fee_per_gas, .. } |
+            Self::Eip4844 { max_fee_per_gas, .. } |
+            Self::Eip7702 { max_fee_per_gas, .. } => *max_fee_per_gas,
+        }
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        match self {
+            Self::Legacy { .. } | Self::Eip2930 { .. } => None,
+            Self::Eip1559 { max_priority_fee_per_gas, .. } |
+            Self::Eip4844 { max_priority_fee_per_gas, .. } |
+            Self::Eip7702 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
+        }
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::Eip4844 { max_fee_per_blob_gas, .. } => Some(*max_fee_per_blob_gas),
+            _ => None,
+        }
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        match self {
+            Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => *gas_price,
+            Self::Eip1559 { max_priority_fee_per_gas, .. } |
+            Self::Eip4844 { max_priority_fee_per_gas, .. } |
+            Self::Eip7702 { max_priority_fee_per_gas, .. } => *max_priority_fee_per_gas,
+        }
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        base_fee.map_or_else(
+            || self.max_fee_per_gas(),
+            |base_fee| {
+                // if the tip is greater than the max priority fee per gas, set it to the max
+                // priority fee per gas + base fee
+                let tip = self.max_fee_per_gas().saturating_sub(base_fee as u128);
+                if let Some(max_tip) = self.max_priority_fee_per_gas() {
+                    if tip > max_tip {
+                        max_tip + base_fee as u128
+                    } else {
+                        // otherwise return the max fee per gas
+                        self.max_fee_per_gas()
+                    }
+                } else {
+                    self.max_fee_per_gas()
+                }
+            },
+        )
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        !matches!(self, Self::Legacy { .. } | Self::Eip2930 { .. })
+    }
+
+    fn kind(&self) -> TxKind {
+        match self {
+            Self::Legacy { to, .. } | Self::Eip1559 { to, .. } | Self::Eip2930 { to, .. } => *to,
+            Self::Eip4844 { to, .. } | Self::Eip7702 { to, .. } => TxKind::Call(*to),
+        }
+    }
+
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Legacy { to, .. } | Self::Eip1559 { to, .. } | Self::Eip2930 { to, .. } => {
+                to.is_create()
+            }
+            Self::Eip4844 { .. } | Self::Eip7702 { .. } => false,
+        }
+    }
+
+    fn value(&self) -> U256 {
+        match self {
+            Self::Legacy { value, .. } |
+            Self::Eip1559 { value, .. } |
+            Self::Eip2930 { value, .. } |
+            Self::Eip4844 { value, .. } |
+            Self::Eip7702 { value, .. } => *value,
+        }
+    }
+
+    fn input(&self) -> &Bytes {
+        self.get_input()
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        match self {
+            Self::Legacy { .. } => None,
+            Self::Eip1559 { access_list: accesslist, .. } |
+            Self::Eip4844 { access_list: accesslist, .. } |
+            Self::Eip2930 { access_list: accesslist, .. } |
+            Self::Eip7702 { access_list: accesslist, .. } => Some(accesslist),
+        }
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        match self {
+            Self::Eip4844 { blob_versioned_hashes, .. } => Some(blob_versioned_hashes),
+            _ => None,
+        }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        match self {
+            Self::Eip7702 { authorization_list, .. } => Some(authorization_list),
+            _ => None,
+        }
+    }
+}
+
+impl EthPoolTransaction for MockTransaction {
+    fn take_blob(&mut self) -> EthBlobTransactionSidecar {
+        match self {
+            Self::Eip4844 { sidecar, .. } => EthBlobTransactionSidecar::Present(sidecar.clone()),
+            _ => EthBlobTransactionSidecar::None,
+        }
+    }
+
+    fn try_into_pooled_eip4844(
+        self,
+        sidecar: Arc<BlobTransactionSidecarVariant>,
+    ) -> Option<Recovered<Self::Pooled>> {
+        let (tx, signer) = self.into_consensus().into_parts();
+        tx.try_into_pooled_eip4844(Arc::unwrap_or_clone(sidecar))
+            .map(|tx| tx.with_signer(signer))
+            .ok()
+    }
+
+    fn try_from_eip4844(
+        tx: Recovered<Self::Consensus>,
+        sidecar: BlobTransactionSidecarVariant,
+    ) -> Option<Self> {
+        let (tx, signer) = tx.into_parts();
+        tx.try_into_pooled_eip4844(sidecar)
+            .map(|tx| tx.with_signer(signer))
+            .ok()
+            .map(Self::from_pooled)
+    }
+
+    fn validate_blob(
+        &self,
+        _blob: &BlobTransactionSidecarVariant,
+        _settings: &KzgSettings,
+    ) -> Result<(), alloy_eips::eip4844::BlobTransactionValidationError> {
+        match &self {
+            Self::Eip4844 { .. } => Ok(()),
+            _ => Err(BlobTransactionValidationError::NotBlobTransaction(self.tx_type())),
+        }
+    }
+}
+
+impl TryFrom<Recovered<TransactionSigned>> for MockTransaction {
+    type Error = TryFromRecoveredTransactionError;
+
+    fn try_from(tx: Recovered<TransactionSigned>) -> Result<Self, Self::Error> {
+        let sender = tx.signer();
+        let transaction = tx.into_inner();
+        let hash = *transaction.tx_hash();
+        let size = transaction.size();
+
+        match transaction.into_typed_transaction() {
+            Transaction::Legacy(TxLegacy {
+                chain_id,
+                nonce,
+                gas_price,
+                gas_limit,
+                to,
+                value,
+                input,
+            }) => Ok(Self::Legacy {
+                chain_id,
+                hash,
+                sender,
+                nonce,
+                gas_price,
+                gas_limit,
+                to,
+                value,
+                input,
+                size,
+                cost: U256::from(gas_limit) * U256::from(gas_price) + value,
+            }),
+            Transaction::Eip2930(TxEip2930 {
+                chain_id,
+                nonce,
+                gas_price,
+                gas_limit,
+                to,
+                value,
+                input,
+                access_list,
+            }) => Ok(Self::Eip2930 {
+                chain_id,
+                hash,
+                sender,
+                nonce,
+                gas_price,
+                gas_limit,
+                to,
+                value,
+                input,
+                access_list,
+                size,
+                cost: U256::from(gas_limit) * U256::from(gas_price) + value,
+            }),
+            Transaction::Eip1559(TxEip1559 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                input,
+                access_list,
+            }) => Ok(Self::Eip1559 {
+                chain_id,
+                hash,
+                sender,
+                nonce,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                gas_limit,
+                to,
+                value,
+                input,
+                access_list,
+                size,
+                cost: U256::from(gas_limit) * U256::from(max_fee_per_gas) + value,
+            }),
+            Transaction::Eip4844(TxEip4844 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                input,
+                access_list,
+                blob_versioned_hashes: _,
+                max_fee_per_blob_gas,
+            }) => Ok(Self::Eip4844 {
+                chain_id,
+                hash,
+                sender,
+                nonce,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                max_fee_per_blob_gas,
+                gas_limit,
+                to,
+                value,
+                input,
+                access_list,
+                sidecar: BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar::default()),
+                blob_versioned_hashes: Default::default(),
+                size,
+                cost: U256::from(gas_limit) * U256::from(max_fee_per_gas) + value,
+            }),
+            Transaction::Eip7702(TxEip7702 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                authorization_list,
+                input,
+            }) => Ok(Self::Eip7702 {
+                chain_id,
+                hash,
+                sender,
+                nonce,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                gas_limit,
+                to,
+                value,
+                input,
+                access_list,
+                authorization_list,
+                size,
+                cost: U256::from(gas_limit) * U256::from(max_fee_per_gas) + value,
+            }),
+        }
+    }
+}
+
+impl TryFrom<Recovered<EthereumTxEnvelope<TxEip4844Variant<BlobTransactionSidecarVariant>>>>
+    for MockTransaction
+{
+    type Error = TryFromRecoveredTransactionError;
+
+    fn try_from(
+        tx: Recovered<EthereumTxEnvelope<TxEip4844Variant<BlobTransactionSidecarVariant>>>,
+    ) -> Result<Self, Self::Error> {
+        let sender = tx.signer();
+        let transaction = tx.into_inner();
+        let hash = *transaction.tx_hash();
+        let size = transaction.size();
+
+        match transaction {
+            EthereumTxEnvelope::Legacy(signed_tx) => {
+                let tx = signed_tx.strip_signature();
+                Ok(Self::Legacy {
+                    chain_id: tx.chain_id,
+                    hash,
+                    sender,
+                    nonce: tx.nonce,
+                    gas_price: tx.gas_price,
+                    gas_limit: tx.gas_limit,
+                    to: tx.to,
+                    value: tx.value,
+                    input: tx.input,
+                    size,
+                    cost: U256::from(tx.gas_limit) * U256::from(tx.gas_price) + tx.value,
+                })
+            }
+            EthereumTxEnvelope::Eip2930(signed_tx) => {
+                let tx = signed_tx.strip_signature();
+                Ok(Self::Eip2930 {
+                    chain_id: tx.chain_id,
+                    hash,
+                    sender,
+                    nonce: tx.nonce,
+                    gas_price: tx.gas_price,
+                    gas_limit: tx.gas_limit,
+                    to: tx.to,
+                    value: tx.value,
+                    input: tx.input,
+                    access_list: tx.access_list,
+                    size,
+                    cost: U256::from(tx.gas_limit) * U256::from(tx.gas_price) + tx.value,
+                })
+            }
+            EthereumTxEnvelope::Eip1559(signed_tx) => {
+                let tx = signed_tx.strip_signature();
+                Ok(Self::Eip1559 {
+                    chain_id: tx.chain_id,
+                    hash,
+                    sender,
+                    nonce: tx.nonce,
+                    max_fee_per_gas: tx.max_fee_per_gas,
+                    max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+                    gas_limit: tx.gas_limit,
+                    to: tx.to,
+                    value: tx.value,
+                    input: tx.input,
+                    access_list: tx.access_list,
+                    size,
+                    cost: U256::from(tx.gas_limit) * U256::from(tx.max_fee_per_gas) + tx.value,
+                })
+            }
+            EthereumTxEnvelope::Eip4844(signed_tx) => match signed_tx.tx() {
+                TxEip4844Variant::TxEip4844(tx) => Ok(Self::Eip4844 {
+                    chain_id: tx.chain_id,
+                    hash,
+                    sender,
+                    nonce: tx.nonce,
+                    max_fee_per_gas: tx.max_fee_per_gas,
+                    max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+                    max_fee_per_blob_gas: tx.max_fee_per_blob_gas,
+                    gas_limit: tx.gas_limit,
+                    to: tx.to,
+                    value: tx.value,
+                    input: tx.input.clone(),
+                    access_list: tx.access_list.clone(),
+                    sidecar: BlobTransactionSidecarVariant::Eip4844(
+                        BlobTransactionSidecar::default(),
+                    ),
+                    blob_versioned_hashes: tx.blob_versioned_hashes.clone(),
+                    size,
+                    cost: U256::from(tx.gas_limit) * U256::from(tx.max_fee_per_gas) + tx.value,
+                }),
+                tx => Err(TryFromRecoveredTransactionError::UnsupportedTransactionType(tx.ty())),
+            },
+            EthereumTxEnvelope::Eip7702(signed_tx) => {
+                let tx = signed_tx.strip_signature();
+                Ok(Self::Eip7702 {
+                    chain_id: tx.chain_id,
+                    hash,
+                    sender,
+                    nonce: tx.nonce,
+                    max_fee_per_gas: tx.max_fee_per_gas,
+                    max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+                    gas_limit: tx.gas_limit,
+                    to: tx.to,
+                    value: tx.value,
+                    access_list: tx.access_list,
+                    authorization_list: tx.authorization_list,
+                    input: tx.input,
+                    size,
+                    cost: U256::from(tx.gas_limit) * U256::from(tx.max_fee_per_gas) + tx.value,
+                })
+            }
+        }
+    }
+}
+
+impl From<Recovered<PooledTransactionVariant>> for MockTransaction {
+    fn from(tx: Recovered<PooledTransactionVariant>) -> Self {
+        let (tx, signer) = tx.into_parts();
+        Recovered::<TransactionSigned>::new_unchecked(tx.into(), signer).try_into().expect(
+            "Failed to convert from PooledTransactionsElementEcRecovered to MockTransaction",
+        )
+    }
+}
+
+impl From<MockTransaction> for Recovered<TransactionSigned> {
+    fn from(tx: MockTransaction) -> Self {
+        let hash = *tx.hash();
+        let sender = tx.sender();
+        let tx = Transaction::from(tx);
+        let tx: TransactionSigned =
+            Signed::new_unchecked(tx, Signature::test_signature(), hash).into();
+        Self::new_unchecked(tx, sender)
+    }
+}
+
+impl From<MockTransaction> for Transaction {
+    fn from(mock: MockTransaction) -> Self {
+        match mock {
+            MockTransaction::Legacy {
+                chain_id,
+                nonce,
+                gas_price,
+                gas_limit,
+                to,
+                value,
+                input,
+                ..
+            } => Self::Legacy(TxLegacy { chain_id, nonce, gas_price, gas_limit, to, value, input }),
+            MockTransaction::Eip2930 {
+                chain_id,
+                nonce,
+                gas_price,
+                gas_limit,
+                to,
+                value,
+                access_list,
+                input,
+                ..
+            } => Self::Eip2930(TxEip2930 {
+                chain_id,
+                nonce,
+                gas_price,
+                gas_limit,
+                to,
+                value,
+                access_list,
+                input,
+            }),
+            MockTransaction::Eip1559 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                input,
+                ..
+            } => Self::Eip1559(TxEip1559 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                input,
+            }),
+            MockTransaction::Eip4844 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                sidecar,
+                max_fee_per_blob_gas,
+                input,
+                ..
+            } => Self::Eip4844(TxEip4844 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                blob_versioned_hashes: sidecar.versioned_hashes().collect(),
+                max_fee_per_blob_gas,
+                input,
+            }),
+            MockTransaction::Eip7702 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                input,
+                authorization_list,
+                ..
+            } => Self::Eip7702(TxEip7702 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                authorization_list,
+                input,
+            }),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl proptest::arbitrary::Arbitrary for MockTransaction {
+    type Parameters = ();
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        use proptest::prelude::Strategy;
+        use proptest_arbitrary_interop::arb;
+
+        arb::<(TransactionSigned, Address)>()
+            .prop_map(|(signed_transaction, signer)| {
+                Recovered::new_unchecked(signed_transaction, signer)
+                    .try_into()
+                    .expect("Failed to create an Arbitrary MockTransaction from a Recovered tx")
+            })
+            .boxed()
+    }
+
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+}
+
+/// A factory for creating and managing various types of mock transactions.
+#[derive(Debug, Default)]
+pub struct MockTransactionFactory {
+    pub(crate) ids: SenderIdentifiers,
+}
+
+// === impl MockTransactionFactory ===
+
+impl MockTransactionFactory {
+    /// Generates a transaction ID for the given [`MockTransaction`].
+    pub fn tx_id(&mut self, tx: &MockTransaction) -> TransactionId {
+        let sender = self.ids.sender_id_or_create(tx.sender());
+        TransactionId::new(sender, *tx.get_nonce())
+    }
+
+    /// Validates a [`MockTransaction`] and returns a [`MockValidTx`].
+    pub fn validated(&mut self, transaction: MockTransaction) -> MockValidTx {
+        self.validated_with_origin(TransactionOrigin::External, transaction)
+    }
+
+    /// Validates a [`MockTransaction`] and returns a shared [`Arc<MockValidTx>`].
+    pub fn validated_arc(&mut self, transaction: MockTransaction) -> Arc<MockValidTx> {
+        Arc::new(self.validated(transaction))
+    }
+
+    /// Converts the transaction into a validated transaction with a specified origin.
+    pub fn validated_with_origin(
+        &mut self,
+        origin: TransactionOrigin,
+        transaction: MockTransaction,
+    ) -> MockValidTx {
+        MockValidTx {
+            propagate: false,
+            transaction_id: self.tx_id(&transaction),
+            transaction,
+            timestamp: Instant::now(),
+            origin,
+            authority_ids: None,
+        }
+    }
+
+    /// Creates a validated legacy [`MockTransaction`].
+    pub fn create_legacy(&mut self) -> MockValidTx {
+        self.validated(MockTransaction::legacy())
+    }
+
+    /// Creates a validated EIP-1559 [`MockTransaction`].
+    pub fn create_eip1559(&mut self) -> MockValidTx {
+        self.validated(MockTransaction::eip1559())
+    }
+
+    /// Creates a validated EIP-4844 [`MockTransaction`].
+    pub fn create_eip4844(&mut self) -> MockValidTx {
+        self.validated(MockTransaction::eip4844())
+    }
+}
+
+/// `MockOrdering` is just a `CoinbaseTipOrdering` with `MockTransaction`
+pub type MockOrdering = CoinbaseTipOrdering<MockTransaction>;
+
+/// A ratio of each of the configured transaction types. The percentages sum up to 100, this is
+/// enforced in [`MockTransactionRatio::new`] by an assert.
+#[derive(Debug, Clone)]
+pub struct MockTransactionRatio {
+    /// Percent of transactions that are legacy transactions
+    pub legacy_pct: u32,
+    /// Percent of transactions that are access list transactions
+    pub access_list_pct: u32,
+    /// Percent of transactions that are EIP-1559 transactions
+    pub dynamic_fee_pct: u32,
+    /// Percent of transactions that are EIP-4844 transactions
+    pub blob_pct: u32,
+}
+
+impl MockTransactionRatio {
+    /// Creates a new [`MockTransactionRatio`] with the given percentages.
+    ///
+    /// Each argument is treated as a full percent, for example `30u32` is `30%`.
+    ///
+    /// The percentages must sum up to 100 exactly, or this method will panic.
+    pub fn new(legacy_pct: u32, access_list_pct: u32, dynamic_fee_pct: u32, blob_pct: u32) -> Self {
+        let total = legacy_pct + access_list_pct + dynamic_fee_pct + blob_pct;
+        assert_eq!(
+            total,
+            100,
+            "percentages must sum up to 100, instead got legacy: {legacy_pct}, access_list: {access_list_pct}, dynamic_fee: {dynamic_fee_pct}, blob: {blob_pct}, total: {total}",
+        );
+
+        Self { legacy_pct, access_list_pct, dynamic_fee_pct, blob_pct }
+    }
+
+    /// Create a [`WeightedIndex`] from this transaction ratio.
+    ///
+    /// This index will sample in the following order:
+    /// * Legacy transaction => 0
+    /// * EIP-2930 transaction => 1
+    /// * EIP-1559 transaction => 2
+    /// * EIP-4844 transaction => 3
+    pub fn weighted_index(&self) -> WeightedIndex<u32> {
+        WeightedIndex::new([
+            self.legacy_pct,
+            self.access_list_pct,
+            self.dynamic_fee_pct,
+            self.blob_pct,
+        ])
+        .unwrap()
+    }
+}
+
+/// The range of each type of fee, for the different transaction types
+#[derive(Debug, Clone)]
+pub struct MockFeeRange {
+    /// The range of `gas_price` or legacy and access list transactions
+    pub gas_price: Uniform<u128>,
+    /// The range of priority fees for EIP-1559 and EIP-4844 transactions
+    pub priority_fee: Uniform<u128>,
+    /// The range of max fees for EIP-1559 and EIP-4844 transactions
+    pub max_fee: Uniform<u128>,
+    /// The range of max fees per blob gas for EIP-4844 transactions
+    pub max_fee_blob: Uniform<u128>,
+}
+
+impl MockFeeRange {
+    /// Creates a new [`MockFeeRange`] with the given ranges.
+    ///
+    /// Expects the bottom of the `priority_fee_range` to be greater than the top of the
+    /// `max_fee_range`.
+    pub fn new(
+        gas_price: Range<u128>,
+        priority_fee: Range<u128>,
+        max_fee: Range<u128>,
+        max_fee_blob: Range<u128>,
+    ) -> Self {
+        assert!(
+            max_fee.start >= priority_fee.end,
+            "max_fee_range should be strictly above the priority fee range"
+        );
+        Self {
+            gas_price: gas_price.try_into().unwrap(),
+            priority_fee: priority_fee.try_into().unwrap(),
+            max_fee: max_fee.try_into().unwrap(),
+            max_fee_blob: max_fee_blob.try_into().unwrap(),
+        }
+    }
+
+    /// Returns a sample of `gas_price` for legacy and access list transactions with the given
+    /// [Rng](rand::Rng).
+    pub fn sample_gas_price(&self, rng: &mut impl rand::Rng) -> u128 {
+        self.gas_price.sample(rng)
+    }
+
+    /// Returns a sample of `max_priority_fee_per_gas` for EIP-1559 and EIP-4844 transactions with
+    /// the given [Rng](rand::Rng).
+    pub fn sample_priority_fee(&self, rng: &mut impl rand::Rng) -> u128 {
+        self.priority_fee.sample(rng)
+    }
+
+    /// Returns a sample of `max_fee_per_gas` for EIP-1559 and EIP-4844 transactions with the given
+    /// [Rng](rand::Rng).
+    pub fn sample_max_fee(&self, rng: &mut impl rand::Rng) -> u128 {
+        self.max_fee.sample(rng)
+    }
+
+    /// Returns a sample of `max_fee_per_blob_gas` for EIP-4844 transactions with the given
+    /// [Rng](rand::Rng).
+    pub fn sample_max_fee_blob(&self, rng: &mut impl rand::Rng) -> u128 {
+        self.max_fee_blob.sample(rng)
+    }
+}
+
+/// A configured distribution that can generate transactions
+#[derive(Debug, Clone)]
+pub struct MockTransactionDistribution {
+    /// ratio of each transaction type to generate
+    transaction_ratio: MockTransactionRatio,
+    /// generates the gas limit
+    gas_limit_range: Uniform<u64>,
+    /// generates the transaction's fake size
+    size_range: Uniform<usize>,
+    /// generates fees for the given transaction types
+    fee_ranges: MockFeeRange,
+}
+
+impl MockTransactionDistribution {
+    /// Creates a new generator distribution.
+    pub fn new(
+        transaction_ratio: MockTransactionRatio,
+        fee_ranges: MockFeeRange,
+        gas_limit_range: Range<u64>,
+        size_range: Range<usize>,
+    ) -> Self {
+        Self {
+            transaction_ratio,
+            gas_limit_range: gas_limit_range.try_into().unwrap(),
+            fee_ranges,
+            size_range: size_range.try_into().unwrap(),
+        }
+    }
+
+    /// Generates a new transaction
+    pub fn tx(&self, nonce: u64, rng: &mut impl rand::Rng) -> MockTransaction {
+        let transaction_sample = self.transaction_ratio.weighted_index().sample(rng);
+        let tx = match transaction_sample {
+            0 => MockTransaction::legacy().with_gas_price(self.fee_ranges.sample_gas_price(rng)),
+            1 => MockTransaction::eip2930().with_gas_price(self.fee_ranges.sample_gas_price(rng)),
+            2 => MockTransaction::eip1559()
+                .with_priority_fee(self.fee_ranges.sample_priority_fee(rng))
+                .with_max_fee(self.fee_ranges.sample_max_fee(rng)),
+            3 => MockTransaction::eip4844()
+                .with_priority_fee(self.fee_ranges.sample_priority_fee(rng))
+                .with_max_fee(self.fee_ranges.sample_max_fee(rng))
+                .with_blob_fee(self.fee_ranges.sample_max_fee_blob(rng)),
+            _ => unreachable!("unknown transaction type returned by the weighted index"),
+        };
+
+        let size = self.size_range.sample(rng);
+
+        tx.with_nonce(nonce).with_gas_limit(self.gas_limit_range.sample(rng)).with_size(size)
+    }
+
+    /// Generates a new transaction set for the given sender.
+    ///
+    /// The nonce range defines which nonces to set, and how many transactions to generate.
+    pub fn tx_set(
+        &self,
+        sender: Address,
+        nonce_range: Range<u64>,
+        rng: &mut impl rand::Rng,
+    ) -> MockTransactionSet {
+        let txs =
+            nonce_range.map(|nonce| self.tx(nonce, rng).with_sender(sender)).collect::<Vec<_>>();
+        MockTransactionSet::new(txs)
+    }
+
+    /// Generates a transaction set that ensures that blob txs are not mixed with other transaction
+    /// types.
+    ///
+    /// This is done by taking the existing distribution, and using the first transaction to
+    /// determine whether or not the sender should generate entirely blob transactions.
+    pub fn tx_set_non_conflicting_types(
+        &self,
+        sender: Address,
+        nonce_range: Range<u64>,
+        rng: &mut impl rand::Rng,
+    ) -> NonConflictingSetOutcome {
+        // This will create a modified distribution that will only generate blob transactions
+        // for the given sender, if the blob transaction is the first transaction in the set.
+        //
+        // Otherwise, it will modify the transaction distribution to only generate legacy, eip2930,
+        // and eip1559 transactions.
+        //
+        // The new distribution should still have the same relative amount of transaction types.
+        let mut modified_distribution = self.clone();
+        let first_tx = self.tx(nonce_range.start, rng);
+
+        // now we can check and modify the distribution, preserving potentially uneven ratios
+        // between transaction types
+        if first_tx.is_eip4844() {
+            modified_distribution.transaction_ratio = MockTransactionRatio {
+                legacy_pct: 0,
+                access_list_pct: 0,
+                dynamic_fee_pct: 0,
+                blob_pct: 100,
+            };
+
+            // finally generate the transaction set
+            NonConflictingSetOutcome::BlobsOnly(modified_distribution.tx_set(
+                sender,
+                nonce_range,
+                rng,
+            ))
+        } else {
+            let MockTransactionRatio { legacy_pct, access_list_pct, dynamic_fee_pct, .. } =
+                modified_distribution.transaction_ratio;
+
+            // Calculate the total weight of non-blob transactions
+            let total_non_blob_weight: u32 = legacy_pct + access_list_pct + dynamic_fee_pct;
+
+            // Calculate new weights, preserving the ratio between non-blob transaction types
+            let new_weights: Vec<u32> = [legacy_pct, access_list_pct, dynamic_fee_pct]
+                .into_iter()
+                .map(|weight| weight * 100 / total_non_blob_weight)
+                .collect();
+
+            let new_ratio = MockTransactionRatio {
+                legacy_pct: new_weights[0],
+                access_list_pct: new_weights[1],
+                dynamic_fee_pct: new_weights[2],
+                blob_pct: 0,
+            };
+
+            // Set the new transaction ratio excluding blob transactions and preserving the relative
+            // ratios
+            modified_distribution.transaction_ratio = new_ratio;
+
+            // finally generate the transaction set
+            NonConflictingSetOutcome::Mixed(modified_distribution.tx_set(sender, nonce_range, rng))
+        }
+    }
+}
+
+/// Indicates whether or not the non-conflicting transaction set generated includes only blobs, or
+/// a mix of transaction types.
+#[derive(Debug, Clone)]
+pub enum NonConflictingSetOutcome {
+    /// The transaction set includes only blob transactions
+    BlobsOnly(MockTransactionSet),
+    /// The transaction set includes a mix of transaction types
+    Mixed(MockTransactionSet),
+}
+
+impl NonConflictingSetOutcome {
+    /// Returns the inner [`MockTransactionSet`]
+    pub fn into_inner(self) -> MockTransactionSet {
+        match self {
+            Self::BlobsOnly(set) | Self::Mixed(set) => set,
+        }
+    }
+
+    /// Introduces artificial nonce gaps into the transaction set, at random, with a range of gap
+    /// sizes.
+    ///
+    /// If this is a [`NonConflictingSetOutcome::BlobsOnly`], then nonce gaps will not be
+    /// introduced. Otherwise, the nonce gaps will be introduced to the mixed transaction set.
+    ///
+    /// See [`MockTransactionSet::with_nonce_gaps`] for more information on the generation process.
+    pub fn with_nonce_gaps(
+        &mut self,
+        gap_pct: u32,
+        gap_range: Range<u64>,
+        rng: &mut impl rand::Rng,
+    ) {
+        match self {
+            Self::BlobsOnly(_) => {}
+            Self::Mixed(set) => set.with_nonce_gaps(gap_pct, gap_range, rng),
+        }
+    }
+}
+
+/// A set of [`MockTransaction`]s that can be modified at once
+#[derive(Debug, Clone)]
+pub struct MockTransactionSet {
+    pub(crate) transactions: Vec<MockTransaction>,
+}
+
+impl MockTransactionSet {
+    /// Create a new [`MockTransactionSet`] from a list of transactions
+    const fn new(transactions: Vec<MockTransaction>) -> Self {
+        Self { transactions }
+    }
+
+    /// Creates a series of dependent transactions for a given sender and nonce.
+    ///
+    /// This method generates a sequence of transactions starting from the provided nonce
+    /// for the given sender.
+    ///
+    /// The number of transactions created is determined by `tx_count`.
+    pub fn dependent(sender: Address, from_nonce: u64, tx_count: usize, tx_type: TxType) -> Self {
+        let mut txs = Vec::with_capacity(tx_count);
+        let mut curr_tx =
+            MockTransaction::new_from_type(tx_type).with_nonce(from_nonce).with_sender(sender);
+        for _ in 0..tx_count {
+            txs.push(curr_tx.clone());
+            curr_tx = curr_tx.next();
+        }
+
+        Self::new(txs)
+    }
+
+    /// Creates a chain of transactions for a given sender with a specified count.
+    ///
+    /// This method generates a sequence of transactions starting from the specified sender
+    /// and creates a chain of transactions based on the `tx_count`.
+    pub fn sequential_transactions_by_sender(
+        sender: Address,
+        tx_count: usize,
+        tx_type: TxType,
+    ) -> Self {
+        Self::dependent(sender, 0, tx_count, tx_type)
+    }
+
+    /// Introduces artificial nonce gaps into the transaction set, at random, with a range of gap
+    /// sizes.
+    ///
+    /// This assumes that the `gap_pct` is between 0 and 100, and the `gap_range` has a lower bound
+    /// of at least one. This is enforced with assertions.
+    ///
+    /// The `gap_pct` is the percent chance that the next transaction in the set will introduce a
+    /// nonce gap.
+    ///
+    /// Let an example transaction set be `[(tx1, 1), (tx2, 2)]`, where the first element of the
+    /// tuple is a transaction, and the second element is the nonce. If the `gap_pct` is 50, and
+    /// the `gap_range` is `1..=1`, then the resulting transaction set could be either
+    /// `[(tx1, 1), (tx2, 2)]` or `[(tx1, 1), (tx2, 3)]`, with a 50% chance of either.
+    pub fn with_nonce_gaps(
+        &mut self,
+        gap_pct: u32,
+        gap_range: Range<u64>,
+        rng: &mut impl rand::Rng,
+    ) {
+        assert!(gap_pct <= 100, "gap_pct must be between 0 and 100");
+        assert!(gap_range.start >= 1, "gap_range must have a lower bound of at least one");
+
+        let mut prev_nonce = 0;
+        for tx in &mut self.transactions {
+            if rng.random_bool(gap_pct as f64 / 100.0) {
+                prev_nonce += gap_range.start;
+            } else {
+                prev_nonce += 1;
+            }
+            tx.set_nonce(prev_nonce);
+        }
+    }
+
+    /// Add transactions to the [`MockTransactionSet`]
+    pub fn extend<T: IntoIterator<Item = MockTransaction>>(&mut self, txs: T) {
+        self.transactions.extend(txs);
+    }
+
+    /// Extract the inner [Vec] of [`MockTransaction`]s
+    pub fn into_vec(self) -> Vec<MockTransaction> {
+        self.transactions
+    }
+
+    /// Returns an iterator over the contained transactions in the set
+    pub fn iter(&self) -> impl Iterator<Item = &MockTransaction> {
+        self.transactions.iter()
+    }
+
+    /// Returns a mutable iterator over the contained transactions in the set.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut MockTransaction> {
+        self.transactions.iter_mut()
+    }
+}
+
+impl IntoIterator for MockTransactionSet {
+    type Item = MockTransaction;
+    type IntoIter = IntoIter<MockTransaction>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.transactions.into_iter()
+    }
+}
+
+#[test]
+fn test_mock_priority() {
+    use crate::TransactionOrdering;
+
+    let o = MockOrdering::default();
+    let lo = MockTransaction::eip1559().with_gas_limit(100_000);
+    let hi = lo.next().inc_price();
+    assert!(o.priority(&hi, 0) > o.priority(&lo, 0));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Transaction;
+    use alloy_primitives::U256;
+
+    #[test]
+    fn test_mock_transaction_factory() {
+        let mut factory = MockTransactionFactory::default();
+
+        // Test legacy transaction creation
+        let legacy = factory.create_legacy();
+        assert_eq!(legacy.transaction.tx_type(), TxType::Legacy);
+
+        // Test EIP1559 transaction creation
+        let eip1559 = factory.create_eip1559();
+        assert_eq!(eip1559.transaction.tx_type(), TxType::Eip1559);
+
+        // Test EIP4844 transaction creation
+        let eip4844 = factory.create_eip4844();
+        assert_eq!(eip4844.transaction.tx_type(), TxType::Eip4844);
+    }
+
+    #[test]
+    fn test_mock_transaction_set() {
+        let sender = Address::random();
+        let nonce_start = 0u64;
+        let count = 3;
+
+        // Test legacy transaction set
+        let legacy_set = MockTransactionSet::dependent(sender, nonce_start, count, TxType::Legacy);
+        assert_eq!(legacy_set.transactions.len(), count);
+        for (idx, tx) in legacy_set.transactions.iter().enumerate() {
+            assert_eq!(tx.tx_type(), TxType::Legacy);
+            assert_eq!(tx.nonce(), nonce_start + idx as u64);
+            assert_eq!(tx.sender(), sender);
+        }
+
+        // Test EIP1559 transaction set
+        let eip1559_set =
+            MockTransactionSet::dependent(sender, nonce_start, count, TxType::Eip1559);
+        assert_eq!(eip1559_set.transactions.len(), count);
+        for (idx, tx) in eip1559_set.transactions.iter().enumerate() {
+            assert_eq!(tx.tx_type(), TxType::Eip1559);
+            assert_eq!(tx.nonce(), nonce_start + idx as u64);
+            assert_eq!(tx.sender(), sender);
+        }
+    }
+
+    #[test]
+    fn test_mock_transaction_modifications() {
+        let tx = MockTransaction::eip1559();
+
+        // Test price increment
+        let original_price = tx.get_gas_price();
+        let tx_inc = tx.inc_price();
+        assert!(tx_inc.get_gas_price() > original_price);
+
+        // Test gas limit increment
+        let original_limit = tx.gas_limit();
+        let tx_inc = tx.inc_limit();
+        assert!(tx_inc.gas_limit() > original_limit);
+
+        // Test nonce increment
+        let original_nonce = tx.nonce();
+        let tx_inc = tx.inc_nonce();
+        assert_eq!(tx_inc.nonce(), original_nonce + 1);
+    }
+
+    #[test]
+    fn test_mock_transaction_cost() {
+        let tx = MockTransaction::eip1559()
+            .with_gas_limit(7_000)
+            .with_max_fee(100)
+            .with_value(U256::ZERO);
+
+        // Cost is calculated as (gas_limit * max_fee_per_gas) + value
+        let expected_cost = U256::from(7_000u64) * U256::from(100u128) + U256::ZERO;
+        assert_eq!(*tx.cost(), expected_cost);
+    }
+}

--- a/patches/reth-transaction-pool/src/test_utils/mod.rs
+++ b/patches/reth-transaction-pool/src/test_utils/mod.rs
@@ -1,0 +1,95 @@
+//! Internal helpers for testing.
+
+use crate::{blobstore::InMemoryBlobStore, noop::MockTransactionValidator, Pool, PoolConfig};
+use std::ops::Deref;
+
+mod tx_gen;
+pub use tx_gen::*;
+
+mod mock;
+pub use mock::*;
+
+mod pool;
+
+mod okvalidator;
+pub use okvalidator::*;
+
+/// A [Pool] used for testing
+pub type TestPool =
+    Pool<MockTransactionValidator<MockTransaction>, MockOrdering, InMemoryBlobStore>;
+
+/// Structure encapsulating a [`TestPool`] used for testing
+#[derive(Debug, Clone)]
+pub struct TestPoolBuilder(TestPool);
+
+impl Default for TestPoolBuilder {
+    fn default() -> Self {
+        Self(Pool::new(
+            MockTransactionValidator::default(),
+            MockOrdering::default(),
+            InMemoryBlobStore::default(),
+            Default::default(),
+        ))
+    }
+}
+
+impl TestPoolBuilder {
+    /// Returns a new [`TestPoolBuilder`] with a custom validator used for testing purposes
+    pub fn with_validator(self, validator: MockTransactionValidator<MockTransaction>) -> Self {
+        Self(Pool::new(
+            validator,
+            MockOrdering::default(),
+            self.pool.blob_store().clone(),
+            self.pool.config().clone(),
+        ))
+    }
+
+    /// Returns a new [`TestPoolBuilder`] with a custom ordering used for testing purposes
+    pub fn with_ordering(self, ordering: MockOrdering) -> Self {
+        Self(Pool::new(
+            self.pool.validator().clone(),
+            ordering,
+            self.pool.blob_store().clone(),
+            self.pool.config().clone(),
+        ))
+    }
+
+    /// Returns a new [`TestPoolBuilder`] with a custom blob store used for testing purposes
+    pub fn with_blob_store(self, blob_store: InMemoryBlobStore) -> Self {
+        Self(Pool::new(
+            self.pool.validator().clone(),
+            MockOrdering::default(),
+            blob_store,
+            self.pool.config().clone(),
+        ))
+    }
+
+    /// Returns a new [`TestPoolBuilder`] with a custom configuration used for testing purposes
+    pub fn with_config(self, config: PoolConfig) -> Self {
+        Self(Pool::new(
+            self.pool.validator().clone(),
+            MockOrdering::default(),
+            self.pool.blob_store().clone(),
+            config,
+        ))
+    }
+}
+
+impl From<TestPoolBuilder> for TestPool {
+    fn from(wrapper: TestPoolBuilder) -> Self {
+        wrapper.0
+    }
+}
+
+impl Deref for TestPoolBuilder {
+    type Target = TestPool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Returns a new [Pool] with default field values used for testing purposes
+pub fn testing_pool() -> TestPool {
+    TestPoolBuilder::default().into()
+}

--- a/patches/reth-transaction-pool/src/test_utils/okvalidator.rs
+++ b/patches/reth-transaction-pool/src/test_utils/okvalidator.rs
@@ -1,0 +1,57 @@
+use std::marker::PhantomData;
+
+use crate::{
+    validate::ValidTransaction, EthPooledTransaction, PoolTransaction, TransactionOrigin,
+    TransactionValidationOutcome, TransactionValidator,
+};
+use reth_ethereum_primitives::Block;
+
+/// A transaction validator that determines all transactions to be valid.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct OkValidator<T = EthPooledTransaction> {
+    _phantom: PhantomData<T>,
+    /// Whether to mark transactions as propagatable.
+    propagate: bool,
+}
+
+impl<T> OkValidator<T> {
+    /// Determines whether transactions should be allowed to be propagated
+    pub const fn set_propagate_transactions(mut self, propagate: bool) -> Self {
+        self.propagate = propagate;
+        self
+    }
+}
+
+impl<T> Default for OkValidator<T> {
+    fn default() -> Self {
+        Self { _phantom: Default::default(), propagate: false }
+    }
+}
+
+impl<T> TransactionValidator for OkValidator<T>
+where
+    T: PoolTransaction,
+{
+    type Transaction = T;
+    type Block = Block;
+
+    async fn validate_transaction(
+        &self,
+        _origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        // Always return valid
+        let authorities = transaction.authorization_list().map(|auths| {
+            auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>()
+        });
+        TransactionValidationOutcome::Valid {
+            balance: *transaction.cost(),
+            state_nonce: transaction.nonce(),
+            bytecode_hash: None,
+            transaction: ValidTransaction::Valid(transaction),
+            propagate: self.propagate,
+            authorities,
+        }
+    }
+}

--- a/patches/reth-transaction-pool/src/test_utils/pool.rs
+++ b/patches/reth-transaction-pool/src/test_utils/pool.rs
@@ -1,0 +1,604 @@
+//! Test helpers for mocking an entire pool.
+
+#![allow(dead_code)]
+
+use crate::{
+    error::PoolErrorKind,
+    pool::{state::SubPool, txpool::TxPool, AddedTransaction},
+    test_utils::{MockOrdering, MockTransactionDistribution, MockTransactionFactory},
+    TransactionOrdering,
+};
+use alloy_primitives::{map::AddressMap, Address, U256};
+use rand::Rng;
+use std::ops::{Deref, DerefMut};
+
+/// A wrapped `TxPool` with additional helpers for testing
+pub(crate) struct MockPool<T: TransactionOrdering = MockOrdering> {
+    // The wrapped pool.
+    pool: TxPool<T>,
+}
+
+impl MockPool {
+    /// The total size of all subpools
+    fn total_subpool_size(&self) -> usize {
+        self.pool.pending().len() + self.pool.base_fee().len() + self.pool.queued().len()
+    }
+
+    /// Checks that all pool invariants hold.
+    fn enforce_invariants(&self) {
+        assert_eq!(
+            self.pool.len(),
+            self.total_subpool_size(),
+            "Tx in AllTransactions and sum(subpools) must match"
+        );
+    }
+}
+
+impl Default for MockPool {
+    fn default() -> Self {
+        Self { pool: TxPool::new(MockOrdering::default(), Default::default()) }
+    }
+}
+
+impl<T: TransactionOrdering> Deref for MockPool<T> {
+    type Target = TxPool<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pool
+    }
+}
+
+impl<T: TransactionOrdering> DerefMut for MockPool<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.pool
+    }
+}
+
+/// Simulates transaction execution.
+pub(crate) struct MockTransactionSimulator<R: Rng> {
+    /// The pending base fee
+    base_fee: u128,
+    /// Generator for transactions
+    tx_generator: MockTransactionDistribution,
+    /// represents the on chain balance of a sender.
+    balances: AddressMap<U256>,
+    /// represents the on chain nonce of a sender.
+    nonces: AddressMap<u64>,
+    /// A set of addresses to use as senders.
+    senders: Vec<Address>,
+    /// What scenarios to execute.
+    scenarios: Vec<ScenarioType>,
+    /// All previous scenarios executed by a sender.
+    executed: AddressMap<ExecutedScenarios>,
+    /// "Validates" generated transactions.
+    validator: MockTransactionFactory,
+    /// Represents the gaps in nonces for each sender.
+    nonce_gaps: AddressMap<u64>,
+    /// The rng instance used to select senders and scenarios.
+    rng: R,
+}
+
+impl<R: Rng> MockTransactionSimulator<R> {
+    /// Returns a new mock instance
+    pub(crate) fn new(mut rng: R, config: MockSimulatorConfig) -> Self {
+        let senders = config.addresses(&mut rng);
+        Self {
+            base_fee: config.base_fee,
+            balances: senders.iter().copied().map(|a| (a, rng.random())).collect(),
+            nonces: senders.iter().copied().map(|a| (a, 0)).collect(),
+            senders,
+            scenarios: config.scenarios,
+            tx_generator: config.tx_generator,
+            executed: Default::default(),
+            validator: Default::default(),
+            nonce_gaps: Default::default(),
+            rng,
+        }
+    }
+
+    /// Creates a pool configured for this simulator
+    ///
+    /// This is needed because `MockPool::default()` sets `pending_basefee` to 7, but we might want
+    /// to use different values
+    pub(crate) fn create_pool(&self) -> MockPool {
+        let mut pool = MockPool::default();
+        let mut info = pool.block_info();
+        info.pending_basefee = self.base_fee as u64;
+        pool.set_block_info(info);
+        pool
+    }
+
+    /// Returns a random address from the senders set
+    fn rng_address(&mut self) -> Address {
+        let idx = self.rng.random_range(0..self.senders.len());
+        self.senders[idx]
+    }
+
+    /// Returns a random scenario from the scenario set
+    fn rng_scenario(&mut self) -> ScenarioType {
+        let idx = self.rng.random_range(0..self.scenarios.len());
+        self.scenarios[idx].clone()
+    }
+
+    /// Executes the next scenario and applies it to the pool
+    pub(crate) fn next(&mut self, pool: &mut MockPool) {
+        let sender = self.rng_address();
+        let scenario = self.rng_scenario();
+        let on_chain_nonce = self.nonces[&sender];
+        let on_chain_balance = self.balances[&sender];
+
+        match scenario {
+            ScenarioType::OnchainNonce => {
+                // uses fee from fee_ranges
+                let tx = self.tx_generator.tx(on_chain_nonce, &mut self.rng).with_sender(sender);
+                let valid_tx = self.validator.validated(tx);
+
+                let res =
+                    match pool.add_transaction(valid_tx, on_chain_balance, on_chain_nonce, None) {
+                        Ok(res) => res,
+                        Err(e) => match e.kind {
+                            // skip pool capacity/replacement errors (not relevant)
+                            PoolErrorKind::SpammerExceededCapacity(_) |
+                            PoolErrorKind::ReplacementUnderpriced => return,
+                            _ => panic!("unexpected error: {e:?}"),
+                        },
+                    };
+
+                match res {
+                    AddedTransaction::Pending(_) => {}
+                    AddedTransaction::Parked { .. } => {
+                        panic!("expected pending")
+                    }
+                }
+
+                self.executed
+                    .entry(sender)
+                    .or_insert_with(|| ExecutedScenarios { sender, scenarios: vec![] }) // in the case of a new sender
+                    .scenarios
+                    .push(ExecutedScenario {
+                        balance: on_chain_balance,
+                        nonce: on_chain_nonce,
+                        scenario: Scenario::OnchainNonce { nonce: on_chain_nonce },
+                    });
+
+                self.nonces.insert(sender, on_chain_nonce + 1);
+            }
+
+            ScenarioType::HigherNonce { skip } => {
+                // if this sender already has a nonce gap, skip
+                if self.nonce_gaps.contains_key(&sender) {
+                    return;
+                }
+
+                let higher_nonce = on_chain_nonce + skip;
+
+                // uses fee from fee_ranges
+                let tx = self.tx_generator.tx(higher_nonce, &mut self.rng).with_sender(sender);
+                let valid_tx = self.validator.validated(tx);
+
+                let res =
+                    match pool.add_transaction(valid_tx, on_chain_balance, on_chain_nonce, None) {
+                        Ok(res) => res,
+                        Err(e) => match e.kind {
+                            // skip pool capacity/replacement errors (not relevant)
+                            PoolErrorKind::SpammerExceededCapacity(_) |
+                            PoolErrorKind::ReplacementUnderpriced => return,
+                            _ => panic!("unexpected error: {e:?}"),
+                        },
+                    };
+
+                match res {
+                    AddedTransaction::Pending(_) => {
+                        panic!("expected parked")
+                    }
+                    AddedTransaction::Parked { subpool, .. } => {
+                        assert_eq!(
+                            subpool,
+                            SubPool::Queued,
+                            "expected to be moved to queued subpool"
+                        );
+                    }
+                }
+
+                self.executed
+                    .entry(sender)
+                    .or_insert_with(|| ExecutedScenarios { sender, scenarios: vec![] }) // in the case of a new sender
+                    .scenarios
+                    .push(ExecutedScenario {
+                        balance: on_chain_balance,
+                        nonce: on_chain_nonce,
+                        scenario: Scenario::HigherNonce {
+                            onchain: on_chain_nonce,
+                            nonce: higher_nonce,
+                        },
+                    });
+                self.nonce_gaps.insert(sender, higher_nonce);
+            }
+
+            ScenarioType::BelowBaseFee { fee } => {
+                // fee should be in [MIN_PROTOCOL_BASE_FEE, base_fee)
+                let tx = self
+                    .tx_generator
+                    .tx(on_chain_nonce, &mut self.rng)
+                    .with_sender(sender)
+                    .with_gas_price(fee);
+                let valid_tx = self.validator.validated(tx);
+
+                let res =
+                    match pool.add_transaction(valid_tx, on_chain_balance, on_chain_nonce, None) {
+                        Ok(res) => res,
+                        Err(e) => match e.kind {
+                            // skip pool capacity/replacement errors (not relevant)
+                            PoolErrorKind::SpammerExceededCapacity(_) |
+                            PoolErrorKind::ReplacementUnderpriced => return,
+                            _ => panic!("unexpected error: {e:?}"),
+                        },
+                    };
+
+                match res {
+                    AddedTransaction::Pending(_) => panic!("expected parked"),
+                    AddedTransaction::Parked { subpool, .. } => {
+                        assert_eq!(
+                            subpool,
+                            SubPool::BaseFee,
+                            "expected to be moved to base fee subpool"
+                        );
+                    }
+                }
+                self.executed
+                    .entry(sender)
+                    .or_insert_with(|| ExecutedScenarios { sender, scenarios: vec![] }) // in the case of a new sender
+                    .scenarios
+                    .push(ExecutedScenario {
+                        balance: on_chain_balance,
+                        nonce: on_chain_nonce,
+                        scenario: Scenario::BelowBaseFee { fee },
+                    });
+            }
+
+            ScenarioType::FillNonceGap => {
+                if self.nonce_gaps.is_empty() {
+                    return;
+                }
+
+                let gap_senders: Vec<Address> = self.nonce_gaps.keys().copied().collect();
+                let idx = self.rng.random_range(0..gap_senders.len());
+                let gap_sender = gap_senders[idx];
+                let queued_nonce = self.nonce_gaps[&gap_sender];
+
+                let sender_onchain_nonce = self.nonces[&gap_sender];
+                let sender_balance = self.balances[&gap_sender];
+
+                for fill_nonce in sender_onchain_nonce..queued_nonce {
+                    let tx =
+                        self.tx_generator.tx(fill_nonce, &mut self.rng).with_sender(gap_sender);
+                    let valid_tx = self.validator.validated(tx);
+
+                    let res = match pool.add_transaction(
+                        valid_tx,
+                        sender_balance,
+                        sender_onchain_nonce,
+                        None,
+                    ) {
+                        Ok(res) => res,
+                        Err(e) => match e.kind {
+                            // skip pool capacity/replacement errors (not relevant)
+                            PoolErrorKind::SpammerExceededCapacity(_) |
+                            PoolErrorKind::ReplacementUnderpriced => return,
+                            _ => panic!("unexpected error: {e:?}"),
+                        },
+                    };
+
+                    match res {
+                        AddedTransaction::Pending(_) => {}
+                        AddedTransaction::Parked { .. } => {
+                            panic!("expected pending when filling gap")
+                        }
+                    }
+
+                    self.executed
+                        .entry(gap_sender)
+                        .or_insert_with(|| ExecutedScenarios {
+                            sender: gap_sender,
+                            scenarios: vec![],
+                        })
+                        .scenarios
+                        .push(ExecutedScenario {
+                            balance: sender_balance,
+                            nonce: fill_nonce,
+                            scenario: Scenario::FillNonceGap {
+                                filled_nonce: fill_nonce,
+                                promoted_nonce: queued_nonce,
+                            },
+                        });
+                }
+                self.nonces.insert(gap_sender, queued_nonce + 1);
+                self.nonce_gaps.remove(&gap_sender);
+            }
+        }
+        // make sure everything is set
+        pool.enforce_invariants();
+    }
+}
+
+/// How to configure a new mock transaction stream
+pub(crate) struct MockSimulatorConfig {
+    /// How many senders to generate.
+    pub(crate) num_senders: usize,
+    /// Scenarios to test
+    pub(crate) scenarios: Vec<ScenarioType>,
+    /// The start base fee
+    pub(crate) base_fee: u128,
+    /// generator for transactions
+    pub(crate) tx_generator: MockTransactionDistribution,
+}
+
+impl MockSimulatorConfig {
+    /// Generates a set of random addresses
+    pub(crate) fn addresses(&self, rng: &mut impl rand::Rng) -> Vec<Address> {
+        std::iter::repeat_with(|| Address::random_with(rng)).take(self.num_senders).collect()
+    }
+}
+
+/// Represents the different types of test scenarios.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub(crate) enum ScenarioType {
+    OnchainNonce,
+    HigherNonce { skip: u64 },
+    BelowBaseFee { fee: u128 },
+    FillNonceGap,
+}
+
+/// The actual scenario, ready to be executed
+///
+/// A scenario produces one or more transactions and expects a certain Outcome.
+///
+/// An executed scenario can affect previous executed transactions
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub(crate) enum Scenario {
+    /// Send a tx with the same nonce as on chain.
+    OnchainNonce { nonce: u64 },
+    /// Send a tx with a higher nonce that what the sender has on chain
+    HigherNonce { onchain: u64, nonce: u64 },
+    /// Send a tx with a base fee below the base fee of the pool
+    BelowBaseFee { fee: u128 },
+    /// Fill a nonce gap to promote queued transactions
+    FillNonceGap { filled_nonce: u64, promoted_nonce: u64 },
+    /// Execute multiple test scenarios
+    Multi { scenario: Vec<Self> },
+}
+
+/// Represents an executed scenario
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub(crate) struct ExecutedScenario {
+    /// balance at the time of execution
+    balance: U256,
+    /// nonce at the time of execution
+    nonce: u64,
+    /// The executed scenario
+    scenario: Scenario,
+}
+
+/// All executed scenarios by a sender
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub(crate) struct ExecutedScenarios {
+    sender: Address,
+    scenarios: Vec<ExecutedScenario>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{MockFeeRange, MockTransactionRatio};
+
+    #[test]
+    fn test_on_chain_nonce_scenario() {
+        let transaction_ratio = MockTransactionRatio {
+            legacy_pct: 30,
+            dynamic_fee_pct: 70,
+            access_list_pct: 0,
+            blob_pct: 0,
+        };
+
+        let base_fee = 10u128;
+        let fee_ranges = MockFeeRange {
+            gas_price: (base_fee..100).try_into().unwrap(),
+            priority_fee: (1u128..10).try_into().unwrap(),
+            max_fee: (base_fee..110).try_into().unwrap(),
+            max_fee_blob: (1u128..100).try_into().unwrap(),
+        };
+
+        let config = MockSimulatorConfig {
+            num_senders: 10,
+            scenarios: vec![ScenarioType::OnchainNonce],
+            base_fee,
+            tx_generator: MockTransactionDistribution::new(
+                transaction_ratio,
+                fee_ranges,
+                10..100,
+                10..100,
+            ),
+        };
+        let mut simulator = MockTransactionSimulator::new(rand::rng(), config);
+        let mut pool = simulator.create_pool();
+
+        simulator.next(&mut pool);
+        assert_eq!(pool.pending().len(), 1);
+        assert_eq!(pool.queued().len(), 0);
+        assert_eq!(pool.base_fee().len(), 0);
+    }
+
+    #[test]
+    fn test_higher_nonce_scenario() {
+        let transaction_ratio = MockTransactionRatio {
+            legacy_pct: 30,
+            dynamic_fee_pct: 70,
+            access_list_pct: 0,
+            blob_pct: 0,
+        };
+
+        let base_fee = 10u128;
+        let fee_ranges = MockFeeRange {
+            gas_price: (base_fee..100).try_into().unwrap(),
+            priority_fee: (1u128..10).try_into().unwrap(),
+            max_fee: (base_fee..110).try_into().unwrap(),
+            max_fee_blob: (1u128..100).try_into().unwrap(),
+        };
+
+        let config = MockSimulatorConfig {
+            num_senders: 10,
+            scenarios: vec![ScenarioType::HigherNonce { skip: 1 }],
+            base_fee,
+            tx_generator: MockTransactionDistribution::new(
+                transaction_ratio,
+                fee_ranges,
+                10..100,
+                10..100,
+            ),
+        };
+        let mut simulator = MockTransactionSimulator::new(rand::rng(), config);
+        let mut pool = simulator.create_pool();
+
+        simulator.next(&mut pool);
+        assert_eq!(pool.pending().len(), 0);
+        assert_eq!(pool.queued().len(), 1);
+        assert_eq!(pool.base_fee().len(), 0);
+    }
+
+    #[test]
+    fn test_below_base_fee_scenario() {
+        let transaction_ratio = MockTransactionRatio {
+            legacy_pct: 30,
+            dynamic_fee_pct: 70,
+            access_list_pct: 0,
+            blob_pct: 0,
+        };
+
+        let base_fee = 10u128;
+        let fee_ranges = MockFeeRange {
+            gas_price: (base_fee..100).try_into().unwrap(),
+            priority_fee: (1u128..10).try_into().unwrap(),
+            max_fee: (base_fee..110).try_into().unwrap(),
+            max_fee_blob: (1u128..100).try_into().unwrap(),
+        };
+
+        let config = MockSimulatorConfig {
+            num_senders: 10,
+            scenarios: vec![ScenarioType::BelowBaseFee { fee: 8 }], /* fee should be in
+                                                                     * [MIN_PROTOCOL_BASE_FEE,
+                                                                     * base_fee) */
+            base_fee,
+            tx_generator: MockTransactionDistribution::new(
+                transaction_ratio,
+                fee_ranges,
+                10..100,
+                10..100,
+            ),
+        };
+        let mut simulator = MockTransactionSimulator::new(rand::rng(), config);
+        let mut pool = simulator.create_pool();
+
+        simulator.next(&mut pool);
+        assert_eq!(pool.pending().len(), 0);
+        assert_eq!(pool.queued().len(), 0);
+        assert_eq!(pool.base_fee().len(), 1);
+    }
+
+    #[test]
+    fn test_fill_nonce_gap_scenario() {
+        let transaction_ratio = MockTransactionRatio {
+            legacy_pct: 30,
+            dynamic_fee_pct: 70,
+            access_list_pct: 0,
+            blob_pct: 0,
+        };
+
+        let base_fee = 10u128;
+        let fee_ranges = MockFeeRange {
+            gas_price: (base_fee..100).try_into().unwrap(),
+            priority_fee: (1u128..10).try_into().unwrap(),
+            max_fee: (base_fee..110).try_into().unwrap(),
+            max_fee_blob: (1u128..100).try_into().unwrap(),
+        };
+
+        let config = MockSimulatorConfig {
+            num_senders: 5,
+            scenarios: vec![ScenarioType::HigherNonce { skip: 5 }],
+            base_fee,
+            tx_generator: MockTransactionDistribution::new(
+                transaction_ratio,
+                fee_ranges,
+                10..100,
+                10..100,
+            ),
+        };
+        let mut simulator = MockTransactionSimulator::new(rand::rng(), config);
+        let mut pool = simulator.create_pool();
+
+        // create some nonce gaps
+        for _ in 0..10 {
+            simulator.next(&mut pool);
+        }
+
+        let num_gaps = simulator.nonce_gaps.len();
+
+        assert_eq!(pool.pending().len(), 0);
+        assert_eq!(pool.queued().len(), num_gaps);
+        assert_eq!(pool.base_fee().len(), 0);
+
+        simulator.scenarios = vec![ScenarioType::FillNonceGap];
+        for _ in 0..num_gaps {
+            simulator.next(&mut pool);
+        }
+
+        let expected_pending = num_gaps * 6;
+        assert_eq!(pool.pending().len(), expected_pending);
+        assert_eq!(pool.queued().len(), 0);
+        assert_eq!(pool.base_fee().len(), 0);
+    }
+
+    #[test]
+    fn test_random_scenarios() {
+        let transaction_ratio = MockTransactionRatio {
+            legacy_pct: 30,
+            dynamic_fee_pct: 70,
+            access_list_pct: 0,
+            blob_pct: 0,
+        };
+
+        let base_fee = 10u128;
+        let fee_ranges = MockFeeRange {
+            gas_price: (base_fee..100).try_into().unwrap(),
+            priority_fee: (1u128..10).try_into().unwrap(),
+            max_fee: (base_fee..110).try_into().unwrap(),
+            max_fee_blob: (1u128..100).try_into().unwrap(),
+        };
+
+        let config = MockSimulatorConfig {
+            num_senders: 10,
+            scenarios: vec![
+                ScenarioType::OnchainNonce,
+                ScenarioType::HigherNonce { skip: 2 },
+                ScenarioType::BelowBaseFee { fee: 8 },
+                ScenarioType::FillNonceGap,
+            ],
+            base_fee,
+            tx_generator: MockTransactionDistribution::new(
+                transaction_ratio,
+                fee_ranges,
+                10..100,
+                10..100,
+            ),
+        };
+        let mut simulator = MockTransactionSimulator::new(rand::rng(), config);
+        let mut pool = simulator.create_pool();
+
+        for _ in 0..1000 {
+            simulator.next(&mut pool);
+        }
+    }
+}

--- a/patches/reth-transaction-pool/src/test_utils/tx_gen.rs
+++ b/patches/reth-transaction-pool/src/test_utils/tx_gen.rs
@@ -1,0 +1,374 @@
+use crate::{EthPooledTransaction, PoolTransaction};
+use alloy_consensus::{SignableTransaction, TxEip1559, TxEip4844, TxLegacy};
+use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, eip2930::AccessList};
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+use rand::{Rng, RngCore};
+use reth_chainspec::MAINNET;
+use reth_ethereum_primitives::{Transaction, TransactionSigned};
+use reth_primitives_traits::{crypto::secp256k1::sign_message, SignedTransaction};
+
+/// A generator for transactions for testing purposes.
+#[derive(Debug)]
+pub struct TransactionGenerator<R> {
+    /// The random number generator used for generating keys and selecting signers.
+    pub rng: R,
+    /// The set of signer keys available for transaction generation.
+    pub signer_keys: Vec<B256>,
+    /// The base fee for transactions.
+    pub base_fee: u128,
+    /// The gas limit for transactions.
+    pub gas_limit: u64,
+}
+
+impl<R: RngCore> TransactionGenerator<R> {
+    /// Initializes the generator with 10 random signers
+    pub fn new(rng: R) -> Self {
+        Self::with_num_signers(rng, 10)
+    }
+
+    /// Generates random signers
+    pub fn with_num_signers(rng: R, num_signers: usize) -> Self {
+        Self {
+            rng,
+            signer_keys: (0..num_signers).map(|_| B256::random()).collect(),
+            base_fee: MIN_PROTOCOL_BASE_FEE as u128,
+            gas_limit: 300_000,
+        }
+    }
+
+    /// Adds a new signer to the set
+    pub fn push_signer(&mut self, signer: B256) -> &mut Self {
+        self.signer_keys.push(signer);
+        self
+    }
+
+    /// Sets the default gas limit for all generated transactions
+    pub const fn set_gas_limit(&mut self, gas_limit: u64) -> &mut Self {
+        self.gas_limit = gas_limit;
+        self
+    }
+
+    /// Sets the default gas limit for all generated transactions
+    pub const fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+        self.gas_limit = gas_limit;
+        self
+    }
+
+    /// Sets the base fee for the generated transactions
+    pub const fn set_base_fee(&mut self, base_fee: u64) -> &mut Self {
+        self.base_fee = base_fee as u128;
+        self
+    }
+
+    /// Sets the base fee for the generated transactions
+    pub const fn with_base_fee(mut self, base_fee: u64) -> Self {
+        self.base_fee = base_fee as u128;
+        self
+    }
+
+    /// Adds the given signers to the set.
+    pub fn extend_signers(&mut self, signers: impl IntoIterator<Item = B256>) -> &mut Self {
+        self.signer_keys.extend(signers);
+        self
+    }
+
+    /// Returns a random signer from the set
+    fn rng_signer(&mut self) -> B256 {
+        let idx = self.rng.random_range(0..self.signer_keys.len());
+        self.signer_keys[idx]
+    }
+
+    /// Creates a new transaction with a random signer
+    pub fn transaction(&mut self) -> TransactionBuilder {
+        TransactionBuilder::default()
+            .signer(self.rng_signer())
+            .max_fee_per_gas(self.base_fee)
+            .max_priority_fee_per_gas(self.base_fee)
+            .gas_limit(self.gas_limit)
+    }
+
+    /// Creates a new transaction with a random signer
+    pub fn gen_eip1559(&mut self) -> TransactionSigned {
+        self.transaction().into_eip1559()
+    }
+
+    /// Creates a new transaction with a random signer
+    pub fn gen_eip4844(&mut self) -> TransactionSigned {
+        self.transaction().into_eip4844()
+    }
+
+    /// Generates and returns a pooled EIP-1559 transaction with a random signer.
+    pub fn gen_eip1559_pooled(&mut self) -> EthPooledTransaction {
+        EthPooledTransaction::try_from_consensus(
+            SignedTransaction::try_into_recovered(self.gen_eip1559()).unwrap(),
+        )
+        .unwrap()
+    }
+
+    /// Generates and returns a pooled EIP-4844 transaction with a random signer.
+    pub fn gen_eip4844_pooled(&mut self) -> EthPooledTransaction {
+        let tx = self.gen_eip4844().try_into_recovered().unwrap();
+        let encoded_length = tx.encode_2718_len();
+        EthPooledTransaction::new(tx, encoded_length)
+    }
+}
+
+/// A Builder type to configure and create a transaction.
+#[derive(Debug)]
+pub struct TransactionBuilder {
+    /// The signer used to sign the transaction.
+    pub signer: B256,
+    /// The chain ID on which the transaction will be executed.
+    pub chain_id: u64,
+    /// The nonce value for the transaction to prevent replay attacks.
+    pub nonce: u64,
+    /// The maximum amount of gas units that the transaction can consume.
+    pub gas_limit: u64,
+    /// The maximum fee per gas unit that the sender is willing to pay.
+    pub max_fee_per_gas: u128,
+    /// The maximum priority fee per gas unit that the sender is willing to pay for faster
+    /// processing.
+    pub max_priority_fee_per_gas: u128,
+    /// The recipient or contract address of the transaction.
+    pub to: TxKind,
+    /// The value to be transferred in the transaction.
+    pub value: U256,
+    /// The list of addresses and storage keys that the transaction can access.
+    pub access_list: AccessList,
+    /// The input data for the transaction, typically containing function parameters for contract
+    /// calls.
+    pub input: Bytes,
+}
+
+impl TransactionBuilder {
+    /// Converts the transaction builder into a legacy transaction format.
+    pub fn into_legacy(self) -> TransactionSigned {
+        Self::signed(
+            TxLegacy {
+                chain_id: Some(self.chain_id),
+                nonce: self.nonce,
+                gas_limit: self.gas_limit,
+                gas_price: self.max_fee_per_gas,
+                to: self.to,
+                value: self.value,
+                input: self.input,
+            }
+            .into(),
+            self.signer,
+        )
+    }
+
+    /// Converts the transaction builder into a transaction format using EIP-1559.
+    pub fn into_eip1559(self) -> TransactionSigned {
+        Self::signed(
+            TxEip1559 {
+                chain_id: self.chain_id,
+                nonce: self.nonce,
+                gas_limit: self.gas_limit,
+                max_fee_per_gas: self.max_fee_per_gas,
+                max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+                to: self.to,
+                value: self.value,
+                access_list: self.access_list,
+                input: self.input,
+            }
+            .into(),
+            self.signer,
+        )
+    }
+    /// Converts the transaction builder into a transaction format using EIP-4844.
+    pub fn into_eip4844(self) -> TransactionSigned {
+        Self::signed(
+            TxEip4844 {
+                chain_id: self.chain_id,
+                nonce: self.nonce,
+                gas_limit: self.gas_limit,
+                max_fee_per_gas: self.max_fee_per_gas,
+                max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+                to: match self.to {
+                    TxKind::Call(to) => to,
+                    TxKind::Create => Address::default(),
+                },
+                value: self.value,
+                access_list: self.access_list,
+                input: self.input,
+                blob_versioned_hashes: Default::default(),
+                max_fee_per_blob_gas: Default::default(),
+            }
+            .into(),
+            self.signer,
+        )
+    }
+
+    /// Signs the provided transaction using the specified signer and returns a signed transaction.
+    fn signed(transaction: Transaction, signer: B256) -> TransactionSigned {
+        let signature = sign_message(signer, transaction.signature_hash()).unwrap();
+        TransactionSigned::new_unhashed(transaction, signature)
+    }
+
+    /// Sets the signer for the transaction builder.
+    pub const fn signer(mut self, signer: B256) -> Self {
+        self.signer = signer;
+        self
+    }
+
+    /// Sets the gas limit for the transaction builder.
+    pub const fn gas_limit(mut self, gas_limit: u64) -> Self {
+        self.gas_limit = gas_limit;
+        self
+    }
+
+    /// Sets the nonce for the transaction builder.
+    pub const fn nonce(mut self, nonce: u64) -> Self {
+        self.nonce = nonce;
+        self
+    }
+
+    /// Increments the nonce value of the transaction builder by 1.
+    pub const fn inc_nonce(mut self) -> Self {
+        self.nonce += 1;
+        self
+    }
+
+    /// Decrements the nonce value of the transaction builder by 1, avoiding underflow.
+    pub const fn decr_nonce(mut self) -> Self {
+        self.nonce = self.nonce.saturating_sub(1);
+        self
+    }
+
+    /// Sets the maximum fee per gas for the transaction builder.
+    pub const fn max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
+        self.max_fee_per_gas = max_fee_per_gas;
+        self
+    }
+
+    /// Sets the maximum priority fee per gas for the transaction builder.
+    pub const fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
+        self.max_priority_fee_per_gas = max_priority_fee_per_gas;
+        self
+    }
+
+    /// Sets the recipient or contract address for the transaction builder.
+    pub const fn to(mut self, to: Address) -> Self {
+        self.to = TxKind::Call(to);
+        self
+    }
+
+    /// Sets the value to be transferred in the transaction.
+    pub fn value(mut self, value: u128) -> Self {
+        self.value = U256::from(value);
+        self
+    }
+
+    /// Sets the access list for the transaction builder.
+    pub fn access_list(mut self, access_list: AccessList) -> Self {
+        self.access_list = access_list;
+        self
+    }
+
+    /// Sets the transaction input data.
+    pub fn input(mut self, input: impl Into<Bytes>) -> Self {
+        self.input = input.into();
+        self
+    }
+
+    /// Sets the chain ID for the transaction.
+    pub const fn chain_id(mut self, chain_id: u64) -> Self {
+        self.chain_id = chain_id;
+        self
+    }
+
+    /// Sets the chain ID for the transaction, mutable reference version.
+    pub const fn set_chain_id(&mut self, chain_id: u64) -> &mut Self {
+        self.chain_id = chain_id;
+        self
+    }
+
+    /// Sets the nonce for the transaction, mutable reference version.
+    pub const fn set_nonce(&mut self, nonce: u64) -> &mut Self {
+        self.nonce = nonce;
+        self
+    }
+
+    /// Sets the gas limit for the transaction, mutable reference version.
+    pub const fn set_gas_limit(&mut self, gas_limit: u64) -> &mut Self {
+        self.gas_limit = gas_limit;
+        self
+    }
+
+    /// Sets the maximum fee per gas for the transaction, mutable reference version.
+    pub const fn set_max_fee_per_gas(&mut self, max_fee_per_gas: u128) -> &mut Self {
+        self.max_fee_per_gas = max_fee_per_gas;
+        self
+    }
+
+    /// Sets the maximum priority fee per gas for the transaction, mutable reference version.
+    pub const fn set_max_priority_fee_per_gas(
+        &mut self,
+        max_priority_fee_per_gas: u128,
+    ) -> &mut Self {
+        self.max_priority_fee_per_gas = max_priority_fee_per_gas;
+        self
+    }
+
+    /// Sets the recipient or contract address for the transaction, mutable reference version.
+    pub fn set_to(&mut self, to: Address) -> &mut Self {
+        self.to = to.into();
+        self
+    }
+
+    /// Sets the value to be transferred in the transaction, mutable reference version.
+    pub fn set_value(&mut self, value: u128) -> &mut Self {
+        self.value = U256::from(value);
+        self
+    }
+
+    /// Sets the access list for the transaction, mutable reference version.
+    pub fn set_access_list(&mut self, access_list: AccessList) -> &mut Self {
+        self.access_list = access_list;
+        self
+    }
+
+    /// Sets the signer for the transaction, mutable reference version.
+    pub const fn set_signer(&mut self, signer: B256) -> &mut Self {
+        self.signer = signer;
+        self
+    }
+
+    /// Sets the transaction input data, mutable reference version.
+    pub fn set_input(&mut self, input: impl Into<Bytes>) -> &mut Self {
+        self.input = input.into();
+        self
+    }
+}
+
+impl Default for TransactionBuilder {
+    fn default() -> Self {
+        Self {
+            signer: B256::random(),
+            chain_id: MAINNET.chain.id(),
+            nonce: 0,
+            gas_limit: 0,
+            max_fee_per_gas: 0,
+            max_priority_fee_per_gas: 0,
+            to: Default::default(),
+            value: Default::default(),
+            access_list: Default::default(),
+            input: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rng;
+
+    #[test]
+    fn test_generate_transaction() {
+        let rng = rng();
+        let mut tx_gen = TransactionGenerator::new(rng);
+        let _tx = tx_gen.transaction().into_legacy();
+        let _tx = tx_gen.transaction().into_eip1559();
+    }
+}

--- a/patches/reth-transaction-pool/src/traits.rs
+++ b/patches/reth-transaction-pool/src/traits.rs
@@ -1,0 +1,2030 @@
+//! Transaction Pool Traits and Types
+//!
+//! This module defines the core abstractions for transaction pool implementations,
+//! handling the complexity of different transaction representations across the
+//! network, mempool, and the chain itself.
+//!
+//! ## Key Concepts
+//!
+//! ### Transaction Representations
+//!
+//! Transactions exist in different formats throughout their lifecycle:
+//!
+//! 1. **Consensus Format** ([`PoolTransaction::Consensus`])
+//!    - The canonical format stored in blocks
+//!    - Minimal size for efficient storage
+//!    - Example: EIP-4844 transactions store only blob hashes: ([`TransactionSigned::Eip4844`])
+//!
+//! 2. **Pooled Format** ([`PoolTransaction::Pooled`])
+//!    - Extended format for network propagation
+//!    - Includes additional validation data
+//!    - Example: EIP-4844 transactions include full blob sidecars: ([`PooledTransactionVariant`])
+//!
+//! ### Type Relationships
+//!
+//! ```text
+//! NodePrimitives::SignedTx  ←──   NetworkPrimitives::BroadcastedTransaction
+//!        │                              │
+//!        │ (consensus format)           │ (announced to peers)
+//!        │                              │
+//!        └──────────┐  ┌────────────────┘
+//!                   ▼  ▼
+//!            PoolTransaction::Consensus
+//!                   │ ▲
+//!                   │ │ from pooled (always succeeds)
+//!                   │ │
+//!                   ▼ │ try_from consensus (may fail)
+//!            PoolTransaction::Pooled  ←──→  NetworkPrimitives::PooledTransaction
+//!                                             (sent on request)
+//! ```
+//!
+//! ### Special Cases
+//!
+//! #### EIP-4844 Blob Transactions
+//! - Consensus format: Only blob hashes (32 bytes each)
+//! - Pooled format: Full blobs + commitments + proofs (large data per blob)
+//! - Network behavior: Not broadcast automatically, only sent on explicit request
+//!
+//! #### Optimism Deposit Transactions
+//! - Only exist in consensus format
+//! - Never enter the mempool (system transactions)
+//! - Conversion from consensus to pooled always fails
+
+use crate::{
+    blobstore::BlobStoreError,
+    error::{InvalidPoolTransactionError, PoolError, PoolResult},
+    pool::{
+        state::SubPool, BestTransactionFilter, NewTransactionEvent, TransactionEvents,
+        TransactionListenerKind,
+    },
+    validate::ValidPoolTransaction,
+    AddedTransactionOutcome, AllTransactionsEvents,
+};
+use alloy_consensus::{error::ValueError, transaction::TxHashRef, BlockHeader, Signed, Typed2718};
+use alloy_eips::{
+    eip2718::{Encodable2718, WithEncoded},
+    eip2930::AccessList,
+    eip4844::{
+        env_settings::KzgSettings, BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1,
+        BlobTransactionValidationError,
+    },
+    eip7594::BlobTransactionSidecarVariant,
+    eip7702::SignedAuthorization,
+};
+use alloy_primitives::{map::AddressSet, Address, Bytes, TxHash, TxKind, B128, B256, U256};
+use futures_util::{ready, Stream};
+use reth_eth_wire_types::HandleMempoolData;
+use reth_ethereum_primitives::{PooledTransactionVariant, TransactionSigned};
+use reth_execution_types::ChangedAccount;
+use reth_primitives_traits::{Block, InMemorySize, Recovered, SealedBlock, SignedTransaction};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fmt,
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc::Receiver;
+
+/// The `PeerId` type.
+pub type PeerId = alloy_primitives::B512;
+
+/// Helper type alias to access [`PoolTransaction`] for a given [`TransactionPool`].
+pub type PoolTx<P> = <P as TransactionPool>::Transaction;
+/// Helper type alias to access [`PoolTransaction::Consensus`] for a given [`TransactionPool`].
+pub type PoolConsensusTx<P> = <<P as TransactionPool>::Transaction as PoolTransaction>::Consensus;
+
+/// Helper type alias to access [`PoolTransaction::Pooled`] for a given [`TransactionPool`].
+pub type PoolPooledTx<P> = <<P as TransactionPool>::Transaction as PoolTransaction>::Pooled;
+
+/// General purpose abstraction of a transaction-pool.
+///
+/// This is intended to be used by API-consumers such as RPC that need inject new incoming,
+/// unverified transactions. And by block production that needs to get transactions to execute in a
+/// new block.
+///
+/// Note: This requires `Clone` for convenience, since it is assumed that this will be implemented
+/// for a wrapped `Arc` type, see also [`Pool`](crate::Pool).
+#[auto_impl::auto_impl(&, Arc)]
+pub trait TransactionPool: Clone + Debug + Send + Sync {
+    /// The transaction type of the pool
+    type Transaction: EthPoolTransaction;
+
+    /// Returns stats about the pool and all sub-pools.
+    fn pool_size(&self) -> PoolSize;
+
+    /// Returns the block the pool is currently tracking.
+    ///
+    /// This tracks the block that the pool has last seen.
+    fn block_info(&self) -> BlockInfo;
+
+    /// Imports an _external_ transaction.
+    ///
+    /// This is intended to be used by the network to insert incoming transactions received over the
+    /// p2p network.
+    ///
+    /// Consumer: P2P
+    fn add_external_transaction(
+        &self,
+        transaction: Self::Transaction,
+    ) -> impl Future<Output = PoolResult<AddedTransactionOutcome>> + Send {
+        self.add_transaction(TransactionOrigin::External, transaction)
+    }
+
+    /// Imports all _external_ transactions
+    ///
+    /// Consumer: Utility
+    fn add_external_transactions(
+        &self,
+        transactions: Vec<Self::Transaction>,
+    ) -> impl Future<Output = Vec<PoolResult<AddedTransactionOutcome>>> + Send {
+        self.add_transactions(TransactionOrigin::External, transactions)
+    }
+
+    /// Adds an _unvalidated_ transaction into the pool and subscribe to state changes.
+    ///
+    /// This is the same as [`TransactionPool::add_transaction`] but returns an event stream for the
+    /// given transaction.
+    ///
+    /// Consumer: Custom
+    fn add_transaction_and_subscribe(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> impl Future<Output = PoolResult<TransactionEvents>> + Send;
+
+    /// Adds an _unvalidated_ transaction into the pool.
+    ///
+    /// Consumer: RPC
+    fn add_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> impl Future<Output = PoolResult<AddedTransactionOutcome>> + Send;
+
+    /// Adds the given _unvalidated_ transactions into the pool.
+    ///
+    /// All transactions will use the same `origin`.
+    ///
+    /// Returns a list of results.
+    ///
+    /// Consumer: RPC
+    fn add_transactions(
+        &self,
+        origin: TransactionOrigin,
+        transactions: Vec<Self::Transaction>,
+    ) -> impl Future<Output = Vec<PoolResult<AddedTransactionOutcome>>> + Send;
+
+    /// Adds the given _unvalidated_ transactions into the pool.
+    ///
+    /// Each transaction is paired with its own [`TransactionOrigin`].
+    ///
+    /// Returns a list of results.
+    ///
+    /// Consumer: RPC
+    fn add_transactions_with_origins(
+        &self,
+        transactions: Vec<(TransactionOrigin, Self::Transaction)>,
+    ) -> impl Future<Output = Vec<PoolResult<AddedTransactionOutcome>>> + Send;
+
+    /// Submit a consensus transaction directly to the pool
+    fn add_consensus_transaction(
+        &self,
+        tx: Recovered<<Self::Transaction as PoolTransaction>::Consensus>,
+        origin: TransactionOrigin,
+    ) -> impl Future<Output = PoolResult<AddedTransactionOutcome>> + Send {
+        async move {
+            let tx_hash = *tx.tx_hash();
+
+            let pool_transaction = match Self::Transaction::try_from_consensus(tx) {
+                Ok(tx) => tx,
+                Err(e) => return Err(PoolError::other(tx_hash, e.to_string())),
+            };
+
+            self.add_transaction(origin, pool_transaction).await
+        }
+    }
+
+    /// Submit a consensus transaction and subscribe to event stream
+    fn add_consensus_transaction_and_subscribe(
+        &self,
+        tx: Recovered<<Self::Transaction as PoolTransaction>::Consensus>,
+        origin: TransactionOrigin,
+    ) -> impl Future<Output = PoolResult<TransactionEvents>> + Send {
+        async move {
+            let tx_hash = *tx.tx_hash();
+
+            let pool_transaction = match Self::Transaction::try_from_consensus(tx) {
+                Ok(tx) => tx,
+                Err(e) => return Err(PoolError::other(tx_hash, e.to_string())),
+            };
+
+            self.add_transaction_and_subscribe(origin, pool_transaction).await
+        }
+    }
+
+    /// Returns a new transaction change event stream for the given transaction.
+    ///
+    /// Returns `None` if the transaction is not in the pool.
+    fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents>;
+
+    /// Returns a new transaction change event stream for _all_ transactions in the pool.
+    fn all_transactions_event_listener(&self) -> AllTransactionsEvents<Self::Transaction>;
+
+    /// Returns a new Stream that yields transactions hashes for new __pending__ transactions
+    /// inserted into the pool that are allowed to be propagated.
+    ///
+    /// Note: This is intended for networking and will __only__ yield transactions that are allowed
+    /// to be propagated over the network, see also [`TransactionListenerKind`].
+    ///
+    /// Consumer: RPC/P2P
+    fn pending_transactions_listener(&self) -> Receiver<TxHash> {
+        self.pending_transactions_listener_for(TransactionListenerKind::PropagateOnly)
+    }
+
+    /// Returns a new [Receiver] that yields transactions hashes for new __pending__ transactions
+    /// inserted into the pending pool depending on the given [`TransactionListenerKind`] argument.
+    fn pending_transactions_listener_for(&self, kind: TransactionListenerKind) -> Receiver<TxHash>;
+
+    /// Returns a new stream that yields new valid transactions added to the pool.
+    fn new_transactions_listener(&self) -> Receiver<NewTransactionEvent<Self::Transaction>> {
+        self.new_transactions_listener_for(TransactionListenerKind::PropagateOnly)
+    }
+
+    /// Returns a new [Receiver] that yields blob "sidecars" (blobs w/ assoc. kzg
+    /// commitments/proofs) for eip-4844 transactions inserted into the pool
+    fn blob_transaction_sidecars_listener(&self) -> Receiver<NewBlobSidecar>;
+
+    /// Returns a new stream that yields new valid transactions added to the pool
+    /// depending on the given [`TransactionListenerKind`] argument.
+    fn new_transactions_listener_for(
+        &self,
+        kind: TransactionListenerKind,
+    ) -> Receiver<NewTransactionEvent<Self::Transaction>>;
+
+    /// Returns a new Stream that yields new transactions added to the pending sub-pool.
+    ///
+    /// This is a convenience wrapper around [`Self::new_transactions_listener`] that filters for
+    /// [`SubPool::Pending`](crate::SubPool).
+    fn new_pending_pool_transactions_listener(
+        &self,
+    ) -> NewSubpoolTransactionStream<Self::Transaction> {
+        NewSubpoolTransactionStream::new(
+            self.new_transactions_listener_for(TransactionListenerKind::PropagateOnly),
+            SubPool::Pending,
+        )
+    }
+
+    /// Returns a new Stream that yields new transactions added to the basefee sub-pool.
+    ///
+    /// This is a convenience wrapper around [`Self::new_transactions_listener`] that filters for
+    /// [`SubPool::BaseFee`](crate::SubPool).
+    fn new_basefee_pool_transactions_listener(
+        &self,
+    ) -> NewSubpoolTransactionStream<Self::Transaction> {
+        NewSubpoolTransactionStream::new(self.new_transactions_listener(), SubPool::BaseFee)
+    }
+
+    /// Returns a new Stream that yields new transactions added to the queued-pool.
+    ///
+    /// This is a convenience wrapper around [`Self::new_transactions_listener`] that filters for
+    /// [`SubPool::Queued`](crate::SubPool).
+    fn new_queued_transactions_listener(&self) -> NewSubpoolTransactionStream<Self::Transaction> {
+        NewSubpoolTransactionStream::new(self.new_transactions_listener(), SubPool::Queued)
+    }
+
+    /// Returns a new Stream that yields new transactions added to the blob sub-pool.
+    ///
+    /// This is a convenience wrapper around [`Self::new_transactions_listener`] that filters for
+    /// [`SubPool::Blob`](crate::SubPool).
+    fn new_blob_pool_transactions_listener(
+        &self,
+    ) -> NewSubpoolTransactionStream<Self::Transaction> {
+        NewSubpoolTransactionStream::new(self.new_transactions_listener(), SubPool::Blob)
+    }
+
+    /// Returns the _hashes_ of all transactions in the pool that are allowed to be propagated.
+    ///
+    /// This excludes hashes that aren't allowed to be propagated.
+    ///
+    /// Note: This returns a `Vec` but should guarantee that all hashes are unique.
+    ///
+    /// Consumer: P2P
+    fn pooled_transaction_hashes(&self) -> Vec<TxHash>;
+
+    /// Returns only the first `max` hashes of transactions in the pool.
+    ///
+    /// Consumer: P2P
+    fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash>;
+
+    /// Returns the _full_ transaction objects all transactions in the pool that are allowed to be
+    /// propagated.
+    ///
+    /// This is intended to be used by the network for the initial exchange of pooled transaction
+    /// _hashes_
+    ///
+    /// Note: This returns a `Vec` but should guarantee that all transactions are unique.
+    ///
+    /// Caution: In case of blob transactions, this does not include the sidecar.
+    ///
+    /// Consumer: P2P
+    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns only the first `max` transactions in the pool.
+    ///
+    /// Consumer: P2P
+    fn pooled_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns converted [`PooledTransactionVariant`] for the given transaction hashes that are
+    /// allowed to be propagated.
+    ///
+    /// This adheres to the expected behavior of
+    /// [`GetPooledTransactions`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getpooledtransactions-0x09):
+    ///
+    /// The transactions must be in same order as in the request, but it is OK to skip transactions
+    /// which are not available.
+    ///
+    /// If the transaction is a blob transaction, the sidecar will be included.
+    ///
+    /// Consumer: P2P
+    fn get_pooled_transaction_elements(
+        &self,
+        tx_hashes: Vec<TxHash>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<<Self::Transaction as PoolTransaction>::Pooled>;
+
+    /// Extends the given vector with pooled transactions for the given hashes that are allowed to
+    /// be propagated.
+    ///
+    /// This adheres to the expected behavior of [`Self::get_pooled_transaction_elements`].
+    ///
+    /// Consumer: P2P
+    fn append_pooled_transaction_elements(
+        &self,
+        tx_hashes: &[TxHash],
+        limit: GetPooledTransactionLimit,
+        out: &mut Vec<<Self::Transaction as PoolTransaction>::Pooled>,
+    ) {
+        out.extend(self.get_pooled_transaction_elements(tx_hashes.to_vec(), limit));
+    }
+
+    /// Returns the pooled transaction variant for the given transaction hash.
+    ///
+    /// This adheres to the expected behavior of
+    /// [`GetPooledTransactions`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getpooledtransactions-0x09):
+    ///
+    /// If the transaction is a blob transaction, the sidecar will be included.
+    ///
+    /// It is expected that this variant represents the valid p2p format for full transactions.
+    /// E.g. for EIP-4844 transactions this is the consensus transaction format with the blob
+    /// sidecar.
+    ///
+    /// Consumer: P2P
+    fn get_pooled_transaction_element(
+        &self,
+        tx_hash: TxHash,
+    ) -> Option<Recovered<<Self::Transaction as PoolTransaction>::Pooled>>;
+
+    /// Returns an iterator that yields transactions that are ready for block production.
+    ///
+    /// Consumer: Block production
+    fn best_transactions(
+        &self,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>>;
+
+    /// Returns an iterator that yields transactions that are ready for block production with the
+    /// given base fee and optional blob fee attributes.
+    ///
+    /// Consumer: Block production
+    fn best_transactions_with_attributes(
+        &self,
+        best_transactions_attributes: BestTransactionsAttributes,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>>;
+
+    /// Returns all transactions that can be included in the next block.
+    ///
+    /// This is primarily used for the `txpool_` RPC namespace:
+    /// <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool> which distinguishes
+    /// between `pending` and `queued` transactions, where `pending` are transactions ready for
+    /// inclusion in the next block and `queued` are transactions that are ready for inclusion in
+    /// future blocks.
+    ///
+    /// Consumer: RPC
+    fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns a pending transaction if it exists and is ready for immediate execution
+    /// (i.e., has the lowest nonce among the sender's pending transactions).
+    fn get_pending_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.best_transactions().find(|tx| tx.sender() == sender && tx.nonce() == nonce)
+    }
+
+    /// Returns first `max` transactions that can be included in the next block.
+    /// See <https://github.com/paradigmxyz/reth/issues/12767#issuecomment-2493223579>
+    ///
+    /// Consumer: Block production
+    fn pending_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all transactions that can be included in _future_ blocks.
+    ///
+    /// This and [`Self::pending_transactions`] are mutually exclusive.
+    ///
+    /// Consumer: RPC
+    fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns the number of transactions that are ready for inclusion in the next block and the
+    /// number of transactions that are ready for inclusion in future blocks: `(pending, queued)`.
+    fn pending_and_queued_txn_count(&self) -> (usize, usize);
+
+    /// Returns all transactions that are currently in the pool grouped by whether they are ready
+    /// for inclusion in the next block or not.
+    ///
+    /// This is primarily used for the `txpool_` namespace: <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool>
+    ///
+    /// Consumer: RPC
+    fn all_transactions(&self) -> AllPoolTransactions<Self::Transaction>;
+
+    /// Returns the _hashes_ of all transactions regardless of whether they can be propagated or
+    /// not.
+    ///
+    /// Unlike [`Self::pooled_transaction_hashes`] this doesn't consider whether the transaction can
+    /// be propagated or not.
+    ///
+    /// Note: This returns a `Vec` but should guarantee that all hashes are unique.
+    ///
+    /// Consumer: Utility
+    fn all_transaction_hashes(&self) -> Vec<TxHash>;
+
+    /// Removes a single transaction corresponding to the given hash.
+    ///
+    /// Note: This removes the transaction as if it got discarded (_not_ mined).
+    ///
+    /// Returns the removed transaction if it was found in the pool.
+    ///
+    /// Consumer: Utility
+    fn remove_transaction(
+        &self,
+        hash: TxHash,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.remove_transactions(vec![hash]).pop()
+    }
+
+    /// Removes all transactions corresponding to the given hashes.
+    ///
+    /// Note: This removes the transactions as if they got discarded (_not_ mined).
+    ///
+    /// Consumer: Utility
+    fn remove_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Removes all transactions corresponding to the given hashes.
+    ///
+    /// Also removes all _dependent_ transactions.
+    ///
+    /// Consumer: Utility
+    fn remove_transactions_and_descendants(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Removes all transactions from the given sender
+    ///
+    /// Consumer: Utility
+    fn remove_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Prunes a single transaction from the pool.
+    ///
+    /// This is similar to [`Self::remove_transaction`] but treats the transaction as _mined_
+    /// rather than discarded. The key difference is that pruning does **not** park descendant
+    /// transactions: their nonce requirements are considered satisfied, so they remain in whatever
+    /// sub-pool they currently occupy and can be included in the next block.
+    ///
+    /// In contrast, [`Self::remove_transaction`] treats the removal as a discard, which
+    /// introduces a nonce gap and moves all descendant transactions to the queued (parked)
+    /// sub-pool.
+    ///
+    /// Returns the pruned transaction if it existed in the pool.
+    ///
+    /// Consumer: Utility
+    fn prune_transaction(
+        &self,
+        hash: TxHash,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.prune_transactions(vec![hash]).pop()
+    }
+
+    /// Prunes all transactions corresponding to the given hashes from the pool.
+    ///
+    /// This behaves like [`Self::prune_transaction`] but for multiple transactions at once.
+    /// Each transaction is removed as if it was mined: descendant transactions are **not** parked
+    /// and their nonce requirements are considered satisfied.
+    ///
+    /// This is useful for scenarios like Flashblocks where transactions are committed across
+    /// multiple partial blocks without a canonical state update: previously committed transactions
+    /// can be pruned so that the best-transactions iterator yields their descendants in the
+    /// correct priority order.
+    ///
+    /// Consumer: Utility
+    fn prune_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Retains only those hashes that are unknown to the pool.
+    /// In other words, removes all transactions from the given set that are currently present in
+    /// the pool. Returns hashes already known to the pool.
+    ///
+    /// Consumer: P2P
+    fn retain_unknown<A>(&self, announcement: &mut A)
+    where
+        A: HandleMempoolData;
+
+    /// Returns if the transaction for the given hash is already included in this pool.
+    fn contains(&self, tx_hash: &TxHash) -> bool {
+        self.get(tx_hash).is_some()
+    }
+
+    /// Returns the transaction for the given hash.
+    fn get(&self, tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all transactions objects for the given hashes.
+    ///
+    /// Caution: This in case of blob transactions, this does not include the sidecar.
+    fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Notify the pool about transactions that are propagated to peers.
+    ///
+    /// Consumer: P2P
+    fn on_propagated(&self, txs: PropagatedTransactions);
+
+    /// Returns all transactions sent by a given user
+    fn get_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all pending transactions filtered by predicate
+    fn get_pending_transactions_with_predicate(
+        &self,
+        predicate: impl FnMut(&ValidPoolTransaction<Self::Transaction>) -> bool,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all pending transactions sent by a given user
+    fn get_pending_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all queued transactions sent by a given user
+    fn get_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns the highest transaction sent by a given user
+    fn get_highest_transaction_by_sender(
+        &self,
+        sender: Address,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns the transaction with the highest nonce that is executable given the on chain nonce.
+    /// In other words the highest non nonce gapped transaction.
+    ///
+    /// Note: The next pending pooled transaction must have the on chain nonce.
+    ///
+    /// For example, for a given on chain nonce of `5`, the next transaction must have that nonce.
+    /// If the pool contains txs `[5,6,7]` this returns tx `7`.
+    /// If the pool contains txs `[6,7]` this returns `None` because the next valid nonce (5) is
+    /// missing, which means txs `[6,7]` are nonce gapped.
+    fn get_highest_consecutive_transaction_by_sender(
+        &self,
+        sender: Address,
+        on_chain_nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns a transaction sent by a given user and a nonce
+    fn get_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all transactions that where submitted with the given [`TransactionOrigin`]
+    fn get_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all pending transactions filtered by [`TransactionOrigin`]
+    fn get_pending_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all transactions that where submitted as [`TransactionOrigin::Local`]
+    fn get_local_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.get_transactions_by_origin(TransactionOrigin::Local)
+    }
+
+    /// Returns all transactions that where submitted as [`TransactionOrigin::Private`]
+    fn get_private_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.get_transactions_by_origin(TransactionOrigin::Private)
+    }
+
+    /// Returns all transactions that where submitted as [`TransactionOrigin::External`]
+    fn get_external_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.get_transactions_by_origin(TransactionOrigin::External)
+    }
+
+    /// Returns all pending transactions that where submitted as [`TransactionOrigin::Local`]
+    fn get_local_pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.get_pending_transactions_by_origin(TransactionOrigin::Local)
+    }
+
+    /// Returns all pending transactions that where submitted as [`TransactionOrigin::Private`]
+    fn get_private_pending_transactions(
+        &self,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.get_pending_transactions_by_origin(TransactionOrigin::Private)
+    }
+
+    /// Returns all pending transactions that where submitted as [`TransactionOrigin::External`]
+    fn get_external_pending_transactions(
+        &self,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.get_pending_transactions_by_origin(TransactionOrigin::External)
+    }
+
+    /// Returns a set of all senders of transactions in the pool
+    fn unique_senders(&self) -> AddressSet;
+
+    /// Returns the [`BlobTransactionSidecarVariant`] for the given transaction hash if it exists in
+    /// the blob store.
+    fn get_blob(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+
+    /// Returns all [`BlobTransactionSidecarVariant`] for the given transaction hashes if they
+    /// exists in the blob store.
+    ///
+    /// This only returns the blobs that were found in the store.
+    /// If there's no blob it will not be returned.
+    fn get_all_blobs(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<(TxHash, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError>;
+
+    /// Returns the exact [`BlobTransactionSidecarVariant`] for the given transaction hashes in the
+    /// order they were requested.
+    ///
+    /// Returns an error if any of the blobs are not found in the blob store.
+    fn get_all_blobs_exact(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+
+    /// Return the [`BlobAndProofV1`]s for a list of blob versioned hashes.
+    fn get_blobs_for_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError>;
+
+    /// Return the [`BlobAndProofV2`]s for a list of blob versioned hashes.
+    /// Blobs and proofs are returned only if they are present for _all_ of the requested versioned
+    /// hashes.
+    fn get_blobs_for_versioned_hashes_v2(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError>;
+
+    /// Return the [`BlobAndProofV2`]s for a list of blob versioned hashes.
+    ///
+    /// The response is always the same length as the request. Missing or older-version blobs are
+    /// returned as `None` elements.
+    fn get_blobs_for_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError>;
+
+    /// Return the [`BlobCellsAndProofsV1`]s for a list of blob versioned hashes and requested cell
+    /// indices.
+    ///
+    /// The response is always the same length as the request. Missing or older-version blobs are
+    /// returned as `None` elements.
+    fn get_blobs_for_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: B128,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError>;
+}
+
+/// Extension for [`TransactionPool`] trait that allows to set the current block info.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait TransactionPoolExt: TransactionPool {
+    /// The block type used for chain tip updates.
+    type Block: Block;
+
+    /// Sets the current block info for the pool.
+    fn set_block_info(&self, info: BlockInfo);
+
+    /// Event listener for when the pool needs to be updated.
+    ///
+    /// Implementers need to update the pool accordingly:
+    ///
+    /// ## Fee changes
+    ///
+    /// The [`CanonicalStateUpdate`] includes the base and blob fee of the pending block, which
+    /// affects the dynamic fee requirement of pending transactions in the pool.
+    ///
+    /// ## EIP-4844 Blob transactions
+    ///
+    /// Mined blob transactions need to be removed from the pool, but from the pool only. The blob
+    /// sidecar must not be removed from the blob store. Only after a blob transaction is
+    /// finalized, its sidecar is removed from the blob store. This ensures that in case of a reorg,
+    /// the sidecar is still available.
+    fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_, Self::Block>);
+
+    /// Updates the accounts in the pool
+    fn update_accounts(&self, accounts: Vec<ChangedAccount>);
+
+    /// Deletes the blob sidecar for the given transaction from the blob store
+    fn delete_blob(&self, tx: B256);
+
+    /// Deletes multiple blob sidecars from the blob store
+    fn delete_blobs(&self, txs: Vec<B256>);
+
+    /// Maintenance function to cleanup blobs that are no longer needed.
+    fn cleanup_blobs(&self);
+}
+
+/// A Helper type that bundles all transactions in the pool.
+#[derive(Debug, Clone)]
+pub struct AllPoolTransactions<T: PoolTransaction> {
+    /// Transactions that are ready for inclusion in the next block.
+    pub pending: Vec<Arc<ValidPoolTransaction<T>>>,
+    /// Transactions that are ready for inclusion in _future_ blocks, but are currently parked,
+    /// because they depend on other transactions that are not yet included in the pool (nonce gap)
+    /// or otherwise blocked.
+    pub queued: Vec<Arc<ValidPoolTransaction<T>>>,
+}
+
+// === impl AllPoolTransactions ===
+
+impl<T: PoolTransaction> AllPoolTransactions<T> {
+    /// Returns the combined number of all transactions.
+    pub const fn count(&self) -> usize {
+        self.pending.len() + self.queued.len()
+    }
+
+    /// Returns an iterator over all pending [`Recovered`] transactions.
+    pub fn pending_recovered(&self) -> impl Iterator<Item = Recovered<T::Consensus>> + '_ {
+        self.pending.iter().map(|tx| tx.to_consensus())
+    }
+
+    /// Returns an iterator over all queued [`Recovered`] transactions.
+    pub fn queued_recovered(&self) -> impl Iterator<Item = Recovered<T::Consensus>> + '_ {
+        self.queued.iter().map(|tx| tx.to_consensus())
+    }
+
+    /// Returns an iterator over all transactions, both pending and queued.
+    pub fn all(&self) -> impl Iterator<Item = Recovered<T::Consensus>> + '_ {
+        self.pending.iter().chain(self.queued.iter()).map(|tx| tx.to_consensus())
+    }
+}
+
+impl<T: PoolTransaction> Default for AllPoolTransactions<T> {
+    fn default() -> Self {
+        Self { pending: Default::default(), queued: Default::default() }
+    }
+}
+
+impl<T: PoolTransaction> IntoIterator for AllPoolTransactions<T> {
+    type Item = Arc<ValidPoolTransaction<T>>;
+    type IntoIter = std::iter::Chain<
+        std::vec::IntoIter<Arc<ValidPoolTransaction<T>>>,
+        std::vec::IntoIter<Arc<ValidPoolTransaction<T>>>,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pending.into_iter().chain(self.queued)
+    }
+}
+
+/// Represents transactions that were propagated over the network.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct PropagatedTransactions(pub HashMap<TxHash, Vec<PropagateKind>>);
+
+impl PropagatedTransactions {
+    /// Records a propagation of a transaction to a peer.
+    pub fn record(&mut self, hash: TxHash, kind: PropagateKind) {
+        self.0.entry(hash).or_default().push(kind);
+    }
+
+    /// Returns the number of distinct transactions that were propagated.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if no transactions were propagated.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the propagation info for a specific transaction.
+    pub fn get(&self, hash: &TxHash) -> Option<&[PropagateKind]> {
+        self.0.get(hash).map(Vec::as_slice)
+    }
+}
+
+impl IntoIterator for PropagatedTransactions {
+    type Item = (TxHash, Vec<PropagateKind>);
+    type IntoIter = std::collections::hash_map::IntoIter<TxHash, Vec<PropagateKind>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Represents how a transaction was propagated over the network.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PropagateKind {
+    /// The full transaction object was sent to the peer.
+    ///
+    /// This is equivalent to the `Transaction` message
+    Full(PeerId),
+    /// Only the Hash was propagated to the peer.
+    Hash(PeerId),
+}
+
+// === impl PropagateKind ===
+
+impl PropagateKind {
+    /// Returns the peer the transaction was sent to
+    pub const fn peer(&self) -> &PeerId {
+        match self {
+            Self::Full(peer) | Self::Hash(peer) => peer,
+        }
+    }
+
+    /// Returns true if the transaction was sent as a full transaction
+    pub const fn is_full(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    /// Returns true if the transaction was sent as a hash
+    pub const fn is_hash(&self) -> bool {
+        matches!(self, Self::Hash(_))
+    }
+}
+
+impl From<PropagateKind> for PeerId {
+    fn from(value: PropagateKind) -> Self {
+        match value {
+            PropagateKind::Full(peer) | PropagateKind::Hash(peer) => peer,
+        }
+    }
+}
+
+/// This type represents a new blob sidecar that has been stored in the transaction pool's
+/// blobstore; it includes the `TransactionHash` of the blob transaction along with the assoc.
+/// sidecar (blobs, commitments, proofs)
+#[derive(Debug, Clone)]
+pub struct NewBlobSidecar {
+    /// hash of the EIP-4844 transaction.
+    pub tx_hash: TxHash,
+    /// the blob transaction sidecar.
+    pub sidecar: Arc<BlobTransactionSidecarVariant>,
+}
+
+/// Where the transaction originates from.
+///
+/// Depending on where the transaction was picked up, it affects how the transaction is handled
+/// internally, e.g. limits for simultaneous transaction of one sender.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
+pub enum TransactionOrigin {
+    /// Transaction is coming from a local source.
+    #[default]
+    Local,
+    /// Transaction has been received externally.
+    ///
+    /// This is usually considered an "untrusted" source, for example received from another in the
+    /// network.
+    External,
+    /// Transaction is originated locally and is intended to remain private.
+    ///
+    /// This type of transaction should not be propagated to the network. It's meant for
+    /// private usage within the local node only.
+    Private,
+}
+
+// === impl TransactionOrigin ===
+
+impl TransactionOrigin {
+    /// Whether the transaction originates from a local source.
+    pub const fn is_local(&self) -> bool {
+        matches!(self, Self::Local)
+    }
+
+    /// Whether the transaction originates from an external source.
+    pub const fn is_external(&self) -> bool {
+        matches!(self, Self::External)
+    }
+    /// Whether the transaction originates from a private source.
+    pub const fn is_private(&self) -> bool {
+        matches!(self, Self::Private)
+    }
+}
+
+/// Represents the kind of update to the canonical state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolUpdateKind {
+    /// The update was due to a block commit.
+    Commit,
+    /// The update was due to a reorganization.
+    Reorg,
+}
+
+/// Represents changes after a new canonical block or range of canonical blocks was added to the
+/// chain.
+///
+/// It is expected that this is only used if the added blocks are canonical to the pool's last known
+/// block hash. In other words, the first added block of the range must be the child of the last
+/// known block hash.
+///
+/// This is used to update the pool state accordingly.
+#[derive(Clone, Debug)]
+pub struct CanonicalStateUpdate<'a, B: Block> {
+    /// Hash of the tip block.
+    pub new_tip: &'a SealedBlock<B>,
+    /// EIP-1559 Base fee of the _next_ (pending) block
+    ///
+    /// The base fee of a block depends on the utilization of the last block and its base fee.
+    pub pending_block_base_fee: u64,
+    /// EIP-4844 blob fee of the _next_ (pending) block
+    ///
+    /// Only after Cancun
+    pub pending_block_blob_fee: Option<u128>,
+    /// A set of changed accounts across a range of blocks.
+    pub changed_accounts: Vec<ChangedAccount>,
+    /// All mined transactions in the block range.
+    pub mined_transactions: Vec<B256>,
+    /// The kind of update to the canonical state.
+    pub update_kind: PoolUpdateKind,
+}
+
+impl<B> CanonicalStateUpdate<'_, B>
+where
+    B: Block,
+{
+    /// Returns the number of the tip block.
+    pub fn number(&self) -> u64 {
+        self.new_tip.number()
+    }
+
+    /// Returns the hash of the tip block.
+    pub fn hash(&self) -> B256 {
+        self.new_tip.hash()
+    }
+
+    /// Timestamp of the latest chain update
+    pub fn timestamp(&self) -> u64 {
+        self.new_tip.timestamp()
+    }
+
+    /// Returns the block info for the tip block.
+    pub fn block_info(&self) -> BlockInfo {
+        BlockInfo {
+            block_gas_limit: self.new_tip.gas_limit(),
+            last_seen_block_hash: self.hash(),
+            last_seen_block_number: self.number(),
+            pending_basefee: self.pending_block_base_fee,
+            pending_blob_fee: self.pending_block_blob_fee,
+        }
+    }
+}
+
+impl<B> fmt::Display for CanonicalStateUpdate<'_, B>
+where
+    B: Block,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CanonicalStateUpdate")
+            .field("hash", &self.hash())
+            .field("number", &self.number())
+            .field("pending_block_base_fee", &self.pending_block_base_fee)
+            .field("pending_block_blob_fee", &self.pending_block_blob_fee)
+            .field("changed_accounts", &self.changed_accounts.len())
+            .field("mined_transactions", &self.mined_transactions.len())
+            .finish()
+    }
+}
+
+/// Alias to restrict the [`BestTransactions`] items to the pool's transaction type.
+pub type BestTransactionsFor<Pool> = Box<
+    dyn BestTransactions<Item = Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>,
+>;
+
+/// An `Iterator` that only returns transactions that are ready to be executed.
+///
+/// This makes no assumptions about the order of the transactions, but expects that _all_
+/// transactions are valid (no nonce gaps.) for the tracked state of the pool.
+///
+/// Note: this iterator will always return the best transaction that it currently knows.
+/// There is no guarantee transactions will be returned sequentially in decreasing
+/// priority order.
+pub trait BestTransactions: Iterator + Send {
+    /// Mark the transaction as invalid.
+    ///
+    /// Implementers must ensure all subsequent transaction _don't_ depend on this transaction.
+    /// In other words, this must remove the given transaction _and_ drain all transaction that
+    /// depend on it.
+    fn mark_invalid(&mut self, transaction: &Self::Item, kind: &InvalidPoolTransactionError);
+
+    /// An iterator may be able to receive additional pending transactions that weren't present it
+    /// the pool when it was created.
+    ///
+    /// This ensures that iterator will return the best transaction that it currently knows and not
+    /// listen to pool updates.
+    fn no_updates(&mut self);
+
+    /// Convenience function for [`Self::no_updates`] that returns the iterator again.
+    fn without_updates(mut self) -> Self
+    where
+        Self: Sized,
+    {
+        self.no_updates();
+        self
+    }
+
+    /// Skip all blob transactions.
+    ///
+    /// There's only limited blob space available in a block, once exhausted, EIP-4844 transactions
+    /// can no longer be included.
+    ///
+    /// If called then the iterator will no longer yield blob transactions.
+    ///
+    /// Note: this will also exclude any transactions that depend on blob transactions.
+    fn skip_blobs(&mut self) {
+        self.set_skip_blobs(true);
+    }
+
+    /// Controls whether the iterator skips blob transactions or not.
+    ///
+    /// If set to true, no blob transactions will be returned.
+    fn set_skip_blobs(&mut self, skip_blobs: bool);
+
+    /// Convenience function for [`Self::skip_blobs`] that returns the iterator again.
+    fn without_blobs(mut self) -> Self
+    where
+        Self: Sized,
+    {
+        self.skip_blobs();
+        self
+    }
+
+    /// Creates an iterator which uses a closure to determine whether a transaction should be
+    /// returned by the iterator.
+    ///
+    /// All items the closure returns false for are marked as invalid via [`Self::mark_invalid`] and
+    /// descendant transactions will be skipped.
+    fn filter_transactions<P>(self, predicate: P) -> BestTransactionFilter<Self, P>
+    where
+        P: FnMut(&Self::Item) -> bool,
+        Self: Sized,
+    {
+        BestTransactionFilter::new(self, predicate)
+    }
+}
+
+impl<T> BestTransactions for Box<T>
+where
+    T: BestTransactions + ?Sized,
+{
+    fn mark_invalid(&mut self, transaction: &Self::Item, kind: &InvalidPoolTransactionError) {
+        (**self).mark_invalid(transaction, kind)
+    }
+
+    fn no_updates(&mut self) {
+        (**self).no_updates();
+    }
+
+    fn skip_blobs(&mut self) {
+        (**self).skip_blobs();
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        (**self).set_skip_blobs(skip_blobs);
+    }
+}
+
+/// A no-op implementation that yields no transactions.
+impl<T> BestTransactions for std::iter::Empty<T> {
+    fn mark_invalid(&mut self, _tx: &T, _kind: &InvalidPoolTransactionError) {}
+
+    fn no_updates(&mut self) {}
+
+    fn skip_blobs(&mut self) {}
+
+    fn set_skip_blobs(&mut self, _skip_blobs: bool) {}
+}
+
+/// A filter that allows to check if a transaction satisfies a set of conditions
+pub trait TransactionFilter {
+    /// The type of the transaction to check.
+    type Transaction;
+
+    /// Returns true if the transaction satisfies the conditions.
+    fn is_valid(&self, transaction: &Self::Transaction) -> bool;
+}
+
+/// A no-op implementation of [`TransactionFilter`] which
+/// marks all transactions as valid.
+#[derive(Debug, Clone)]
+pub struct NoopTransactionFilter<T>(std::marker::PhantomData<T>);
+
+// We can't derive Default because this forces T to be
+// Default as well, which isn't necessary.
+impl<T> Default for NoopTransactionFilter<T> {
+    fn default() -> Self {
+        Self(std::marker::PhantomData)
+    }
+}
+
+impl<T> TransactionFilter for NoopTransactionFilter<T> {
+    type Transaction = T;
+
+    fn is_valid(&self, _transaction: &Self::Transaction) -> bool {
+        true
+    }
+}
+
+/// A Helper type that bundles the best transactions attributes together.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct BestTransactionsAttributes {
+    /// The base fee attribute for best transactions.
+    pub basefee: u64,
+    /// The blob fee attribute for best transactions.
+    pub blob_fee: Option<u64>,
+}
+
+// === impl BestTransactionsAttributes ===
+
+impl BestTransactionsAttributes {
+    /// Creates a new `BestTransactionsAttributes` with the given basefee and blob fee.
+    pub const fn new(basefee: u64, blob_fee: Option<u64>) -> Self {
+        Self { basefee, blob_fee }
+    }
+
+    /// Creates a new `BestTransactionsAttributes` with the given basefee.
+    pub const fn base_fee(basefee: u64) -> Self {
+        Self::new(basefee, None)
+    }
+
+    /// Sets the given blob fee.
+    pub const fn with_blob_fee(mut self, blob_fee: u64) -> Self {
+        self.blob_fee = Some(blob_fee);
+        self
+    }
+}
+
+/// Trait for transaction types stored in the transaction pool.
+///
+/// This trait represents the actual transaction object stored in the mempool, which includes not
+/// only the transaction data itself but also additional metadata needed for efficient pool
+/// operations. Implementations typically cache values that are frequently accessed during
+/// transaction ordering, validation, and eviction.
+///
+/// ## Key Responsibilities
+///
+/// 1. **Metadata Caching**: Store computed values like address, cost and encoded size
+/// 2. **Representation Conversion**: Handle conversions between consensus and pooled
+///    representations
+/// 3. **Validation Support**: Provide methods for pool-specific validation rules
+///
+/// ## Cached Metadata
+///
+/// Implementations should cache frequently accessed values to avoid recomputation:
+/// - **Address**: Recovered sender address of the transaction
+/// - **Cost**: Max amount spendable (gas × price + value + blob costs)
+/// - **Size**: RLP encoded length for mempool size limits
+///
+/// See [`EthPooledTransaction`] for a reference implementation.
+///
+/// ## Transaction Representations
+///
+/// This trait abstracts over the different representations a transaction can have:
+///
+/// 1. **Consensus representation** (`Consensus` associated type): The canonical form included in
+///    blocks
+///    - Compact representation without networking metadata
+///    - For EIP-4844: includes only blob hashes, not the actual blobs
+///    - Used for block execution and state transitions
+///
+/// 2. **Pooled representation** (`Pooled` associated type): The form used for network propagation
+///    - May include additional data for validation
+///    - For EIP-4844: includes full blob sidecars (blobs, commitments, proofs)
+///    - Used for mempool validation and p2p gossiping
+///
+/// ## Why Two Representations?
+///
+/// This distinction is necessary because:
+///
+/// - **EIP-4844 blob transactions**: Require large blob sidecars for validation that would bloat
+///   blocks if included. Only blob hashes are stored on-chain.
+///
+/// - **Network efficiency**: Blob transactions are not broadcast to all peers automatically but
+///   must be explicitly requested to reduce bandwidth usage.
+///
+/// - **Special transactions**: Some transactions (like OP deposit transactions) exist only in
+///   consensus format and are never in the mempool.
+///
+/// ## Conversion Rules
+///
+/// - `Consensus` → `Pooled`: May fail for transactions that cannot be pooled (e.g., OP deposit
+///   transactions, blob transactions without sidecars)
+/// - `Pooled` → `Consensus`: Always succeeds (pooled is a superset)
+pub trait PoolTransaction:
+    alloy_consensus::Transaction + InMemorySize + Debug + Send + Sync + Clone
+{
+    /// Associated error type for the `try_from_consensus` method.
+    type TryFromConsensusError: fmt::Display;
+
+    /// Associated type representing the raw consensus variant of the transaction.
+    type Consensus: SignedTransaction + From<Self::Pooled>;
+
+    /// Associated type representing the recovered pooled variant of the transaction.
+    type Pooled: TryFrom<Self::Consensus, Error = Self::TryFromConsensusError> + SignedTransaction;
+
+    /// Define a method to convert from the `Consensus` type to `Self`
+    ///
+    /// This conversion may fail for transactions that are valid for inclusion in blocks
+    /// but cannot exist in the transaction pool. Examples include:
+    ///
+    /// - **OP Deposit transactions**: These are special system transactions that are directly
+    ///   included in blocks by the sequencer/validator and never enter the mempool
+    /// - **Blob transactions without sidecars**: After being included in a block, the sidecar data
+    ///   is pruned, making the consensus transaction unpoolable
+    fn try_from_consensus(
+        tx: Recovered<Self::Consensus>,
+    ) -> Result<Self, Self::TryFromConsensusError> {
+        let (tx, signer) = tx.into_parts();
+        Ok(Self::from_pooled(Recovered::new_unchecked(tx.try_into()?, signer)))
+    }
+
+    /// Clone the transaction into a consensus variant.
+    ///
+    /// This method is preferred when the [`PoolTransaction`] already wraps the consensus variant.
+    fn clone_into_consensus(&self) -> Recovered<Self::Consensus> {
+        self.clone().into_consensus()
+    }
+
+    /// Returns a reference to the consensus transaction with the recovered sender.
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus>;
+
+    /// Define a method to convert from the `Self` type to `Consensus`
+    fn into_consensus(self) -> Recovered<Self::Consensus>;
+
+    /// Converts the transaction into consensus format while preserving the EIP-2718 encoded bytes.
+    /// This is used to optimize transaction execution by reusing cached encoded bytes instead of
+    /// re-encoding the transaction. The cached bytes are particularly useful in payload building
+    /// where the same transaction may be executed multiple times.
+    fn into_consensus_with2718(self) -> WithEncoded<Recovered<Self::Consensus>> {
+        self.into_consensus().into_encoded()
+    }
+
+    /// Define a method to convert from the `Pooled` type to `Self`
+    fn from_pooled(pooled: Recovered<Self::Pooled>) -> Self;
+
+    /// Tries to convert the `Consensus` type into the `Pooled` type.
+    fn try_into_pooled(self) -> Result<Recovered<Self::Pooled>, Self::TryFromConsensusError> {
+        let consensus = self.into_consensus();
+        let (tx, signer) = consensus.into_parts();
+        Ok(Recovered::new_unchecked(tx.try_into()?, signer))
+    }
+
+    /// Clones the consensus transactions and tries to convert the `Consensus` type into the
+    /// `Pooled` type.
+    fn clone_into_pooled(&self) -> Result<Recovered<Self::Pooled>, Self::TryFromConsensusError> {
+        let consensus = self.clone_into_consensus();
+        let (tx, signer) = consensus.into_parts();
+        Ok(Recovered::new_unchecked(tx.try_into()?, signer))
+    }
+
+    /// Converts the `Pooled` type into the `Consensus` type.
+    fn pooled_into_consensus(tx: Self::Pooled) -> Self::Consensus {
+        tx.into()
+    }
+
+    /// Hash of the transaction.
+    fn hash(&self) -> &TxHash;
+
+    /// The Sender of the transaction.
+    fn sender(&self) -> Address;
+
+    /// Reference to the Sender of the transaction.
+    fn sender_ref(&self) -> &Address;
+
+    /// Returns the cost that this transaction is allowed to consume:
+    ///
+    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
+    /// For legacy transactions: `gas_price * gas_limit + tx_value`.
+    /// For EIP-4844 blob transactions: `max_fee_per_gas * gas_limit + tx_value +
+    /// max_blob_fee_per_gas * blob_gas_used`.
+    fn cost(&self) -> &U256;
+
+    /// Extra balance beyond [`PoolTransaction::cost`] the sender must have (e.g. OP L1 data fee +
+    /// operator fee). Defaults to zero. `[MANTLE PATCH]`
+    fn extra_balance_cost(&self) -> U256 {
+        U256::ZERO
+    }
+
+    /// Returns the length of the rlp encoded transaction object
+    ///
+    /// Note: Implementations should cache this value.
+    fn encoded_length(&self) -> usize;
+
+    /// Ensures that the transaction's code size does not exceed the provided `max_init_code_size`.
+    ///
+    /// This is specifically relevant for contract creation transactions ([`TxKind::Create`]),
+    /// where the input data contains the initialization code. If the input code size exceeds
+    /// the configured limit, an [`InvalidPoolTransactionError::ExceedsMaxInitCodeSize`] error is
+    /// returned.
+    fn ensure_max_init_code_size(
+        &self,
+        max_init_code_size: usize,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        let input_len = self.input().len();
+        if self.is_create() && input_len > max_init_code_size {
+            Err(InvalidPoolTransactionError::ExceedsMaxInitCodeSize(input_len, max_init_code_size))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Allows to communicate to the pool that the transaction doesn't require a nonce check.
+    fn requires_nonce_check(&self) -> bool {
+        true
+    }
+}
+
+/// Super trait for transactions that can be converted to and from Eth transactions intended for the
+/// ethereum style pool.
+///
+/// This extends the [`PoolTransaction`] trait with additional methods that are specific to the
+/// Ethereum pool.
+pub trait EthPoolTransaction: PoolTransaction {
+    /// Extracts the blob sidecar from the transaction.
+    fn take_blob(&mut self) -> EthBlobTransactionSidecar;
+
+    /// A specialization for the EIP-4844 transaction type.
+    /// Tries to reattach the blob sidecar to the transaction.
+    ///
+    /// This returns an option, but callers should ensure that the transaction is an EIP-4844
+    /// transaction: [`Typed2718::is_eip4844`].
+    fn try_into_pooled_eip4844(
+        self,
+        sidecar: Arc<BlobTransactionSidecarVariant>,
+    ) -> Option<Recovered<Self::Pooled>>;
+
+    /// Tries to convert the `Consensus` type with a blob sidecar into the `Pooled` type.
+    ///
+    /// Returns `None` if passed transaction is not a blob transaction.
+    fn try_from_eip4844(
+        tx: Recovered<Self::Consensus>,
+        sidecar: BlobTransactionSidecarVariant,
+    ) -> Option<Self>;
+
+    /// Validates the blob sidecar of the transaction with the given settings.
+    fn validate_blob(
+        &self,
+        blob: &BlobTransactionSidecarVariant,
+        settings: &KzgSettings,
+    ) -> Result<(), BlobTransactionValidationError>;
+}
+
+/// The default [`PoolTransaction`] for the [Pool](crate::Pool) for Ethereum.
+///
+/// This type wraps a consensus transaction with additional cached data that's
+/// frequently accessed by the pool for transaction ordering and validation:
+///
+/// - `cost`: Pre-calculated max cost (gas * price + value + blob costs)
+/// - `encoded_length`: Cached RLP encoding length for size limits
+/// - `blob_sidecar`: Blob data state (None/Missing/Present)
+///
+/// This avoids recalculating these values repeatedly during pool operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EthPooledTransaction<T = TransactionSigned> {
+    /// `EcRecovered` transaction, the consensus format.
+    pub transaction: Recovered<T>,
+
+    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
+    /// For legacy transactions: `gas_price * gas_limit + tx_value`.
+    /// For EIP-4844 blob transactions: `max_fee_per_gas * gas_limit + tx_value +
+    /// max_blob_fee_per_gas * blob_gas_used`.
+    pub cost: U256,
+
+    /// This is the RLP length of the transaction, computed when the transaction is added to the
+    /// pool.
+    pub encoded_length: usize,
+
+    /// The blob side car for this transaction
+    pub blob_sidecar: EthBlobTransactionSidecar,
+}
+
+impl<T: SignedTransaction> EthPooledTransaction<T> {
+    /// Create new instance of [Self].
+    ///
+    /// Caution: In case of blob transactions, this does marks the blob sidecar as
+    /// [`EthBlobTransactionSidecar::Missing`]
+    pub fn new(transaction: Recovered<T>, encoded_length: usize) -> Self {
+        let mut blob_sidecar = EthBlobTransactionSidecar::None;
+
+        let gas_cost = U256::from(transaction.max_fee_per_gas())
+            .saturating_mul(U256::from(transaction.gas_limit()));
+
+        let mut cost = gas_cost.saturating_add(transaction.value());
+
+        if let (Some(blob_gas_used), Some(max_fee_per_blob_gas)) =
+            (transaction.blob_gas_used(), transaction.max_fee_per_blob_gas())
+        {
+            // Add max blob cost using saturating math to avoid overflow
+            cost = cost.saturating_add(U256::from(
+                max_fee_per_blob_gas.saturating_mul(blob_gas_used as u128),
+            ));
+
+            // because the blob sidecar is not included in this transaction variant, mark it as
+            // missing
+            blob_sidecar = EthBlobTransactionSidecar::Missing;
+        }
+
+        Self { transaction, cost, encoded_length, blob_sidecar }
+    }
+
+    /// Return the reference to the underlying transaction.
+    pub const fn transaction(&self) -> &Recovered<T> {
+        &self.transaction
+    }
+}
+
+impl PoolTransaction for EthPooledTransaction {
+    type TryFromConsensusError = ValueError<TransactionSigned>;
+
+    type Consensus = TransactionSigned;
+
+    type Pooled = PooledTransactionVariant;
+
+    fn clone_into_consensus(&self) -> Recovered<Self::Consensus> {
+        self.transaction().clone()
+    }
+
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+        Recovered::new_unchecked(&*self.transaction, self.transaction.signer())
+    }
+
+    fn into_consensus(self) -> Recovered<Self::Consensus> {
+        self.transaction
+    }
+
+    fn from_pooled(tx: Recovered<Self::Pooled>) -> Self {
+        let encoded_length = tx.encode_2718_len();
+        let (tx, signer) = tx.into_parts();
+        match tx {
+            PooledTransactionVariant::Eip4844(tx) => {
+                // include the blob sidecar
+                let (tx, sig, hash) = tx.into_parts();
+                let (tx, blob) = tx.into_parts();
+                let tx = Signed::new_unchecked(tx, sig, hash);
+                let tx = TransactionSigned::from(tx);
+                let tx = Recovered::new_unchecked(tx, signer);
+                let mut pooled = Self::new(tx, encoded_length);
+                pooled.blob_sidecar = EthBlobTransactionSidecar::Present(blob);
+                pooled
+            }
+            tx => {
+                // no blob sidecar
+                let tx = Recovered::new_unchecked(tx.into(), signer);
+                Self::new(tx, encoded_length)
+            }
+        }
+    }
+
+    /// Returns hash of the transaction.
+    fn hash(&self) -> &TxHash {
+        self.transaction.tx_hash()
+    }
+
+    /// Returns the Sender of the transaction.
+    fn sender(&self) -> Address {
+        self.transaction.signer()
+    }
+
+    /// Returns a reference to the Sender of the transaction.
+    fn sender_ref(&self) -> &Address {
+        self.transaction.signer_ref()
+    }
+
+    /// Returns the cost that this transaction is allowed to consume:
+    ///
+    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
+    /// For legacy transactions: `gas_price * gas_limit + tx_value`.
+    /// For EIP-4844 blob transactions: `max_fee_per_gas * gas_limit + tx_value +
+    /// max_blob_fee_per_gas * blob_gas_used`.
+    fn cost(&self) -> &U256 {
+        &self.cost
+    }
+
+    /// Returns the length of the rlp encoded object
+    fn encoded_length(&self) -> usize {
+        self.encoded_length
+    }
+}
+
+impl<T: Typed2718> Typed2718 for EthPooledTransaction<T> {
+    fn ty(&self) -> u8 {
+        self.transaction.ty()
+    }
+}
+
+impl<T: InMemorySize> InMemorySize for EthPooledTransaction<T> {
+    fn size(&self) -> usize {
+        self.transaction.size()
+    }
+}
+
+impl<T: alloy_consensus::Transaction> alloy_consensus::Transaction for EthPooledTransaction<T> {
+    fn chain_id(&self) -> Option<alloy_primitives::ChainId> {
+        self.transaction.chain_id()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.transaction.nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.transaction.gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        self.transaction.gas_price()
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.transaction.max_fee_per_gas()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.transaction.max_priority_fee_per_gas()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.transaction.max_fee_per_blob_gas()
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.transaction.priority_fee_or_price()
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.transaction.effective_gas_price(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.transaction.is_dynamic_fee()
+    }
+
+    fn kind(&self) -> TxKind {
+        self.transaction.kind()
+    }
+
+    fn is_create(&self) -> bool {
+        self.transaction.is_create()
+    }
+
+    fn value(&self) -> U256 {
+        self.transaction.value()
+    }
+
+    fn input(&self) -> &Bytes {
+        self.transaction.input()
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        self.transaction.access_list()
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        self.transaction.blob_versioned_hashes()
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.transaction.authorization_list()
+    }
+}
+
+impl EthPoolTransaction for EthPooledTransaction {
+    fn take_blob(&mut self) -> EthBlobTransactionSidecar {
+        if self.is_eip4844() {
+            std::mem::replace(&mut self.blob_sidecar, EthBlobTransactionSidecar::Missing)
+        } else {
+            EthBlobTransactionSidecar::None
+        }
+    }
+
+    fn try_into_pooled_eip4844(
+        self,
+        sidecar: Arc<BlobTransactionSidecarVariant>,
+    ) -> Option<Recovered<Self::Pooled>> {
+        let (signed_transaction, signer) = self.into_consensus().into_parts();
+        let pooled_transaction =
+            signed_transaction.try_into_pooled_eip4844(Arc::unwrap_or_clone(sidecar)).ok()?;
+
+        Some(Recovered::new_unchecked(pooled_transaction, signer))
+    }
+
+    fn try_from_eip4844(
+        tx: Recovered<Self::Consensus>,
+        sidecar: BlobTransactionSidecarVariant,
+    ) -> Option<Self> {
+        let (tx, signer) = tx.into_parts();
+        tx.try_into_pooled_eip4844(sidecar)
+            .ok()
+            .map(|tx| tx.with_signer(signer))
+            .map(Self::from_pooled)
+    }
+
+    fn validate_blob(
+        &self,
+        sidecar: &BlobTransactionSidecarVariant,
+        settings: &KzgSettings,
+    ) -> Result<(), BlobTransactionValidationError> {
+        match self.transaction.inner().as_eip4844() {
+            Some(tx) => tx.tx().validate_blob(sidecar, settings),
+            _ => Err(BlobTransactionValidationError::NotBlobTransaction(self.ty())),
+        }
+    }
+}
+
+/// Represents the blob sidecar of the [`EthPooledTransaction`].
+///
+/// EIP-4844 blob transactions require additional data (blobs, commitments, proofs)
+/// for validation that is not included in the consensus format. This enum tracks
+/// the sidecar state throughout the transaction's lifecycle in the pool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EthBlobTransactionSidecar {
+    /// This transaction does not have a blob sidecar
+    /// (applies to all non-EIP-4844 transaction types)
+    None,
+    /// This transaction has a blob sidecar (EIP-4844) but it is missing.
+    ///
+    /// This can happen when:
+    /// - The sidecar was extracted after the transaction was added to the pool
+    /// - The transaction was re-injected after a reorg without its sidecar
+    /// - The transaction was recovered from the consensus format (e.g., from a block)
+    Missing,
+    /// The EIP-4844 transaction was received from the network with its complete sidecar.
+    ///
+    /// This sidecar contains:
+    /// - The actual blob data (large data per blob)
+    /// - KZG commitments for each blob
+    /// - KZG proofs for validation
+    ///
+    /// The sidecar is required for validating the transaction but is not included
+    /// in blocks (only the blob hashes are included in the consensus format).
+    Present(BlobTransactionSidecarVariant),
+}
+
+impl EthBlobTransactionSidecar {
+    /// Returns the blob sidecar if it is present
+    pub const fn maybe_sidecar(&self) -> Option<&BlobTransactionSidecarVariant> {
+        match self {
+            Self::Present(sidecar) => Some(sidecar),
+            _ => None,
+        }
+    }
+}
+
+/// Represents the current status of the pool.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PoolSize {
+    /// Number of transactions in the _pending_ sub-pool.
+    pub pending: usize,
+    /// Reported size of transactions in the _pending_ sub-pool.
+    pub pending_size: usize,
+    /// Number of transactions in the _blob_ pool.
+    pub blob: usize,
+    /// Reported size of transactions in the _blob_ pool.
+    pub blob_size: usize,
+    /// Number of transactions in the _basefee_ pool.
+    pub basefee: usize,
+    /// Reported size of transactions in the _basefee_ sub-pool.
+    pub basefee_size: usize,
+    /// Number of transactions in the _queued_ sub-pool.
+    pub queued: usize,
+    /// Reported size of transactions in the _queued_ sub-pool.
+    pub queued_size: usize,
+    /// Number of all transactions of all sub-pools
+    ///
+    /// Note: this is the sum of ```pending + basefee + queued + blob```
+    pub total: usize,
+}
+
+// === impl PoolSize ===
+
+impl PoolSize {
+    /// Asserts that the invariants of the pool size are met.
+    #[cfg(test)]
+    pub(crate) fn assert_invariants(&self) {
+        assert_eq!(self.total, self.pending + self.basefee + self.queued + self.blob);
+    }
+}
+
+/// Represents the current status of the pool.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct BlockInfo {
+    /// Hash for the currently tracked block.
+    pub last_seen_block_hash: B256,
+    /// Currently tracked block.
+    pub last_seen_block_number: u64,
+    /// Current block gas limit for the latest block.
+    pub block_gas_limit: u64,
+    /// Currently enforced base fee: the threshold for the basefee sub-pool.
+    ///
+    /// Note: this is the derived base fee of the _next_ block that builds on the block the pool is
+    /// currently tracking.
+    pub pending_basefee: u64,
+    /// Currently enforced blob fee: the threshold for eip-4844 blob transactions.
+    ///
+    /// Note: this is the derived blob fee of the _next_ block that builds on the block the pool is
+    /// currently tracking
+    pub pending_blob_fee: Option<u128>,
+}
+
+/// The limit to enforce for [`TransactionPool::get_pooled_transaction_elements`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GetPooledTransactionLimit {
+    /// No limit, return all transactions.
+    None,
+    /// Enforce a size limit on the returned transactions, for example 2MB
+    ResponseSizeSoftLimit(usize),
+}
+
+impl GetPooledTransactionLimit {
+    /// Returns true if the given size exceeds the limit.
+    #[inline]
+    pub const fn exceeds(&self, size: usize) -> bool {
+        match self {
+            Self::None => false,
+            Self::ResponseSizeSoftLimit(limit) => size > *limit,
+        }
+    }
+}
+
+/// A Stream that yields full transactions the subpool
+#[must_use = "streams do nothing unless polled"]
+#[derive(Debug)]
+pub struct NewSubpoolTransactionStream<Tx: PoolTransaction> {
+    st: Receiver<NewTransactionEvent<Tx>>,
+    subpool: SubPool,
+}
+
+// === impl NewSubpoolTransactionStream ===
+
+impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
+    /// Create a new stream that yields full transactions from the subpool
+    pub const fn new(st: Receiver<NewTransactionEvent<Tx>>, subpool: SubPool) -> Self {
+        Self { st, subpool }
+    }
+
+    /// Tries to receive the next value for this stream.
+    pub fn try_recv(
+        &mut self,
+    ) -> Result<NewTransactionEvent<Tx>, tokio::sync::mpsc::error::TryRecvError> {
+        loop {
+            let event = self.st.try_recv()?;
+            if event.subpool == self.subpool {
+                return Ok(event)
+            }
+        }
+    }
+}
+
+impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
+    type Item = NewTransactionEvent<Tx>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match ready!(self.st.poll_recv(cx)) {
+                Some(event) => {
+                    if event.subpool == self.subpool {
+                        return Poll::Ready(Some(event))
+                    }
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{
+        EthereumTxEnvelope, SignableTransaction, TxEip1559, TxEip2930, TxEip4844, TxEip7702,
+        TxEnvelope, TxLegacy,
+    };
+    use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
+    use alloy_primitives::Signature;
+
+    #[test]
+    fn test_pool_size_invariants() {
+        let pool_size = PoolSize {
+            pending: 10,
+            pending_size: 1000,
+            blob: 5,
+            blob_size: 500,
+            basefee: 8,
+            basefee_size: 800,
+            queued: 7,
+            queued_size: 700,
+            total: 10 + 5 + 8 + 7, // Correct total
+        };
+
+        // Call the assert_invariants method to check if the invariants are correct
+        pool_size.assert_invariants();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_pool_size_invariants_fail() {
+        let pool_size = PoolSize {
+            pending: 10,
+            pending_size: 1000,
+            blob: 5,
+            blob_size: 500,
+            basefee: 8,
+            basefee_size: 800,
+            queued: 7,
+            queued_size: 700,
+            total: 10 + 5 + 8, // Incorrect total
+        };
+
+        // Call the assert_invariants method, which should panic
+        pool_size.assert_invariants();
+    }
+
+    #[test]
+    fn test_eth_pooled_transaction_new_legacy() {
+        // Create a legacy transaction with specific parameters
+        let tx = TxEnvelope::Legacy(
+            TxLegacy {
+                gas_price: 10,
+                gas_limit: 1000,
+                value: U256::from(100),
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let transaction = Recovered::new_unchecked(tx, Default::default());
+        let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
+
+        // Check that the pooled transaction is created correctly
+        assert_eq!(pooled_tx.transaction, transaction);
+        assert_eq!(pooled_tx.encoded_length, 200);
+        assert_eq!(pooled_tx.blob_sidecar, EthBlobTransactionSidecar::None);
+        assert_eq!(pooled_tx.cost, U256::from(100) + U256::from(10 * 1000));
+    }
+
+    #[test]
+    fn test_eth_pooled_transaction_new_eip2930() {
+        // Create an EIP-2930 transaction with specific parameters
+        let tx = TxEnvelope::Eip2930(
+            TxEip2930 {
+                gas_price: 10,
+                gas_limit: 1000,
+                value: U256::from(100),
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let transaction = Recovered::new_unchecked(tx, Default::default());
+        let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
+        let expected_cost = U256::from(100) + (U256::from(10 * 1000));
+
+        assert_eq!(pooled_tx.transaction, transaction);
+        assert_eq!(pooled_tx.encoded_length, 200);
+        assert_eq!(pooled_tx.blob_sidecar, EthBlobTransactionSidecar::None);
+        assert_eq!(pooled_tx.cost, expected_cost);
+    }
+
+    #[test]
+    fn test_eth_pooled_transaction_new_eip1559() {
+        // Create an EIP-1559 transaction with specific parameters
+        let tx = TxEnvelope::Eip1559(
+            TxEip1559 {
+                max_fee_per_gas: 10,
+                gas_limit: 1000,
+                value: U256::from(100),
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let transaction = Recovered::new_unchecked(tx, Default::default());
+        let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
+
+        // Check that the pooled transaction is created correctly
+        assert_eq!(pooled_tx.transaction, transaction);
+        assert_eq!(pooled_tx.encoded_length, 200);
+        assert_eq!(pooled_tx.blob_sidecar, EthBlobTransactionSidecar::None);
+        assert_eq!(pooled_tx.cost, U256::from(100) + U256::from(10 * 1000));
+    }
+
+    #[test]
+    fn test_eth_pooled_transaction_new_eip4844() {
+        // Create an EIP-4844 transaction with specific parameters
+        let tx = EthereumTxEnvelope::Eip4844(
+            TxEip4844 {
+                max_fee_per_gas: 10,
+                gas_limit: 1000,
+                value: U256::from(100),
+                max_fee_per_blob_gas: 5,
+                blob_versioned_hashes: vec![B256::default()],
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let transaction = Recovered::new_unchecked(tx, Default::default());
+        let pooled_tx = EthPooledTransaction::new(transaction.clone(), 300);
+
+        // Check that the pooled transaction is created correctly
+        assert_eq!(pooled_tx.transaction, transaction);
+        assert_eq!(pooled_tx.encoded_length, 300);
+        assert_eq!(pooled_tx.blob_sidecar, EthBlobTransactionSidecar::Missing);
+        let expected_cost =
+            U256::from(100) + U256::from(10 * 1000) + U256::from(5 * DATA_GAS_PER_BLOB);
+        assert_eq!(pooled_tx.cost, expected_cost);
+    }
+
+    #[test]
+    fn test_eth_pooled_transaction_new_eip7702() {
+        // Init an EIP-7702 transaction with specific parameters
+        let tx = EthereumTxEnvelope::<TxEip4844>::Eip7702(
+            TxEip7702 {
+                max_fee_per_gas: 10,
+                gas_limit: 1000,
+                value: U256::from(100),
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let transaction = Recovered::new_unchecked(tx, Default::default());
+        let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
+
+        // Check that the pooled transaction is created correctly
+        assert_eq!(pooled_tx.transaction, transaction);
+        assert_eq!(pooled_tx.encoded_length, 200);
+        assert_eq!(pooled_tx.blob_sidecar, EthBlobTransactionSidecar::None);
+        assert_eq!(pooled_tx.cost, U256::from(100) + U256::from(10 * 1000));
+    }
+
+    #[test]
+    fn test_pooled_transaction_limit() {
+        // No limit should never exceed
+        let limit_none = GetPooledTransactionLimit::None;
+        // Any size should return false
+        assert!(!limit_none.exceeds(1000));
+
+        // Size limit of 2MB (2 * 1024 * 1024 bytes)
+        let size_limit_2mb = GetPooledTransactionLimit::ResponseSizeSoftLimit(2 * 1024 * 1024);
+
+        // Test with size below the limit
+        // 1MB is below 2MB, should return false
+        assert!(!size_limit_2mb.exceeds(1024 * 1024));
+
+        // Test with size exactly at the limit
+        // 2MB equals the limit, should return false
+        assert!(!size_limit_2mb.exceeds(2 * 1024 * 1024));
+
+        // Test with size exceeding the limit
+        // 3MB is above the 2MB limit, should return true
+        assert!(size_limit_2mb.exceeds(3 * 1024 * 1024));
+    }
+}

--- a/patches/reth-transaction-pool/src/validate/constants.rs
+++ b/patches/reth-transaction-pool/src/validate/constants.rs
@@ -1,0 +1,12 @@
+/// [`TX_SLOT_BYTE_SIZE`] is used to calculate how many data slots a single transaction
+/// takes up based on its byte size. The slots are used as `DoS` protection, ensuring
+/// that validating a new transaction remains a constant operation (in reality
+/// O(maxslots), where max slots are 4 currently).
+pub const TX_SLOT_BYTE_SIZE: usize = 32 * 1024;
+
+/// [`DEFAULT_MAX_TX_INPUT_BYTES`] is the default maximum size a single transaction can have. This
+/// field has non-trivial consequences: larger transactions are significantly harder and
+/// more expensive to propagate; larger transactions also take more resources
+/// to validate whether they fit into the pool or not. Default is 4 times [`TX_SLOT_BYTE_SIZE`],
+/// which defaults to 32 KiB, so 128 KiB.
+pub const DEFAULT_MAX_TX_INPUT_BYTES: usize = 4 * TX_SLOT_BYTE_SIZE; // 128KB

--- a/patches/reth-transaction-pool/src/validate/eth.rs
+++ b/patches/reth-transaction-pool/src/validate/eth.rs
@@ -1,0 +1,1906 @@
+//! Ethereum transaction validator.
+
+use super::constants::DEFAULT_MAX_TX_INPUT_BYTES;
+use crate::{
+    blobstore::BlobStore,
+    error::{
+        Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
+    },
+    metrics::TxPoolValidationMetrics,
+    traits::TransactionOrigin,
+    validate::ValidTransaction,
+    Address, BlobTransactionSidecarVariant, EthBlobTransactionSidecar, EthPoolTransaction,
+    LocalTransactionConfig, TransactionValidationOutcome, TransactionValidationTaskExecutor,
+    TransactionValidator,
+};
+
+use alloy_consensus::{
+    constants::{
+        EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+        LEGACY_TX_TYPE_ID,
+    },
+    BlockHeader,
+};
+use alloy_eips::{
+    eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M, eip4844::env_settings::EnvKzgSettings,
+    eip7840::BlobParams, BlockId,
+};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_evm::ConfigureEvm;
+use reth_primitives_traits::{
+    transaction::error::InvalidTransactionError, Account, BlockTy, GotExpected, HeaderTy,
+    SealedBlock,
+};
+use reth_storage_api::{AccountInfoReader, BlockReaderIdExt, BytecodeReader, StateProviderFactory};
+use reth_tasks::Runtime;
+use revm::context_interface::Cfg;
+use revm_primitives::U256;
+use std::{
+    fmt,
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, AtomicUsize},
+        Arc,
+    },
+    time::{Instant, SystemTime},
+};
+
+/// Additional stateless validation function signature.
+///
+/// Receives the transaction origin and a reference to the transaction. Returns `Ok(())` if the
+/// transaction passes or `Err` to reject it.
+type StatelessValidationFn<T> =
+    Arc<dyn Fn(TransactionOrigin, &T) -> Result<(), InvalidPoolTransactionError> + Send + Sync>;
+
+/// Additional stateful validation function signature.
+///
+/// Receives the transaction origin, a reference to the transaction, and an account state reader.
+/// Returns `Ok(())` if the transaction passes or `Err` to reject it.
+type StatefulValidationFn<T> = Arc<
+    dyn Fn(TransactionOrigin, &T, &dyn AccountInfoReader) -> Result<(), InvalidPoolTransactionError>
+        + Send
+        + Sync,
+>;
+
+/// A [`TransactionValidator`] implementation that validates ethereum transaction.
+///
+/// It supports all known ethereum transaction types:
+/// - Legacy
+/// - EIP-2718
+/// - EIP-1559
+/// - EIP-4844
+/// - EIP-7702
+///
+/// And enforces additional constraints such as:
+/// - Maximum transaction size
+/// - Maximum gas limit
+///
+/// And adheres to the configured [`LocalTransactionConfig`].
+pub struct EthTransactionValidator<Client, T, Evm> {
+    /// This type fetches account info from the db
+    client: Client,
+    /// Blobstore used for fetching re-injected blob transactions.
+    blob_store: Box<dyn BlobStore>,
+    /// tracks activated forks relevant for transaction validation
+    fork_tracker: ForkTracker,
+    /// Fork indicator whether we are using EIP-2718 type transactions.
+    eip2718: bool,
+    /// Fork indicator whether we are using EIP-1559 type transactions.
+    eip1559: bool,
+    /// Fork indicator whether we are using EIP-4844 blob transactions.
+    eip4844: bool,
+    /// Fork indicator whether we are using EIP-7702 type transactions.
+    eip7702: bool,
+    /// The current max gas limit
+    block_gas_limit: AtomicU64,
+    /// The current tx fee cap limit in wei locally submitted into the pool.
+    tx_fee_cap: Option<u128>,
+    /// Minimum priority fee to enforce for acceptance into the pool.
+    minimum_priority_fee: Option<u128>,
+    /// Stores the setup and parameters needed for validating KZG proofs.
+    kzg_settings: EnvKzgSettings,
+    /// How to handle [`TransactionOrigin::Local`](TransactionOrigin) transactions.
+    local_transactions_config: LocalTransactionConfig,
+    /// Maximum size in bytes a single transaction can have in order to be accepted into the pool.
+    max_tx_input_bytes: usize,
+    /// Maximum gas limit for individual transactions
+    max_tx_gas_limit: Option<u64>,
+    /// Disable balance checks during transaction validation
+    disable_balance_check: bool,
+    /// EVM configuration for fetching execution limits
+    evm_config: Evm,
+    /// Marker for the transaction type
+    _marker: PhantomData<T>,
+    /// Metrics for tsx pool validation
+    validation_metrics: TxPoolValidationMetrics,
+    /// Bitmap of custom transaction types that are allowed.
+    other_tx_types: U256,
+    /// Whether EIP-7594 blob sidecars are accepted.
+    /// When false, EIP-7594 (v1) sidecars are always rejected and EIP-4844 (v0) sidecars
+    /// are always accepted, regardless of Osaka fork activation.
+    eip7594: bool,
+    /// Optional additional stateless validation check applied at the end of
+    /// [`validate_stateless`](Self::validate_stateless).
+    additional_stateless_validation: Option<StatelessValidationFn<T>>,
+    /// Optional additional stateful validation check applied at the end of
+    /// [`validate_stateful`](Self::validate_stateful).
+    additional_stateful_validation: Option<StatefulValidationFn<T>>,
+}
+
+impl<Client, Tx, Evm> fmt::Debug for EthTransactionValidator<Client, Tx, Evm> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EthTransactionValidator")
+            .field("fork_tracker", &self.fork_tracker)
+            .field("eip2718", &self.eip2718)
+            .field("eip1559", &self.eip1559)
+            .field("eip4844", &self.eip4844)
+            .field("eip7702", &self.eip7702)
+            .field("block_gas_limit", &self.block_gas_limit)
+            .field("tx_fee_cap", &self.tx_fee_cap)
+            .field("minimum_priority_fee", &self.minimum_priority_fee)
+            .field("max_tx_input_bytes", &self.max_tx_input_bytes)
+            .field("max_tx_gas_limit", &self.max_tx_gas_limit)
+            .field("disable_balance_check", &self.disable_balance_check)
+            .field("eip7594", &self.eip7594)
+            .field(
+                "additional_stateless_validation",
+                &self.additional_stateless_validation.as_ref().map(|_| "..."),
+            )
+            .field(
+                "additional_stateful_validation",
+                &self.additional_stateful_validation.as_ref().map(|_| "..."),
+            )
+            .finish()
+    }
+}
+
+impl<Client, Tx, Evm> EthTransactionValidator<Client, Tx, Evm> {
+    /// Returns the configured chain spec
+    pub fn chain_spec(&self) -> Arc<Client::ChainSpec>
+    where
+        Client: ChainSpecProvider,
+    {
+        self.client().chain_spec()
+    }
+
+    /// Returns the configured chain id
+    pub fn chain_id(&self) -> u64
+    where
+        Client: ChainSpecProvider,
+    {
+        self.client().chain_spec().chain().id()
+    }
+
+    /// Returns the configured client
+    pub const fn client(&self) -> &Client {
+        &self.client
+    }
+
+    /// Returns the tracks activated forks relevant for transaction validation
+    pub const fn fork_tracker(&self) -> &ForkTracker {
+        &self.fork_tracker
+    }
+
+    /// Returns the EVM config used for transaction validation.
+    pub const fn evm_config(&self) -> &Evm {
+        &self.evm_config
+    }
+
+    /// Returns if there are EIP-2718 type transactions
+    pub const fn eip2718(&self) -> bool {
+        self.eip2718
+    }
+
+    /// Returns if there are EIP-1559 type transactions
+    pub const fn eip1559(&self) -> bool {
+        self.eip1559
+    }
+
+    /// Returns if there are EIP-4844 blob transactions
+    pub const fn eip4844(&self) -> bool {
+        self.eip4844
+    }
+
+    /// Returns if there are EIP-7702 type transactions
+    pub const fn eip7702(&self) -> bool {
+        self.eip7702
+    }
+
+    /// Returns the current tx fee cap limit in wei locally submitted into the pool
+    pub const fn tx_fee_cap(&self) -> &Option<u128> {
+        &self.tx_fee_cap
+    }
+
+    /// Returns the minimum priority fee to enforce for acceptance into the pool
+    pub const fn minimum_priority_fee(&self) -> &Option<u128> {
+        &self.minimum_priority_fee
+    }
+
+    /// Returns the setup and parameters needed for validating KZG proofs.
+    pub const fn kzg_settings(&self) -> &EnvKzgSettings {
+        &self.kzg_settings
+    }
+
+    /// Returns the config to handle [`TransactionOrigin::Local`](TransactionOrigin) transactions..
+    pub const fn local_transactions_config(&self) -> &LocalTransactionConfig {
+        &self.local_transactions_config
+    }
+
+    /// Returns the maximum size in bytes a single transaction can have in order to be accepted into
+    /// the pool.
+    pub const fn max_tx_input_bytes(&self) -> usize {
+        self.max_tx_input_bytes
+    }
+
+    /// Returns whether balance checks are disabled for this validator.
+    pub const fn disable_balance_check(&self) -> bool {
+        self.disable_balance_check
+    }
+
+    /// Sets an additional stateless validation check that is applied at the end of
+    /// [`validate_stateless`](Self::validate_stateless).
+    ///
+    /// The check receives the transaction origin and a reference to the transaction, and
+    /// should return `Ok(())` if the transaction is valid or
+    /// `Err(InvalidPoolTransactionError)` to reject it.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use reth_transaction_pool::{error::InvalidPoolTransactionError, TransactionOrigin};
+    ///
+    /// let mut validator = builder.build(blob_store);
+    /// // Reject external transactions with input data exceeding 1KB
+    /// validator.set_additional_stateless_validation(|origin, tx| {
+    ///     if origin.is_external() && tx.input().len() > 1024 {
+    ///         return Err(InvalidPoolTransactionError::OversizedData {
+    ///             size: tx.input().len(),
+    ///             limit: 1024,
+    ///         });
+    ///     }
+    ///     Ok(())
+    /// });
+    /// ```
+    pub fn set_additional_stateless_validation<F>(&mut self, f: F)
+    where
+        F: Fn(TransactionOrigin, &Tx) -> Result<(), InvalidPoolTransactionError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.additional_stateless_validation = Some(Arc::new(f));
+    }
+
+    /// Sets an additional stateful validation check that is applied at the end of
+    /// [`validate_stateful`](Self::validate_stateful).
+    ///
+    /// The check receives the transaction origin, a reference to the transaction, and the
+    /// account state reader, and should return `Ok(())` if the transaction is valid or
+    /// `Err(InvalidPoolTransactionError)` to reject it.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use reth_transaction_pool::{error::InvalidPoolTransactionError, TransactionOrigin};
+    ///
+    /// let mut validator = builder.build(blob_store);
+    /// // Reject transactions from accounts with zero balance
+    /// validator.set_additional_stateful_validation(|origin, tx, state| {
+    ///     let account = state.basic_account(tx.sender_ref())?.unwrap_or_default();
+    ///     if account.balance.is_zero() {
+    ///         return Err(InvalidPoolTransactionError::Other(Box::new(
+    ///             std::io::Error::new(std::io::ErrorKind::Other, "zero balance"),
+    ///         )));
+    ///     }
+    ///     Ok(())
+    /// });
+    /// ```
+    pub fn set_additional_stateful_validation<F>(&mut self, f: F)
+    where
+        F: Fn(
+                TransactionOrigin,
+                &Tx,
+                &dyn AccountInfoReader,
+            ) -> Result<(), InvalidPoolTransactionError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.additional_stateful_validation = Some(Arc::new(f));
+    }
+}
+
+impl<Client, Tx, Evm> EthTransactionValidator<Client, Tx, Evm>
+where
+    Client: ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks> + StateProviderFactory,
+    Tx: EthPoolTransaction,
+    Evm: ConfigureEvm,
+{
+    /// Returns the current max gas limit
+    pub fn block_gas_limit(&self) -> u64 {
+        self.max_gas_limit()
+    }
+
+    /// Validates a single transaction.
+    ///
+    /// See also [`TransactionValidator::validate_transaction`]
+    pub fn validate_one(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+    ) -> TransactionValidationOutcome<Tx> {
+        self.validate_one_with_provider(origin, transaction, &mut None)
+    }
+
+    /// Validates a single transaction with the provided state provider.
+    ///
+    /// This allows reusing the same provider across multiple transaction validations,
+    /// which can improve performance when validating many transactions.
+    ///
+    /// If `state` is `None`, a new state provider will be created.
+    pub fn validate_one_with_state(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+        state: &mut Option<Box<dyn AccountInfoReader + Send>>,
+    ) -> TransactionValidationOutcome<Tx> {
+        self.validate_one_with_provider(origin, transaction, state)
+    }
+
+    /// Validates a single transaction using an optional cached state provider.
+    /// If no provider is passed, a new one will be created. This allows reusing
+    /// the same provider across multiple txs.
+    fn validate_one_with_provider(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+        maybe_state: &mut Option<Box<dyn AccountInfoReader + Send>>,
+    ) -> TransactionValidationOutcome<Tx> {
+        match self.validate_stateless(origin, &transaction) {
+            Ok(()) => {
+                // stateless checks passed, pass transaction down stateful validation pipeline
+                // If we don't have a state provider yet, fetch the latest state
+                if maybe_state.is_none() {
+                    match self.client.latest() {
+                        Ok(new_state) => {
+                            *maybe_state = Some(Box::new(new_state));
+                        }
+                        Err(err) => {
+                            return TransactionValidationOutcome::Error(
+                                *transaction.hash(),
+                                Box::new(err),
+                            )
+                        }
+                    }
+                }
+
+                let state = maybe_state.as_deref().expect("provider is set");
+
+                self.validate_stateful(origin, transaction, state)
+            }
+            Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
+        }
+    }
+
+    /// Validates a single transaction against the given state provider, performing both
+    /// [stateless](Self::validate_stateless) and [stateful](Self::validate_stateful) checks.
+    pub fn validate_one_with_state_provider(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+        state: impl AccountInfoReader,
+    ) -> TransactionValidationOutcome<Tx> {
+        if let Err(err) = self.validate_stateless(origin, &transaction) {
+            return TransactionValidationOutcome::Invalid(transaction, err);
+        }
+        self.validate_stateful(origin, transaction, state)
+    }
+
+    /// Validates a single transaction without requiring any state access (stateless checks only).
+    ///
+    /// Checks tx type support, nonce bounds, size limits, gas limits, fee constraints, chain ID,
+    /// intrinsic gas, and blob tx pre-checks.
+    pub fn validate_stateless(
+        &self,
+        origin: TransactionOrigin,
+        transaction: &Tx,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        // Checks for tx_type
+        match transaction.ty() {
+            // Accept only legacy transactions until EIP-2718/2930 activates
+            EIP2930_TX_TYPE_ID if !self.eip2718 => {
+                return Err(InvalidTransactionError::Eip2930Disabled.into())
+            }
+            // Reject dynamic fee transactions until EIP-1559 activates.
+            EIP1559_TX_TYPE_ID if !self.eip1559 => {
+                return Err(InvalidTransactionError::Eip1559Disabled.into())
+            }
+            // Reject blob transactions.
+            EIP4844_TX_TYPE_ID if !self.eip4844 => {
+                return Err(InvalidTransactionError::Eip4844Disabled.into())
+            }
+            // Reject EIP-7702 transactions.
+            EIP7702_TX_TYPE_ID if !self.eip7702 => {
+                return Err(InvalidTransactionError::Eip7702Disabled.into())
+            }
+            // Accept known transaction types when their respective fork is active
+            LEGACY_TX_TYPE_ID | EIP2930_TX_TYPE_ID | EIP1559_TX_TYPE_ID | EIP4844_TX_TYPE_ID |
+            EIP7702_TX_TYPE_ID => {}
+
+            ty if !self.other_tx_types.bit(ty as usize) => {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into())
+            }
+
+            _ => {}
+        };
+
+        // Reject transactions with a nonce equal to U64::max according to EIP-2681
+        let tx_nonce = transaction.nonce();
+        if tx_nonce == u64::MAX {
+            return Err(InvalidPoolTransactionError::Eip2681)
+        }
+
+        // Reject transactions over defined size to prevent DOS attacks
+        if transaction.is_eip4844() {
+            // Since blob transactions are pulled instead of pushed, and only the consensus data is
+            // kept in memory while the sidecar is cached on disk, there is no critical limit that
+            // should be enforced. Still, enforcing some cap on the input bytes. blob txs also must
+            // be executable right away when they enter the pool.
+            let tx_input_len = transaction.input().len();
+            if tx_input_len > self.max_tx_input_bytes {
+                return Err(InvalidPoolTransactionError::OversizedData {
+                    size: tx_input_len,
+                    limit: self.max_tx_input_bytes,
+                })
+            }
+        } else {
+            // ensure the size of the non-blob transaction
+            let tx_size = transaction.encoded_length();
+            if tx_size > self.max_tx_input_bytes {
+                return Err(InvalidPoolTransactionError::OversizedData {
+                    size: tx_size,
+                    limit: self.max_tx_input_bytes,
+                })
+            }
+        }
+
+        // Check whether the init code size has been exceeded.
+        if self.fork_tracker.is_shanghai_activated() {
+            let max_initcode_size =
+                self.fork_tracker.max_initcode_size.load(std::sync::atomic::Ordering::Relaxed);
+            transaction.ensure_max_init_code_size(max_initcode_size)?;
+        }
+
+        // Checks for gas limit
+        let transaction_gas_limit = transaction.gas_limit();
+        let block_gas_limit = self.max_gas_limit();
+        if transaction_gas_limit > block_gas_limit {
+            return Err(InvalidPoolTransactionError::ExceedsGasLimit(
+                transaction_gas_limit,
+                block_gas_limit,
+            ))
+        }
+
+        // Check individual transaction gas limit if configured
+        if let Some(max_tx_gas_limit) = self.max_tx_gas_limit &&
+            transaction_gas_limit > max_tx_gas_limit
+        {
+            return Err(InvalidPoolTransactionError::MaxTxGasLimitExceeded(
+                transaction_gas_limit,
+                max_tx_gas_limit,
+            ))
+        }
+
+        // Ensure max_priority_fee_per_gas (if EIP1559) is less than max_fee_per_gas if any.
+        if transaction.max_priority_fee_per_gas() > Some(transaction.max_fee_per_gas()) {
+            return Err(InvalidTransactionError::TipAboveFeeCap.into())
+        }
+
+        // determine whether the transaction should be treated as local
+        let is_local = self.local_transactions_config.is_local(origin, transaction.sender_ref());
+
+        // Ensure max possible transaction fee doesn't exceed configured transaction fee cap.
+        // Only for transactions locally submitted for acceptance into the pool.
+        if is_local {
+            match self.tx_fee_cap {
+                Some(0) | None => {} // Skip if cap is 0 or None
+                Some(tx_fee_cap_wei) => {
+                    let max_tx_fee_wei = transaction.cost().saturating_sub(transaction.value());
+                    if max_tx_fee_wei > tx_fee_cap_wei {
+                        return Err(InvalidPoolTransactionError::ExceedsFeeCap {
+                            max_tx_fee_wei: max_tx_fee_wei.saturating_to(),
+                            tx_fee_cap_wei,
+                        })
+                    }
+                }
+            }
+        }
+
+        // Drop non-local transactions with a fee lower than the configured fee for acceptance into
+        // the pool.
+        if !is_local &&
+            transaction.is_dynamic_fee() &&
+            transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
+        {
+            return Err(InvalidPoolTransactionError::PriorityFeeBelowMinimum {
+                minimum_priority_fee: self
+                    .minimum_priority_fee
+                    .expect("minimum priority fee is expected inside if statement"),
+            })
+        }
+
+        // Checks for chainid
+        if let Some(chain_id) = transaction.chain_id() &&
+            chain_id != self.chain_id()
+        {
+            return Err(InvalidTransactionError::ChainIdMismatch.into())
+        }
+
+        if transaction.is_eip7702() {
+            // Prague fork is required for 7702 txs
+            if !self.fork_tracker.is_prague_activated() {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into())
+            }
+
+            if transaction.authorization_list().is_none_or(|l| l.is_empty()) {
+                return Err(Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into())
+            }
+        }
+
+        ensure_intrinsic_gas(transaction, &self.fork_tracker)?;
+
+        // light blob tx pre-checks
+        if transaction.is_eip4844() {
+            // Cancun fork is required for blob txs
+            if !self.fork_tracker.is_cancun_activated() {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into())
+            }
+
+            let blob_count = transaction.blob_count().unwrap_or(0);
+            if blob_count == 0 {
+                // no blobs
+                return Err(InvalidPoolTransactionError::Eip4844(
+                    Eip4844PoolTransactionError::NoEip4844Blobs,
+                ))
+            }
+
+            let max_blob_count = self.fork_tracker.max_blob_count();
+            if blob_count > max_blob_count {
+                return Err(InvalidPoolTransactionError::Eip4844(
+                    Eip4844PoolTransactionError::TooManyEip4844Blobs {
+                        have: blob_count,
+                        permitted: max_blob_count,
+                    },
+                ))
+            }
+        }
+
+        // Transaction gas limit validation (EIP-7825 for Osaka+)
+        let tx_gas_limit_cap =
+            self.fork_tracker.tx_gas_limit_cap.load(std::sync::atomic::Ordering::Relaxed);
+        if tx_gas_limit_cap > 0 && transaction.gas_limit() > tx_gas_limit_cap {
+            return Err(InvalidTransactionError::GasLimitTooHigh.into())
+        }
+
+        // Run additional stateless validation if configured
+        if let Some(check) = &self.additional_stateless_validation {
+            check(origin, transaction)?;
+        }
+
+        Ok(())
+    }
+
+    /// Validates a single transaction against the given state (stateful checks only).
+    ///
+    /// Checks sender account balance, nonce, bytecode, and validates blob sidecars. The
+    /// transaction must have already passed [`validate_stateless`](Self::validate_stateless).
+    pub fn validate_stateful<P>(
+        &self,
+        origin: TransactionOrigin,
+        mut transaction: Tx,
+        state: P,
+    ) -> TransactionValidationOutcome<Tx>
+    where
+        P: AccountInfoReader,
+    {
+        // Use provider to get account info
+        let account = match state.basic_account(transaction.sender_ref()) {
+            Ok(account) => account.unwrap_or_default(),
+            Err(err) => {
+                return TransactionValidationOutcome::Error(*transaction.hash(), Box::new(err))
+            }
+        };
+
+        // check for bytecode
+        match self.validate_sender_bytecode(&transaction, &account, &state) {
+            Err(outcome) => return outcome,
+            Ok(Err(err)) => return TransactionValidationOutcome::Invalid(transaction, err),
+            _ => {}
+        };
+
+        // Checks for nonce
+        if transaction.requires_nonce_check() &&
+            let Err(err) = self.validate_sender_nonce(&transaction, &account)
+        {
+            return TransactionValidationOutcome::Invalid(transaction, err)
+        }
+
+        // checks for max cost not exceedng account_balance
+        if let Err(err) = self.validate_sender_balance(&transaction, &account) {
+            return TransactionValidationOutcome::Invalid(transaction, err)
+        }
+
+        // heavy blob tx validation
+        let maybe_blob_sidecar = match self.validate_eip4844(&mut transaction) {
+            Err(err) => return TransactionValidationOutcome::Invalid(transaction, err),
+            Ok(sidecar) => sidecar,
+        };
+
+        // Run additional stateful validation if configured
+        if let Some(check) = &self.additional_stateful_validation &&
+            let Err(err) = check(origin, &transaction, &state)
+        {
+            return TransactionValidationOutcome::Invalid(transaction, err)
+        }
+
+        let authorities = self.recover_authorities(&transaction);
+        // Return the valid transaction
+        TransactionValidationOutcome::Valid {
+            balance: account.balance,
+            state_nonce: account.nonce,
+            bytecode_hash: account.bytecode_hash,
+            transaction: ValidTransaction::new(transaction, maybe_blob_sidecar),
+            // by this point assume all external transactions should be propagated
+            propagate: match origin {
+                TransactionOrigin::External => true,
+                TransactionOrigin::Local => {
+                    self.local_transactions_config.propagate_local_transactions
+                }
+                TransactionOrigin::Private => false,
+            },
+            authorities,
+        }
+    }
+
+    /// Validates that the sender’s account has valid or no bytecode.
+    pub fn validate_sender_bytecode(
+        &self,
+        transaction: &Tx,
+        sender: &Account,
+        state: impl BytecodeReader,
+    ) -> Result<Result<(), InvalidPoolTransactionError>, TransactionValidationOutcome<Tx>> {
+        // Unless Prague is active, the signer account shouldn't have bytecode.
+        //
+        // If Prague is active, only EIP-7702 bytecode is allowed for the sender.
+        //
+        // Any other case means that the account is not an EOA, and should not be able to send
+        // transactions.
+        if let Some(code_hash) = &sender.bytecode_hash {
+            let is_eip7702 = if self.fork_tracker.is_prague_activated() {
+                match state.bytecode_by_hash(code_hash) {
+                    Ok(bytecode) => bytecode.unwrap_or_default().is_eip7702(),
+                    Err(err) => {
+                        return Err(TransactionValidationOutcome::Error(
+                            *transaction.hash(),
+                            Box::new(err),
+                        ))
+                    }
+                }
+            } else {
+                false
+            };
+
+            if !is_eip7702 {
+                return Ok(Err(InvalidTransactionError::SignerAccountHasBytecode.into()))
+            }
+        }
+        Ok(Ok(()))
+    }
+
+    /// Checks if the transaction nonce is valid.
+    pub fn validate_sender_nonce(
+        &self,
+        transaction: &Tx,
+        sender: &Account,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        let tx_nonce = transaction.nonce();
+
+        if tx_nonce < sender.nonce {
+            return Err(InvalidTransactionError::NonceNotConsistent {
+                tx: tx_nonce,
+                state: sender.nonce,
+            }
+            .into())
+        }
+        Ok(())
+    }
+
+    /// Ensures the sender has sufficient account balance.
+    pub fn validate_sender_balance(
+        &self,
+        transaction: &Tx,
+        sender: &Account,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        // [MANTLE PATCH] + extra_balance_cost (L1 + operator fee)
+        let cost = *transaction.cost() + transaction.extra_balance_cost();
+
+        if !self.disable_balance_check && cost > sender.balance {
+            let expected = cost;
+            return Err(InvalidTransactionError::InsufficientFunds(
+                GotExpected { got: sender.balance, expected }.into(),
+            )
+            .into())
+        }
+        Ok(())
+    }
+
+    /// Validates EIP-4844 blob sidecar data and returns the extracted sidecar, if any.
+    pub fn validate_eip4844(
+        &self,
+        transaction: &mut Tx,
+    ) -> Result<Option<BlobTransactionSidecarVariant>, InvalidPoolTransactionError> {
+        let mut maybe_blob_sidecar = None;
+
+        // heavy blob tx validation
+        if transaction.is_eip4844() {
+            // extract the blob from the transaction
+            match transaction.take_blob() {
+                EthBlobTransactionSidecar::None => {
+                    // this should not happen
+                    return Err(InvalidTransactionError::TxTypeNotSupported.into())
+                }
+                EthBlobTransactionSidecar::Missing => {
+                    // This can happen for re-injected blob transactions (on re-org), since the blob
+                    // is stripped from the transaction and not included in a block.
+                    // check if the blob is in the store, if it's included we previously validated
+                    // it and inserted it
+                    if self.blob_store.contains(*transaction.hash()).is_ok_and(|c| c) {
+                        // validated transaction is already in the store
+                    } else {
+                        return Err(InvalidPoolTransactionError::Eip4844(
+                            Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
+                        ))
+                    }
+                }
+                EthBlobTransactionSidecar::Present(sidecar) => {
+                    let now = Instant::now();
+
+                    // EIP-7594 sidecar version handling
+                    if self.eip7594 {
+                        // Standard Ethereum behavior
+                        if self.fork_tracker.is_osaka_activated() {
+                            if sidecar.is_eip4844() {
+                                return Err(InvalidPoolTransactionError::Eip4844(
+                                    Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka,
+                                ))
+                            }
+                        } else if sidecar.is_eip7594() && !self.allow_7594_sidecars() {
+                            return Err(InvalidPoolTransactionError::Eip4844(
+                                Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka,
+                            ))
+                        }
+                    } else {
+                        // EIP-7594 disabled: always reject v1 sidecars, accept v0
+                        if sidecar.is_eip7594() {
+                            return Err(InvalidPoolTransactionError::Eip4844(
+                                Eip4844PoolTransactionError::Eip7594SidecarDisallowed,
+                            ))
+                        }
+                    }
+
+                    // validate the blob
+                    if let Err(err) = transaction.validate_blob(&sidecar, self.kzg_settings.get()) {
+                        return Err(InvalidPoolTransactionError::Eip4844(
+                            Eip4844PoolTransactionError::InvalidEip4844Blob(err),
+                        ))
+                    }
+                    // Record the duration of successful blob validation as histogram
+                    self.validation_metrics.blob_validation_duration.record(now.elapsed());
+                    // store the extracted blob
+                    maybe_blob_sidecar = Some(sidecar);
+                }
+            }
+        }
+        Ok(maybe_blob_sidecar)
+    }
+
+    /// Returns the recovered authorities for the given transaction
+    fn recover_authorities(&self, transaction: &Tx) -> std::option::Option<Vec<Address>> {
+        transaction
+            .authorization_list()
+            .map(|auths| auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>())
+    }
+
+    /// Validates all given transactions.
+    fn validate_batch(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Tx)>,
+    ) -> Vec<TransactionValidationOutcome<Tx>> {
+        let mut provider = None;
+        transactions
+            .into_iter()
+            .map(|(origin, tx)| self.validate_one_with_provider(origin, tx, &mut provider))
+            .collect()
+    }
+
+    /// Validates all given transactions with origin.
+    fn validate_batch_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Tx> + Send,
+    ) -> Vec<TransactionValidationOutcome<Tx>> {
+        let mut provider = None;
+        transactions
+            .into_iter()
+            .map(|tx| self.validate_one_with_provider(origin, tx, &mut provider))
+            .collect()
+    }
+
+    fn on_new_head_block(&self, new_tip_block: &HeaderTy<Evm::Primitives>) {
+        // update all forks
+        if self.chain_spec().is_shanghai_active_at_timestamp(new_tip_block.timestamp()) {
+            self.fork_tracker.shanghai.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        if self.chain_spec().is_cancun_active_at_timestamp(new_tip_block.timestamp()) {
+            self.fork_tracker.cancun.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        if self.chain_spec().is_prague_active_at_timestamp(new_tip_block.timestamp()) {
+            self.fork_tracker.prague.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        if self.chain_spec().is_osaka_active_at_timestamp(new_tip_block.timestamp()) {
+            self.fork_tracker.osaka.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        self.fork_tracker
+            .tip_timestamp
+            .store(new_tip_block.timestamp(), std::sync::atomic::Ordering::Relaxed);
+
+        if let Some(blob_params) =
+            self.chain_spec().blob_params_at_timestamp(new_tip_block.timestamp())
+        {
+            self.fork_tracker
+                .max_blob_count
+                .store(blob_params.max_blobs_per_tx, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        self.block_gas_limit.store(new_tip_block.gas_limit(), std::sync::atomic::Ordering::Relaxed);
+
+        // Get EVM limits from evm_config.evm_env()
+        let evm_env = self
+            .evm_config
+            .evm_env(new_tip_block)
+            .expect("evm_env should not fail for executed block");
+
+        self.fork_tracker
+            .max_initcode_size
+            .store(evm_env.cfg_env.max_initcode_size(), std::sync::atomic::Ordering::Relaxed);
+        // EIP-8037: When state gas is enabled, `tx.gas` can exceed the per-tx gas limit cap
+        // because the cap only applies to regular gas (state gas uses a reservoir).
+        // Store 0 to disable the txpool-level check.
+        let tx_gas_limit_cap = if evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
+            0
+        } else {
+            evm_env.cfg_env.tx_gas_limit_cap()
+        };
+        self.fork_tracker
+            .tx_gas_limit_cap
+            .store(tx_gas_limit_cap, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn max_gas_limit(&self) -> u64 {
+        self.block_gas_limit.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns whether EIP-7594 sidecars are allowed
+    fn allow_7594_sidecars(&self) -> bool {
+        let tip_timestamp = self.fork_tracker.tip_timestamp();
+
+        // If next block is Osaka, allow 7594 sidecars
+        if self.chain_spec().is_osaka_active_at_timestamp(tip_timestamp.saturating_add(12)) {
+            true
+        } else if self.chain_spec().is_osaka_active_at_timestamp(tip_timestamp.saturating_add(24)) {
+            let current_timestamp =
+                SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
+
+            // Allow after 4 seconds into last non-Osaka slot
+            current_timestamp >= tip_timestamp.saturating_add(4)
+        } else {
+            false
+        }
+    }
+}
+
+impl<Client, Tx, Evm> TransactionValidator for EthTransactionValidator<Client, Tx, Evm>
+where
+    Client: ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks> + StateProviderFactory,
+    Tx: EthPoolTransaction,
+    Evm: ConfigureEvm,
+{
+    type Transaction = Tx;
+    type Block = BlockTy<Evm::Primitives>;
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        self.validate_one(origin, transaction)
+    }
+
+    async fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+            + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        self.validate_batch(transactions)
+    }
+
+    async fn validate_transactions_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        self.validate_batch_with_origin(origin, transactions)
+    }
+
+    fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
+        Self::on_new_head_block(self, new_tip_block.header())
+    }
+}
+
+/// A builder for [`EthTransactionValidator`] and [`TransactionValidationTaskExecutor`]
+#[derive(Debug)]
+pub struct EthTransactionValidatorBuilder<Client, Evm> {
+    client: Client,
+    /// The EVM configuration to use for validation.
+    evm_config: Evm,
+    /// Fork indicator whether we are in the Shanghai stage.
+    shanghai: bool,
+    /// Fork indicator whether we are in the Cancun hardfork.
+    cancun: bool,
+    /// Fork indicator whether we are in the Prague hardfork.
+    prague: bool,
+    /// Fork indicator whether we are in the Osaka hardfork.
+    osaka: bool,
+    /// Timestamp of the tip block.
+    tip_timestamp: u64,
+    /// Max blob count at the block's timestamp.
+    max_blob_count: u64,
+    /// Whether using EIP-2718 type transactions is allowed
+    eip2718: bool,
+    /// Whether using EIP-1559 type transactions is allowed
+    eip1559: bool,
+    /// Whether using EIP-4844 type transactions is allowed
+    eip4844: bool,
+    /// Whether using EIP-7702 type transactions is allowed
+    eip7702: bool,
+    /// The current max gas limit
+    block_gas_limit: AtomicU64,
+    /// The current tx fee cap limit in wei locally submitted into the pool.
+    tx_fee_cap: Option<u128>,
+    /// Minimum priority fee to enforce for acceptance into the pool.
+    minimum_priority_fee: Option<u128>,
+    /// Determines how many additional tasks to spawn
+    ///
+    /// Default is 1
+    additional_tasks: usize,
+
+    /// Stores the setup and parameters needed for validating KZG proofs.
+    kzg_settings: EnvKzgSettings,
+    /// How to handle [`TransactionOrigin::Local`](TransactionOrigin) transactions.
+    local_transactions_config: LocalTransactionConfig,
+    /// Max size in bytes of a single transaction allowed
+    max_tx_input_bytes: usize,
+    /// Maximum gas limit for individual transactions
+    max_tx_gas_limit: Option<u64>,
+    /// Disable balance checks during transaction validation
+    disable_balance_check: bool,
+    /// Bitmap of custom transaction types that are allowed.
+    other_tx_types: U256,
+    /// Cached max initcode size from EVM config
+    max_initcode_size: usize,
+    /// Cached transaction gas limit cap from EVM config (0 = no cap)
+    tx_gas_limit_cap: u64,
+    /// Whether EIP-7594 blob sidecars are accepted.
+    /// When false, EIP-7594 (v1) sidecars are always rejected and EIP-4844 (v0) sidecars
+    /// are always accepted, regardless of Osaka fork activation.
+    eip7594: bool,
+}
+
+impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
+    /// Creates a new builder for the given client and EVM config
+    ///
+    /// By default this assumes the network is on the `Prague` hardfork and the following
+    /// transactions are allowed:
+    ///  - Legacy
+    ///  - EIP-2718
+    ///  - EIP-1559
+    ///  - EIP-4844
+    ///  - EIP-7702
+    pub fn new(client: Client, evm_config: Evm) -> Self
+    where
+        Client: ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
+            + BlockReaderIdExt<Header = HeaderTy<Evm::Primitives>>,
+        Evm: ConfigureEvm,
+    {
+        let chain_spec = client.chain_spec();
+        let tip = client
+            .header_by_id(BlockId::latest())
+            .expect("failed to fetch latest header")
+            .expect("latest header is not found");
+        let evm_env =
+            evm_config.evm_env(&tip).expect("evm_env should not fail for existing blocks");
+
+        Self {
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M.into(),
+            client,
+            evm_config,
+            minimum_priority_fee: None,
+            additional_tasks: 1,
+            kzg_settings: EnvKzgSettings::Default,
+            local_transactions_config: Default::default(),
+            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
+            tx_fee_cap: Some(1e18 as u128),
+            max_tx_gas_limit: None,
+            // by default all transaction types are allowed
+            eip2718: true,
+            eip1559: true,
+            eip4844: true,
+            eip7702: true,
+
+            shanghai: chain_spec.is_shanghai_active_at_timestamp(tip.timestamp()),
+            cancun: chain_spec.is_cancun_active_at_timestamp(tip.timestamp()),
+            prague: chain_spec.is_prague_active_at_timestamp(tip.timestamp()),
+            osaka: chain_spec.is_osaka_active_at_timestamp(tip.timestamp()),
+
+            tip_timestamp: tip.timestamp(),
+
+            max_blob_count: chain_spec
+                .blob_params_at_timestamp(tip.timestamp())
+                .unwrap_or_else(BlobParams::prague)
+                .max_blobs_per_tx,
+
+            // balance checks are enabled by default
+            disable_balance_check: false,
+
+            // no custom transaction types by default
+            other_tx_types: U256::ZERO,
+
+            // EIP-8037: When state gas is enabled, tx.gas can exceed the per-tx cap
+            tx_gas_limit_cap: if evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
+                0
+            } else {
+                evm_env.cfg_env.tx_gas_limit_cap()
+            },
+            max_initcode_size: evm_env.cfg_env.max_initcode_size(),
+
+            // EIP-7594 sidecars are accepted by default (standard Ethereum behavior)
+            eip7594: true,
+        }
+    }
+
+    /// Disables the Cancun fork.
+    pub const fn no_cancun(self) -> Self {
+        self.set_cancun(false)
+    }
+
+    /// Whether to allow exemptions for local transaction exemptions.
+    pub fn with_local_transactions_config(
+        mut self,
+        local_transactions_config: LocalTransactionConfig,
+    ) -> Self {
+        self.local_transactions_config = local_transactions_config;
+        self
+    }
+
+    /// Set the Cancun fork.
+    pub const fn set_cancun(mut self, cancun: bool) -> Self {
+        self.cancun = cancun;
+        self
+    }
+
+    /// Disables the Shanghai fork.
+    pub const fn no_shanghai(self) -> Self {
+        self.set_shanghai(false)
+    }
+
+    /// Set the Shanghai fork.
+    pub const fn set_shanghai(mut self, shanghai: bool) -> Self {
+        self.shanghai = shanghai;
+        self
+    }
+
+    /// Disables the Prague fork.
+    pub const fn no_prague(self) -> Self {
+        self.set_prague(false)
+    }
+
+    /// Set the Prague fork.
+    pub const fn set_prague(mut self, prague: bool) -> Self {
+        self.prague = prague;
+        self
+    }
+
+    /// Disables the Osaka fork.
+    pub const fn no_osaka(self) -> Self {
+        self.set_osaka(false)
+    }
+
+    /// Set the Osaka fork.
+    pub const fn set_osaka(mut self, osaka: bool) -> Self {
+        self.osaka = osaka;
+        self
+    }
+
+    /// Disables the support for EIP-2718 transactions.
+    pub const fn no_eip2718(self) -> Self {
+        self.set_eip2718(false)
+    }
+
+    /// Set the support for EIP-2718 transactions.
+    pub const fn set_eip2718(mut self, eip2718: bool) -> Self {
+        self.eip2718 = eip2718;
+        self
+    }
+
+    /// Disables the support for EIP-1559 transactions.
+    pub const fn no_eip1559(self) -> Self {
+        self.set_eip1559(false)
+    }
+
+    /// Set the support for EIP-1559 transactions.
+    pub const fn set_eip1559(mut self, eip1559: bool) -> Self {
+        self.eip1559 = eip1559;
+        self
+    }
+
+    /// Disables the support for EIP-4844 transactions.
+    pub const fn no_eip4844(self) -> Self {
+        self.set_eip4844(false)
+    }
+
+    /// Set the support for EIP-4844 transactions.
+    pub const fn set_eip4844(mut self, eip4844: bool) -> Self {
+        self.eip4844 = eip4844;
+        self
+    }
+
+    /// Disables the support for EIP-7702 transactions.
+    pub const fn no_eip7702(self) -> Self {
+        self.set_eip7702(false)
+    }
+
+    /// Set the support for EIP-7702 transactions.
+    pub const fn set_eip7702(mut self, eip7702: bool) -> Self {
+        self.eip7702 = eip7702;
+        self
+    }
+
+    /// Disables EIP-7594 blob sidecar support.
+    ///
+    /// When disabled, EIP-7594 (v1) blob sidecars are always rejected and EIP-4844 (v0)
+    /// sidecars are always accepted, regardless of Osaka fork activation.
+    ///
+    /// Use this for chains that do not adopt EIP-7594 (`PeerDAS`).
+    pub const fn no_eip7594(self) -> Self {
+        self.set_eip7594(false)
+    }
+
+    /// Set EIP-7594 blob sidecar support.
+    ///
+    /// When true (default), standard Ethereum behavior applies: v0 sidecars before Osaka,
+    /// v1 sidecars after Osaka. When false, v1 sidecars are always rejected.
+    pub const fn set_eip7594(mut self, eip7594: bool) -> Self {
+        self.eip7594 = eip7594;
+        self
+    }
+
+    /// Sets the [`EnvKzgSettings`] to use for validating KZG proofs.
+    pub fn kzg_settings(mut self, kzg_settings: EnvKzgSettings) -> Self {
+        self.kzg_settings = kzg_settings;
+        self
+    }
+
+    /// Sets a minimum priority fee that's enforced for acceptance into the pool.
+    pub const fn with_minimum_priority_fee(mut self, minimum_priority_fee: Option<u128>) -> Self {
+        self.minimum_priority_fee = minimum_priority_fee;
+        self
+    }
+
+    /// Sets the number of additional tasks to spawn.
+    pub const fn with_additional_tasks(mut self, additional_tasks: usize) -> Self {
+        self.additional_tasks = additional_tasks;
+        self
+    }
+
+    /// Sets a max size in bytes of a single transaction allowed into the pool
+    pub const fn with_max_tx_input_bytes(mut self, max_tx_input_bytes: usize) -> Self {
+        self.max_tx_input_bytes = max_tx_input_bytes;
+        self
+    }
+
+    /// Sets the block gas limit
+    ///
+    /// Transactions with a gas limit greater than this will be rejected.
+    pub fn set_block_gas_limit(self, block_gas_limit: u64) -> Self {
+        self.block_gas_limit.store(block_gas_limit, std::sync::atomic::Ordering::Relaxed);
+        self
+    }
+
+    /// Sets the block gas limit
+    ///
+    /// Transactions with a gas limit greater than this will be rejected.
+    pub const fn set_tx_fee_cap(mut self, tx_fee_cap: u128) -> Self {
+        self.tx_fee_cap = Some(tx_fee_cap);
+        self
+    }
+
+    /// Sets the maximum gas limit for individual transactions
+    pub const fn with_max_tx_gas_limit(mut self, max_tx_gas_limit: Option<u64>) -> Self {
+        self.max_tx_gas_limit = max_tx_gas_limit;
+        self
+    }
+
+    /// Disables balance checks during transaction validation
+    pub const fn disable_balance_check(mut self) -> Self {
+        self.disable_balance_check = true;
+        self
+    }
+
+    /// Adds a custom transaction type to the validator.
+    pub const fn with_custom_tx_type(mut self, tx_type: u8) -> Self {
+        self.other_tx_types.set_bit(tx_type as usize, true);
+        self
+    }
+
+    /// Builds a the [`EthTransactionValidator`] without spawning validator tasks.
+    pub fn build<Tx, S>(self, blob_store: S) -> EthTransactionValidator<Client, Tx, Evm>
+    where
+        S: BlobStore,
+    {
+        let Self {
+            client,
+            evm_config,
+            shanghai,
+            cancun,
+            prague,
+            osaka,
+            tip_timestamp,
+            eip2718,
+            eip1559,
+            eip4844,
+            eip7702,
+            block_gas_limit,
+            tx_fee_cap,
+            minimum_priority_fee,
+            kzg_settings,
+            local_transactions_config,
+            max_tx_input_bytes,
+            max_tx_gas_limit,
+            disable_balance_check,
+            max_blob_count,
+            additional_tasks: _,
+            other_tx_types,
+            max_initcode_size,
+            tx_gas_limit_cap,
+            eip7594,
+        } = self;
+
+        let fork_tracker = ForkTracker {
+            shanghai: AtomicBool::new(shanghai),
+            cancun: AtomicBool::new(cancun),
+            prague: AtomicBool::new(prague),
+            osaka: AtomicBool::new(osaka),
+            tip_timestamp: AtomicU64::new(tip_timestamp),
+            max_blob_count: AtomicU64::new(max_blob_count),
+            max_initcode_size: AtomicUsize::new(max_initcode_size),
+            tx_gas_limit_cap: AtomicU64::new(tx_gas_limit_cap),
+        };
+
+        EthTransactionValidator {
+            client,
+            eip2718,
+            eip1559,
+            fork_tracker,
+            eip4844,
+            eip7702,
+            block_gas_limit,
+            tx_fee_cap,
+            minimum_priority_fee,
+            blob_store: Box::new(blob_store),
+            kzg_settings,
+            local_transactions_config,
+            max_tx_input_bytes,
+            max_tx_gas_limit,
+            disable_balance_check,
+            evm_config,
+            _marker: Default::default(),
+            validation_metrics: TxPoolValidationMetrics::default(),
+            other_tx_types,
+            eip7594,
+            additional_stateless_validation: None,
+            additional_stateful_validation: None,
+        }
+    }
+
+    /// Builds a [`EthTransactionValidator`] and spawns validation tasks via the
+    /// [`TransactionValidationTaskExecutor`]
+    ///
+    /// The validator will spawn `additional_tasks` additional tasks for validation.
+    ///
+    /// By default this will spawn 1 additional task.
+    pub fn build_with_tasks<Tx, S>(
+        self,
+        tasks: Runtime,
+        blob_store: S,
+    ) -> TransactionValidationTaskExecutor<EthTransactionValidator<Client, Tx, Evm>>
+    where
+        S: BlobStore,
+    {
+        let additional_tasks = self.additional_tasks;
+        let validator = self.build::<Tx, S>(blob_store);
+        TransactionValidationTaskExecutor::spawn(validator, &tasks, additional_tasks)
+    }
+}
+
+/// Keeps track of whether certain forks are activated
+#[derive(Debug)]
+pub struct ForkTracker {
+    /// Tracks if shanghai is activated at the block's timestamp.
+    pub shanghai: AtomicBool,
+    /// Tracks if cancun is activated at the block's timestamp.
+    pub cancun: AtomicBool,
+    /// Tracks if prague is activated at the block's timestamp.
+    pub prague: AtomicBool,
+    /// Tracks if osaka is activated at the block's timestamp.
+    pub osaka: AtomicBool,
+    /// Tracks max blob count per transaction at the block's timestamp.
+    pub max_blob_count: AtomicU64,
+    /// Tracks the timestamp of the tip block.
+    pub tip_timestamp: AtomicU64,
+    /// Cached max initcode size from EVM config
+    pub max_initcode_size: AtomicUsize,
+    /// Cached transaction gas limit cap from EVM config (0 = no cap)
+    pub tx_gas_limit_cap: AtomicU64,
+}
+
+impl ForkTracker {
+    /// Returns `true` if Shanghai fork is activated.
+    pub fn is_shanghai_activated(&self) -> bool {
+        self.shanghai.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns `true` if Cancun fork is activated.
+    pub fn is_cancun_activated(&self) -> bool {
+        self.cancun.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns `true` if Prague fork is activated.
+    pub fn is_prague_activated(&self) -> bool {
+        self.prague.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns `true` if Osaka fork is activated.
+    pub fn is_osaka_activated(&self) -> bool {
+        self.osaka.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns the timestamp of the tip block.
+    pub fn tip_timestamp(&self) -> u64 {
+        self.tip_timestamp.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns the max allowed blob count per transaction.
+    pub fn max_blob_count(&self) -> u64 {
+        self.max_blob_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// Ensures that gas limit of the transaction exceeds the intrinsic gas of the transaction.
+///
+/// Caution: This only checks past the Merge hardfork.
+pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
+    transaction: &T,
+    fork_tracker: &ForkTracker,
+) -> Result<(), InvalidPoolTransactionError> {
+    use revm_primitives::hardfork::SpecId;
+    let spec_id = if fork_tracker.is_prague_activated() {
+        SpecId::PRAGUE
+    } else if fork_tracker.is_shanghai_activated() {
+        SpecId::SHANGHAI
+    } else {
+        SpecId::MERGE
+    };
+
+    let gas = revm_interpreter::gas::calculate_initial_tx_gas(
+        spec_id,
+        transaction.input(),
+        transaction.is_create(),
+        transaction.access_list().map(|l| l.len()).unwrap_or_default() as u64,
+        transaction
+            .access_list()
+            .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
+            .unwrap_or_default() as u64,
+        transaction.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
+    );
+
+    let gas_limit = transaction.gas_limit();
+    if gas_limit < gas.initial_total_gas || gas_limit < gas.floor_gas {
+        Err(InvalidPoolTransactionError::IntrinsicGasTooLow)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        blobstore::InMemoryBlobStore, error::PoolErrorKind, traits::PoolTransaction,
+        CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionPool,
+    };
+    use alloy_consensus::Transaction;
+    use alloy_eips::eip2718::Decodable2718;
+    use alloy_primitives::{hex, U256};
+    use reth_ethereum_primitives::PooledTransactionVariant;
+    use reth_evm_ethereum::EthEvmConfig;
+    use reth_primitives_traits::SignedTransaction;
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+    use revm_primitives::eip3860::MAX_INITCODE_SIZE;
+
+    fn test_evm_config() -> EthEvmConfig {
+        EthEvmConfig::mainnet()
+    }
+
+    fn get_transaction() -> EthPooledTransaction {
+        let raw = "0x02f914950181ad84b2d05e0085117553845b830f7df88080b9143a6040608081523462000414576200133a803803806200001e8162000419565b9283398101608082820312620004145781516001600160401b03908181116200041457826200004f9185016200043f565b92602092838201519083821162000414576200006d9183016200043f565b8186015190946001600160a01b03821692909183900362000414576060015190805193808511620003145760038054956001938488811c9816801562000409575b89891014620003f3578190601f988981116200039d575b50899089831160011462000336576000926200032a575b505060001982841b1c191690841b1781555b8751918211620003145760049788548481811c9116801562000309575b89821014620002f457878111620002a9575b5087908784116001146200023e5793839491849260009562000232575b50501b92600019911b1c19161785555b6005556007805460ff60a01b19169055600880546001600160a01b0319169190911790553015620001f3575060025469d3c21bcecceda100000092838201809211620001de57506000917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9160025530835282815284832084815401905584519384523093a351610e889081620004b28239f35b601190634e487b7160e01b6000525260246000fd5b90606493519262461bcd60e51b845283015260248201527f45524332303a206d696e7420746f20746865207a65726f2061646472657373006044820152fd5b0151935038806200013a565b9190601f198416928a600052848a6000209460005b8c8983831062000291575050501062000276575b50505050811b0185556200014a565b01519060f884600019921b161c191690553880808062000267565b86860151895590970196948501948893500162000253565b89600052886000208880860160051c8201928b8710620002ea575b0160051c019085905b828110620002dd5750506200011d565b60008155018590620002cd565b92508192620002c4565b60228a634e487b7160e01b6000525260246000fd5b90607f16906200010b565b634e487b7160e01b600052604160045260246000fd5b015190503880620000dc565b90869350601f19831691856000528b6000209260005b8d8282106200038657505084116200036d575b505050811b018155620000ee565b015160001983861b60f8161c191690553880806200035f565b8385015186558a979095019493840193016200034c565b90915083600052896000208980850160051c8201928c8610620003e9575b918891869594930160051c01915b828110620003d9575050620000c5565b60008155859450889101620003c9565b92508192620003bb565b634e487b7160e01b600052602260045260246000fd5b97607f1697620000ae565b600080fd5b6040519190601f01601f191682016001600160401b038111838210176200031457604052565b919080601f84011215620004145782516001600160401b038111620003145760209062000475601f8201601f1916830162000419565b92818452828287010111620004145760005b8181106200049d57508260009394955001015290565b85810183015184820184015282016200048756fe608060408181526004918236101561001657600080fd5b600092833560e01c91826306fdde0314610a1c57508163095ea7b3146109f257816318160ddd146109d35781631b4c84d2146109ac57816323b872dd14610833578163313ce5671461081757816339509351146107c357816370a082311461078c578163715018a6146107685781638124f7ac146107495781638da5cb5b1461072057816395d89b411461061d578163a457c2d714610575578163a9059cbb146104e4578163c9567bf914610120575063dd62ed3e146100d557600080fd5b3461011c578060031936011261011c57806020926100f1610b5a565b6100f9610b75565b6001600160a01b0391821683526001865283832091168252845220549051908152f35b5080fd5b905082600319360112610338576008546001600160a01b039190821633036104975760079283549160ff8360a01c1661045557737a250d5630b4cf539739df2c5dacb4c659f2488d92836bffffffffffffffffffffffff60a01b8092161786553087526020938785528388205430156104065730895260018652848920828a52865280858a205584519081527f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925863092a38554835163c45a015560e01b815290861685828581845afa9182156103dd57849187918b946103e7575b5086516315ab88c960e31b815292839182905afa9081156103dd576044879289928c916103c0575b508b83895196879586946364e329cb60e11b8652308c870152166024850152165af19081156103b6579086918991610389575b50169060065416176006558385541660604730895288865260c4858a20548860085416928751958694859363f305d71960e01b8552308a86015260248501528d60448501528d606485015260848401524260a48401525af1801561037f579084929161034c575b50604485600654169587541691888551978894859363095ea7b360e01b855284015260001960248401525af1908115610343575061030c575b5050805460ff60a01b1916600160a01b17905580f35b81813d831161033c575b6103208183610b8b565b8101031261033857518015150361011c5738806102f6565b8280fd5b503d610316565b513d86823e3d90fd5b6060809293503d8111610378575b6103648183610b8b565b81010312610374578290386102bd565b8580fd5b503d61035a565b83513d89823e3d90fd5b6103a99150863d88116103af575b6103a18183610b8b565b810190610e33565b38610256565b503d610397565b84513d8a823e3d90fd5b6103d79150843d86116103af576103a18183610b8b565b38610223565b85513d8b823e3d90fd5b6103ff919450823d84116103af576103a18183610b8b565b92386101fb565b845162461bcd60e51b81528085018790526024808201527f45524332303a20617070726f76652066726f6d20746865207a65726f206164646044820152637265737360e01b6064820152608490fd5b6020606492519162461bcd60e51b8352820152601760248201527f74726164696e6720697320616c7265616479206f70656e0000000000000000006044820152fd5b608490602084519162461bcd60e51b8352820152602160248201527f4f6e6c79206f776e65722063616e2063616c6c20746869732066756e6374696f6044820152603760f91b6064820152fd5b9050346103385781600319360112610338576104fe610b5a565b9060243593303303610520575b602084610519878633610bc3565b5160018152f35b600594919454808302908382041483151715610562576127109004820391821161054f5750925080602061050b565b634e487b7160e01b815260118552602490fd5b634e487b7160e01b825260118652602482fd5b9050823461061a578260031936011261061a57610590610b5a565b918360243592338152600160205281812060018060a01b03861682526020522054908282106105c9576020856105198585038733610d31565b608490602086519162461bcd60e51b8352820152602560248201527f45524332303a2064656372656173656420616c6c6f77616e63652062656c6f77604482015264207a65726f60d81b6064820152fd5b80fd5b83833461011c578160031936011261011c57805191809380549160019083821c92828516948515610716575b6020958686108114610703578589529081156106df5750600114610687575b6106838787610679828c0383610b8b565b5191829182610b11565b0390f35b81529295507f8a35acfbc15ff81a39ae7d344fd709f28e8600b4aa8c65c6b64bfe7fe36bd19b5b8284106106cc57505050826106839461067992820101948680610668565b80548685018801529286019281016106ae565b60ff19168887015250505050151560051b8301019250610679826106838680610668565b634e487b7160e01b845260228352602484fd5b93607f1693610649565b50503461011c578160031936011261011c5760085490516001600160a01b039091168152602090f35b50503461011c578160031936011261011c576020906005549051908152f35b833461061a578060031936011261061a57600880546001600160a01b031916905580f35b50503461011c57602036600319011261011c5760209181906001600160a01b036107b4610b5a565b16815280845220549051908152f35b82843461061a578160031936011261061a576107dd610b5a565b338252600160209081528383206001600160a01b038316845290528282205460243581019290831061054f57602084610519858533610d31565b50503461011c578160031936011261011c576020905160128152f35b83833461011c57606036600319011261011c5761084e610b5a565b610856610b75565b6044359160018060a01b0381169485815260209560018752858220338352875285822054976000198903610893575b505050906105199291610bc3565b85891061096957811561091a5733156108cc5750948481979861051997845260018a528284203385528a52039120558594938780610885565b865162461bcd60e51b8152908101889052602260248201527f45524332303a20617070726f766520746f20746865207a65726f206164647265604482015261737360f01b6064820152608490fd5b865162461bcd60e51b81529081018890526024808201527f45524332303a20617070726f76652066726f6d20746865207a65726f206164646044820152637265737360e01b6064820152608490fd5b865162461bcd60e51b8152908101889052601d60248201527f45524332303a20696e73756666696369656e7420616c6c6f77616e63650000006044820152606490fd5b50503461011c578160031936011261011c5760209060ff60075460a01c1690519015158152f35b50503461011c578160031936011261011c576020906002549051908152f35b50503461011c578060031936011261011c57602090610519610a12610b5a565b6024359033610d31565b92915034610b0d5783600319360112610b0d57600354600181811c9186908281168015610b03575b6020958686108214610af05750848852908115610ace5750600114610a75575b6106838686610679828b0383610b8b565b929550600383527fc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b5b828410610abb575050508261068394610679928201019438610a64565b8054868501880152928601928101610a9e565b60ff191687860152505050151560051b83010192506106798261068338610a64565b634e487b7160e01b845260229052602483fd5b93607f1693610a44565b8380fd5b6020808252825181830181905290939260005b828110610b4657505060409293506000838284010152601f8019910116010190565b818101860151848201604001528501610b24565b600435906001600160a01b0382168203610b7057565b600080fd5b602435906001600160a01b0382168203610b7057565b90601f8019910116810190811067ffffffffffffffff821117610bad57604052565b634e487b7160e01b600052604160045260246000fd5b6001600160a01b03908116918215610cde5716918215610c8d57600082815280602052604081205491808310610c3957604082827fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef958760209652828652038282205586815220818154019055604051908152a3565b60405162461bcd60e51b815260206004820152602660248201527f45524332303a207472616e7366657220616d6f756e7420657863656564732062604482015265616c616e636560d01b6064820152608490fd5b60405162461bcd60e51b815260206004820152602360248201527f45524332303a207472616e7366657220746f20746865207a65726f206164647260448201526265737360e81b6064820152608490fd5b60405162461bcd60e51b815260206004820152602560248201527f45524332303a207472616e736665722066726f6d20746865207a65726f206164604482015264647265737360d81b6064820152608490fd5b6001600160a01b03908116918215610de25716918215610d925760207f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925918360005260018252604060002085600052825280604060002055604051908152a3565b60405162461bcd60e51b815260206004820152602260248201527f45524332303a20617070726f766520746f20746865207a65726f206164647265604482015261737360f01b6064820152608490fd5b60405162461bcd60e51b8152602060048201526024808201527f45524332303a20617070726f76652066726f6d20746865207a65726f206164646044820152637265737360e01b6064820152608490fd5b90816020910312610b7057516001600160a01b0381168103610b70579056fea2646970667358221220285c200b3978b10818ff576bb83f2dc4a2a7c98dfb6a36ea01170de792aa652764736f6c63430008140033000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000d3fd4f95820a9aa848ce716d6c200eaefb9a2e4900000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000003543131000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000035431310000000000000000000000000000000000000000000000000000000000c001a04e551c75810ffdfe6caff57da9f5a8732449f42f0f4c57f935b05250a76db3b6a046cd47e6d01914270c1ec0d9ac7fae7dfb240ec9a8b6ec7898c4d6aa174388f2";
+
+        let data = hex::decode(raw).unwrap();
+        let tx = PooledTransactionVariant::decode_2718(&mut data.as_ref()).unwrap();
+
+        EthPooledTransaction::from_pooled(tx.try_into_recovered().unwrap())
+    }
+
+    // <https://github.com/paradigmxyz/reth/issues/5178>
+    #[tokio::test]
+    async fn validate_transaction() {
+        let transaction = get_transaction();
+        let mut fork_tracker = ForkTracker {
+            shanghai: false.into(),
+            cancun: false.into(),
+            prague: false.into(),
+            osaka: false.into(),
+            tip_timestamp: 0.into(),
+            max_blob_count: 0.into(),
+            max_initcode_size: AtomicUsize::new(MAX_INITCODE_SIZE),
+            tx_gas_limit_cap: AtomicU64::new(0),
+        };
+
+        let res = ensure_intrinsic_gas(&transaction, &fork_tracker);
+        assert!(res.is_ok());
+
+        fork_tracker.shanghai = true.into();
+        let res = ensure_intrinsic_gas(&transaction, &fork_tracker);
+        assert!(res.is_ok());
+
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, test_evm_config())
+            .build(blob_store.clone());
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
+
+        assert!(outcome.is_valid());
+
+        let pool =
+            Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, Default::default());
+
+        let res = pool.add_external_transaction(transaction.clone()).await;
+        assert!(res.is_ok());
+        let tx = pool.get(transaction.hash());
+        assert!(tx.is_some());
+    }
+
+    // <https://github.com/paradigmxyz/reth/issues/8550>
+    #[tokio::test]
+    async fn invalid_on_gas_limit_too_high() {
+        let transaction = get_transaction();
+
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, test_evm_config())
+            .set_block_gas_limit(1_000_000) // tx gas limit is 1_015_288
+            .build(blob_store.clone());
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
+
+        assert!(outcome.is_invalid());
+
+        let pool =
+            Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, Default::default());
+
+        let res = pool.add_external_transaction(transaction.clone()).await;
+        assert!(res.is_err());
+        assert!(matches!(
+            res.unwrap_err().kind,
+            PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::ExceedsGasLimit(
+                1_015_288, 1_000_000
+            ))
+        ));
+        let tx = pool.get(transaction.hash());
+        assert!(tx.is_none());
+    }
+
+    #[tokio::test]
+    async fn invalid_on_fee_cap_exceeded() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, test_evm_config())
+            .set_tx_fee_cap(100) // 100 wei cap
+            .build(blob_store.clone());
+
+        let outcome = validator.validate_one(TransactionOrigin::Local, transaction.clone());
+        assert!(outcome.is_invalid());
+
+        if let TransactionValidationOutcome::Invalid(_, err) = outcome {
+            assert!(matches!(
+                err,
+                InvalidPoolTransactionError::ExceedsFeeCap { max_tx_fee_wei, tx_fee_cap_wei }
+                if (max_tx_fee_wei > tx_fee_cap_wei)
+            ));
+        }
+
+        let pool =
+            Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, Default::default());
+        let res = pool.add_transaction(TransactionOrigin::Local, transaction.clone()).await;
+        assert!(res.is_err());
+        assert!(matches!(
+            res.unwrap_err().kind,
+            PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::ExceedsFeeCap { .. })
+        ));
+        let tx = pool.get(transaction.hash());
+        assert!(tx.is_none());
+    }
+
+    #[tokio::test]
+    async fn valid_on_zero_fee_cap() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+            .set_tx_fee_cap(0) // no cap
+            .build(blob_store);
+
+        let outcome = validator.validate_one(TransactionOrigin::Local, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_normal_fee_cap() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+            .set_tx_fee_cap(2e18 as u128) // 2 ETH cap
+            .build(blob_store);
+
+        let outcome = validator.validate_one(TransactionOrigin::Local, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn invalid_on_max_tx_gas_limit_exceeded() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+            .with_max_tx_gas_limit(Some(500_000)) // Set limit lower than transaction gas limit (1_015_288)
+            .build(blob_store.clone());
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
+        assert!(outcome.is_invalid());
+
+        let pool =
+            Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, Default::default());
+
+        let res = pool.add_external_transaction(transaction.clone()).await;
+        assert!(res.is_err());
+        assert!(matches!(
+            res.unwrap_err().kind,
+            PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::MaxTxGasLimitExceeded(
+                1_015_288, 500_000
+            ))
+        ));
+        let tx = pool.get(transaction.hash());
+        assert!(tx.is_none());
+    }
+
+    #[tokio::test]
+    async fn valid_on_max_tx_gas_limit_disabled() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+            .with_max_tx_gas_limit(None) // disabled
+            .build(blob_store);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_max_tx_gas_limit_within_limit() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+            .with_max_tx_gas_limit(Some(2_000_000)) // Set limit higher than transaction gas limit (1_015_288)
+            .build(blob_store);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    // Helper function to set up common test infrastructure for priority fee tests
+    fn setup_priority_fee_test() -> (EthPooledTransaction, MockEthProvider) {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+        (transaction, provider)
+    }
+
+    // Helper function to create a validator with minimum priority fee
+    fn create_validator_with_minimum_fee(
+        provider: MockEthProvider,
+        minimum_priority_fee: Option<u128>,
+        local_config: Option<LocalTransactionConfig>,
+    ) -> EthTransactionValidator<MockEthProvider, EthPooledTransaction, EthEvmConfig> {
+        let blob_store = InMemoryBlobStore::default();
+        let mut builder = EthTransactionValidatorBuilder::new(provider, test_evm_config())
+            .with_minimum_priority_fee(minimum_priority_fee);
+
+        if let Some(config) = local_config {
+            builder = builder.with_local_transactions_config(config);
+        }
+
+        builder.build(blob_store)
+    }
+
+    #[tokio::test]
+    async fn invalid_on_priority_fee_lower_than_configured_minimum() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Verify the test transaction is a dynamic fee transaction
+        assert!(transaction.is_dynamic_fee());
+
+        // Set minimum priority fee to be double the transaction's priority fee
+        let minimum_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
+
+        let validator =
+            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+
+        // External transaction should be rejected due to low priority fee
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
+        assert!(outcome.is_invalid());
+
+        if let TransactionValidationOutcome::Invalid(_, err) = outcome {
+            assert!(matches!(
+                err,
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum { minimum_priority_fee: min_fee }
+                if min_fee == minimum_priority_fee
+            ));
+        }
+
+        // Test pool integration
+        let blob_store = InMemoryBlobStore::default();
+        let pool =
+            Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, Default::default());
+
+        let res = pool.add_external_transaction(transaction.clone()).await;
+        assert!(res.is_err());
+        assert!(matches!(
+            res.unwrap_err().kind,
+            PoolErrorKind::InvalidTransaction(
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum { .. }
+            )
+        ));
+        let tx = pool.get(transaction.hash());
+        assert!(tx.is_none());
+
+        // Local transactions should still be accepted regardless of minimum priority fee
+        let (_, local_provider) = setup_priority_fee_test();
+        let validator_local =
+            create_validator_with_minimum_fee(local_provider, Some(minimum_priority_fee), None);
+
+        let local_outcome = validator_local.validate_one(TransactionOrigin::Local, transaction);
+        assert!(local_outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_priority_fee_equal_to_minimum() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee equal to transaction's priority fee
+        let tx_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected");
+        let validator = create_validator_with_minimum_fee(provider, Some(tx_priority_fee), None);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_priority_fee_above_minimum() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee below transaction's priority fee
+        let tx_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected");
+        let minimum_priority_fee = tx_priority_fee / 2; // Half of transaction's priority fee
+
+        let validator =
+            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_minimum_priority_fee_disabled() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // No minimum priority fee set (default is None)
+        let validator = create_validator_with_minimum_fee(provider, None, None);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn priority_fee_validation_applies_to_private_transactions() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee to be double the transaction's priority fee
+        let minimum_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
+
+        let validator =
+            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+
+        // Private transactions are also subject to minimum priority fee validation
+        // because they are not considered "local" by default unless specifically configured
+        let outcome = validator.validate_one(TransactionOrigin::Private, transaction);
+        assert!(outcome.is_invalid());
+
+        if let TransactionValidationOutcome::Invalid(_, err) = outcome {
+            assert!(matches!(
+                err,
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum { minimum_priority_fee: min_fee }
+                if min_fee == minimum_priority_fee
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_on_local_config_exempts_private_transactions() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee to be double the transaction's priority fee
+        let minimum_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
+
+        // Configure local transactions to include all private transactions
+        let local_config =
+            LocalTransactionConfig { propagate_local_transactions: true, ..Default::default() };
+
+        let validator = create_validator_with_minimum_fee(
+            provider,
+            Some(minimum_priority_fee),
+            Some(local_config),
+        );
+
+        // With appropriate local config, the behavior depends on the local transaction logic
+        // This test documents the current behavior - private transactions are still validated
+        // unless the sender is specifically whitelisted in local_transactions_config
+        let outcome = validator.validate_one(TransactionOrigin::Private, transaction);
+        assert!(outcome.is_invalid()); // Still invalid because sender not in whitelist
+    }
+
+    #[test]
+    fn reject_oversized_tx() {
+        let mut transaction = get_transaction();
+        transaction.encoded_length = DEFAULT_MAX_TX_INPUT_BYTES + 1;
+        let provider = MockEthProvider::default().with_genesis_block();
+
+        // No minimum priority fee set (default is None)
+        let validator = create_validator_with_minimum_fee(provider, None, None);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        let invalid = outcome.as_invalid().unwrap();
+        assert!(invalid.is_oversized());
+    }
+
+    #[tokio::test]
+    async fn valid_with_disabled_balance_check() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+
+        // Set account with 0 balance
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), alloy_primitives::U256::ZERO),
+        );
+
+        // Validate with balance check enabled
+        let validator =
+            EthTransactionValidatorBuilder::new(provider.clone(), EthEvmConfig::mainnet())
+                .build(InMemoryBlobStore::default());
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
+        let expected_cost = *transaction.cost();
+        if let TransactionValidationOutcome::Invalid(_, err) = outcome {
+            assert!(matches!(
+                err,
+                InvalidPoolTransactionError::Consensus(InvalidTransactionError::InsufficientFunds(ref funds_err))
+                if funds_err.got == alloy_primitives::U256::ZERO && funds_err.expected == expected_cost
+            ));
+        } else {
+            panic!("Expected Invalid outcome with InsufficientFunds error");
+        }
+
+        // Validate with balance check disabled
+        let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+            .disable_balance_check()
+            .build(InMemoryBlobStore::default());
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid()); // Should be valid because balance check is disabled
+    }
+}

--- a/patches/reth-transaction-pool/src/validate/mod.rs
+++ b/patches/reth-transaction-pool/src/validate/mod.rs
@@ -1,0 +1,532 @@
+//! Transaction validation abstractions.
+
+use crate::{
+    error::InvalidPoolTransactionError,
+    identifier::{SenderId, TransactionId},
+    traits::{PoolTransaction, TransactionOrigin},
+    PriceBumpConfig,
+};
+use alloy_eips::{eip7594::BlobTransactionSidecarVariant, eip7702::SignedAuthorization};
+use alloy_primitives::{Address, TxHash, B256, U256};
+use futures_util::future::Either;
+use reth_primitives_traits::{Block, Recovered, SealedBlock};
+use std::{fmt, fmt::Debug, future::Future, time::Instant};
+
+mod constants;
+mod eth;
+mod task;
+
+pub use eth::*;
+
+pub use task::{TransactionValidationTaskExecutor, ValidationTask};
+
+/// Validation constants.
+pub use constants::{DEFAULT_MAX_TX_INPUT_BYTES, TX_SLOT_BYTE_SIZE};
+
+/// A Result type returned after checking a transaction's validity.
+#[derive(Debug)]
+pub enum TransactionValidationOutcome<T: PoolTransaction> {
+    /// The transaction is considered _currently_ valid and can be inserted into the pool.
+    Valid {
+        /// Balance of the sender at the current point.
+        balance: U256,
+        /// Current nonce of the sender.
+        state_nonce: u64,
+        /// Code hash of the sender.
+        bytecode_hash: Option<B256>,
+        /// The validated transaction.
+        ///
+        /// See also [`ValidTransaction`].
+        ///
+        /// If this is a _new_ EIP-4844 blob transaction, then this must contain the extracted
+        /// sidecar.
+        transaction: ValidTransaction<T>,
+        /// Whether to propagate the transaction to the network.
+        propagate: bool,
+        /// The authorities of EIP-7702 transaction.
+        authorities: Option<Vec<Address>>,
+    },
+    /// The transaction is considered invalid indefinitely: It violates constraints that prevent
+    /// this transaction from ever becoming valid.
+    Invalid(T, InvalidPoolTransactionError),
+    /// An error occurred while trying to validate the transaction
+    Error(TxHash, Box<dyn core::error::Error + Send + Sync>),
+}
+
+impl<T: PoolTransaction> TransactionValidationOutcome<T> {
+    /// Returns the hash of the transactions
+    pub fn tx_hash(&self) -> TxHash {
+        match self {
+            Self::Valid { transaction, .. } => *transaction.hash(),
+            Self::Invalid(transaction, ..) => *transaction.hash(),
+            Self::Error(hash, ..) => *hash,
+        }
+    }
+
+    /// Returns the [`InvalidPoolTransactionError`] if this is an invalid variant.
+    pub const fn as_invalid(&self) -> Option<&InvalidPoolTransactionError> {
+        match self {
+            Self::Invalid(_, err) => Some(err),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`ValidTransaction`] if this is a [`TransactionValidationOutcome::Valid`].
+    pub const fn as_valid_transaction(&self) -> Option<&ValidTransaction<T>> {
+        match self {
+            Self::Valid { transaction, .. } => Some(transaction),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the transaction is valid.
+    pub const fn is_valid(&self) -> bool {
+        matches!(self, Self::Valid { .. })
+    }
+
+    /// Returns true if the transaction is invalid.
+    pub const fn is_invalid(&self) -> bool {
+        matches!(self, Self::Invalid(_, _))
+    }
+
+    /// Returns true if validation resulted in an error.
+    pub const fn is_error(&self) -> bool {
+        matches!(self, Self::Error(_, _))
+    }
+}
+
+/// A wrapper type for a transaction that is valid and has an optional extracted EIP-4844 blob
+/// transaction sidecar.
+///
+/// If this is provided, then the sidecar will be temporarily stored in the blob store until the
+/// transaction is finalized.
+///
+/// Note: Since blob transactions can be re-injected without their sidecar (after reorg), the
+/// validator can omit the sidecar if it is still in the blob store and return a
+/// [`ValidTransaction::Valid`] instead.
+#[derive(Debug)]
+pub enum ValidTransaction<T> {
+    /// A valid transaction without a sidecar.
+    Valid(T),
+    /// A valid transaction for which a sidecar should be stored.
+    ///
+    /// Caution: The [`TransactionValidator`] must ensure that this is only returned for EIP-4844
+    /// transactions.
+    ValidWithSidecar {
+        /// The valid EIP-4844 transaction.
+        transaction: T,
+        /// The extracted sidecar of that transaction
+        sidecar: BlobTransactionSidecarVariant,
+    },
+}
+
+impl<T> ValidTransaction<T> {
+    /// Creates a new valid transaction with an optional sidecar.
+    pub fn new(transaction: T, sidecar: Option<BlobTransactionSidecarVariant>) -> Self {
+        if let Some(sidecar) = sidecar {
+            Self::ValidWithSidecar { transaction, sidecar }
+        } else {
+            Self::Valid(transaction)
+        }
+    }
+}
+
+impl<T: PoolTransaction> ValidTransaction<T> {
+    /// Returns the transaction.
+    #[inline]
+    pub const fn transaction(&self) -> &T {
+        match self {
+            Self::Valid(transaction) | Self::ValidWithSidecar { transaction, .. } => transaction,
+        }
+    }
+
+    /// Consumes the wrapper and returns the transaction.
+    pub fn into_transaction(self) -> T {
+        match self {
+            Self::Valid(transaction) | Self::ValidWithSidecar { transaction, .. } => transaction,
+        }
+    }
+
+    /// Returns the address of that transaction.
+    #[inline]
+    pub(crate) fn sender(&self) -> Address {
+        self.transaction().sender()
+    }
+
+    /// Returns the hash of the transaction.
+    #[inline]
+    pub fn hash(&self) -> &B256 {
+        self.transaction().hash()
+    }
+
+    /// Returns the nonce of the transaction.
+    #[inline]
+    pub fn nonce(&self) -> u64 {
+        self.transaction().nonce()
+    }
+}
+
+/// Provides support for validating transaction at any given state of the chain
+pub trait TransactionValidator: Debug + Send + Sync {
+    /// The transaction type to validate.
+    type Transaction: PoolTransaction;
+
+    /// The block type used for new head block notifications.
+    type Block: Block;
+
+    /// Validates the transaction and returns a [`TransactionValidationOutcome`] describing the
+    /// validity of the given transaction.
+    ///
+    /// This will be used by the transaction-pool to check whether the transaction should be
+    /// inserted into the pool or discarded right away.
+    ///
+    /// Implementers of this trait must ensure that the transaction is well-formed, i.e. that it
+    /// complies at least all static constraints, which includes checking for:
+    ///
+    ///    * chain id
+    ///    * gas limit
+    ///    * max cost
+    ///    * nonce >= next nonce of the sender
+    ///    * ...
+    ///
+    /// See [`InvalidTransactionError`](reth_primitives_traits::transaction::error::InvalidTransactionError) for common
+    /// errors variants.
+    ///
+    /// The transaction pool makes no additional assumptions about the validity of the transaction
+    /// at the time of this call before it inserts it into the pool. However, the validity of
+    /// this transaction is still subject to future (dynamic) changes enforced by the pool, for
+    /// example nonce or balance changes. Hence, any validation checks must be applied in this
+    /// function.
+    ///
+    /// See [`TransactionValidationTaskExecutor`] for a reference implementation.
+    fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> impl Future<Output = TransactionValidationOutcome<Self::Transaction>> + Send;
+
+    /// Validates a batch of transactions.
+    ///
+    /// Must return all outcomes for the given transactions in the same order.
+    ///
+    /// See also [`Self::validate_transaction`].
+    fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+            + Send,
+    ) -> impl Future<Output = Vec<TransactionValidationOutcome<Self::Transaction>>> + Send {
+        futures_util::future::join_all(
+            transactions.into_iter().map(|(origin, tx)| self.validate_transaction(origin, tx)),
+        )
+    }
+
+    /// Validates a batch of transactions with that given origin.
+    ///
+    /// Must return all outcomes for the given transactions in the same order.
+    ///
+    /// See also [`Self::validate_transaction`].
+    fn validate_transactions_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+    ) -> impl Future<Output = Vec<TransactionValidationOutcome<Self::Transaction>>> + Send {
+        self.validate_transactions(transactions.into_iter().map(move |tx| (origin, tx)))
+    }
+
+    /// Invoked when the head block changes.
+    ///
+    /// This can be used to update fork specific values (timestamp).
+    fn on_new_head_block(&self, _new_tip_block: &SealedBlock<Self::Block>) {}
+}
+
+impl<A, B> TransactionValidator for Either<A, B>
+where
+    A: TransactionValidator,
+    B: TransactionValidator<Transaction = A::Transaction, Block = A::Block>,
+{
+    type Transaction = A::Transaction;
+    type Block = A::Block;
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        match self {
+            Self::Left(v) => v.validate_transaction(origin, transaction).await,
+            Self::Right(v) => v.validate_transaction(origin, transaction).await,
+        }
+    }
+
+    async fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+            + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        match self {
+            Self::Left(v) => v.validate_transactions(transactions).await,
+            Self::Right(v) => v.validate_transactions(transactions).await,
+        }
+    }
+
+    fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
+        match self {
+            Self::Left(v) => v.on_new_head_block(new_tip_block),
+            Self::Right(v) => v.on_new_head_block(new_tip_block),
+        }
+    }
+}
+
+/// A valid transaction in the pool.
+///
+/// This is used as the internal representation of a transaction inside the pool.
+///
+/// For EIP-4844 blob transactions this will _not_ contain the blob sidecar which is stored
+/// separately in the [`BlobStore`](crate::blobstore::BlobStore).
+pub struct ValidPoolTransaction<T: PoolTransaction> {
+    /// The transaction
+    pub transaction: T,
+    /// The identifier for this transaction.
+    pub transaction_id: TransactionId,
+    /// Whether it is allowed to propagate the transaction.
+    pub propagate: bool,
+    /// Timestamp when this was added to the pool.
+    pub timestamp: Instant,
+    /// Where this transaction originated from.
+    pub origin: TransactionOrigin,
+    /// The sender ids of the 7702 transaction authorities.
+    pub authority_ids: Option<Vec<SenderId>>,
+}
+
+// === impl ValidPoolTransaction ===
+
+impl<T: PoolTransaction> ValidPoolTransaction<T> {
+    /// Returns the hash of the transaction.
+    pub fn hash(&self) -> &TxHash {
+        self.transaction.hash()
+    }
+
+    /// Returns the type identifier of the transaction
+    pub fn tx_type(&self) -> u8 {
+        self.transaction.ty()
+    }
+
+    /// Returns the address of the sender
+    pub fn sender(&self) -> Address {
+        self.transaction.sender()
+    }
+
+    /// Returns a reference to the address of the sender
+    pub fn sender_ref(&self) -> &Address {
+        self.transaction.sender_ref()
+    }
+
+    /// Returns the recipient of the transaction if it is not a CREATE transaction.
+    pub fn to(&self) -> Option<Address> {
+        self.transaction.to()
+    }
+
+    /// Returns the internal identifier for the sender of this transaction
+    pub const fn sender_id(&self) -> SenderId {
+        self.transaction_id.sender
+    }
+
+    /// Returns the internal identifier for this transaction.
+    pub const fn id(&self) -> &TransactionId {
+        &self.transaction_id
+    }
+
+    /// Returns the length of the rlp encoded transaction
+    #[inline]
+    pub fn encoded_length(&self) -> usize {
+        self.transaction.encoded_length()
+    }
+
+    /// Returns the nonce set for this transaction.
+    pub fn nonce(&self) -> u64 {
+        self.transaction.nonce()
+    }
+
+    /// Returns the cost that this transaction is allowed to consume:
+    ///
+    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
+    /// For legacy transactions: `gas_price * gas_limit + tx_value`.
+    pub fn cost(&self) -> &U256 {
+        self.transaction.cost()
+    }
+
+    /// Extra balance beyond [`Self::cost`] the sender must have (e.g. OP fees). `[MANTLE PATCH]`
+    pub fn extra_balance_cost(&self) -> U256 {
+        self.transaction.extra_balance_cost()
+    }
+
+    /// Returns the EIP-4844 max blob fee the caller is willing to pay.
+    ///
+    /// For non-EIP-4844 transactions, this returns [None].
+    pub fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.transaction.max_fee_per_blob_gas()
+    }
+
+    /// Returns the EIP-1559 Max base fee the caller is willing to pay.
+    ///
+    /// For legacy transactions this is `gas_price`.
+    pub fn max_fee_per_gas(&self) -> u128 {
+        self.transaction.max_fee_per_gas()
+    }
+
+    /// Returns the EIP-1559 Max priority fee the caller is willing to pay, or `None` for
+    /// non-EIP-1559 transactions.
+    pub fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.transaction.max_priority_fee_per_gas()
+    }
+
+    /// Returns the effective tip for this transaction.
+    ///
+    /// For EIP-1559 transactions: `min(max_fee_per_gas - base_fee, max_priority_fee_per_gas)`.
+    /// For legacy transactions: `gas_price - base_fee`.
+    pub fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
+        self.transaction.effective_tip_per_gas(base_fee)
+    }
+
+    /// Returns the max priority fee per gas if the transaction is an EIP-1559 transaction, and
+    /// otherwise returns the gas price.
+    pub fn priority_fee_or_price(&self) -> u128 {
+        self.transaction.priority_fee_or_price()
+    }
+
+    /// Maximum amount of gas that the transaction is allowed to consume.
+    pub fn gas_limit(&self) -> u64 {
+        self.transaction.gas_limit()
+    }
+
+    /// Whether the transaction originated locally.
+    pub const fn is_local(&self) -> bool {
+        self.origin.is_local()
+    }
+
+    /// Whether the transaction is an EIP-4844 blob transaction.
+    #[inline]
+    pub fn is_eip4844(&self) -> bool {
+        self.transaction.is_eip4844()
+    }
+
+    /// The heap allocated size of this transaction.
+    pub(crate) fn size(&self) -> usize {
+        self.transaction.size()
+    }
+
+    /// Returns the [`SignedAuthorization`] list of the transaction.
+    ///
+    /// Returns `None` if this transaction is not EIP-7702.
+    pub fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.transaction.authorization_list()
+    }
+
+    /// Returns the number of blobs of [`SignedAuthorization`] in this transactions
+    ///
+    /// This is convenience function for `len(authorization_list)`.
+    ///
+    /// Returns `None` for non-eip7702 transactions.
+    pub fn authorization_count(&self) -> Option<u64> {
+        self.transaction.authorization_count()
+    }
+
+    /// EIP-4844 blob transactions and normal transactions are treated as mutually exclusive per
+    /// account.
+    ///
+    /// Returns true if the transaction is an EIP-4844 blob transaction and the other is not, or
+    /// vice versa.
+    #[inline]
+    pub(crate) fn tx_type_conflicts_with(&self, other: &Self) -> bool {
+        self.is_eip4844() != other.is_eip4844()
+    }
+
+    /// Converts to this type into the consensus transaction of the pooled transaction.
+    ///
+    /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
+    pub fn to_consensus(&self) -> Recovered<T::Consensus> {
+        self.transaction.clone_into_consensus()
+    }
+
+    /// Determines whether a candidate transaction (`maybe_replacement`) is underpriced compared to
+    /// an existing transaction in the pool.
+    ///
+    /// A transaction is considered underpriced if it doesn't meet the required fee bump threshold.
+    /// This applies to both standard gas fees and, for blob-carrying transactions (EIP-4844),
+    /// the blob-specific fees.
+    #[inline]
+    pub fn is_underpriced(&self, maybe_replacement: &Self, price_bumps: &PriceBumpConfig) -> bool {
+        // Retrieve the required price bump percentage for this type of transaction.
+        //
+        // The bump is different for EIP-4844 and other transactions. See `PriceBumpConfig`.
+        let price_bump = price_bumps.price_bump(self.tx_type());
+        let required_bumped_fee =
+            |existing_fee: u128| existing_fee.saturating_mul(100 + price_bump).div_ceil(100);
+
+        // Check if the max fee per gas is underpriced.
+        if maybe_replacement.max_fee_per_gas() < required_bumped_fee(self.max_fee_per_gas()) {
+            return true
+        }
+
+        let existing_max_priority_fee_per_gas =
+            self.transaction.max_priority_fee_per_gas().unwrap_or_default();
+        let replacement_max_priority_fee_per_gas =
+            maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or_default();
+
+        // Check max priority fee per gas (relevant for EIP-1559 transactions only)
+        if existing_max_priority_fee_per_gas != 0 &&
+            replacement_max_priority_fee_per_gas != 0 &&
+            replacement_max_priority_fee_per_gas <
+                required_bumped_fee(existing_max_priority_fee_per_gas)
+        {
+            return true
+        }
+
+        // Check max blob fee per gas
+        if let Some(existing_max_blob_fee_per_gas) = self.transaction.max_fee_per_blob_gas() {
+            // This enforces that blob txs can only be replaced by blob txs
+            let replacement_max_blob_fee_per_gas =
+                maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or_default();
+            if replacement_max_blob_fee_per_gas < required_bumped_fee(existing_max_blob_fee_per_gas)
+            {
+                return true
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+impl<T: PoolTransaction> Clone for ValidPoolTransaction<T> {
+    fn clone(&self) -> Self {
+        Self {
+            transaction: self.transaction.clone(),
+            transaction_id: self.transaction_id,
+            propagate: self.propagate,
+            timestamp: self.timestamp,
+            origin: self.origin,
+            authority_ids: self.authority_ids.clone(),
+        }
+    }
+}
+
+impl<T: PoolTransaction> fmt::Debug for ValidPoolTransaction<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ValidPoolTransaction")
+            .field("id", &self.transaction_id)
+            .field("propagate", &self.propagate)
+            .field("origin", &self.origin)
+            .field("hash", self.transaction.hash())
+            .field("tx", &self.transaction)
+            .finish()
+    }
+}
+
+/// Validation Errors that can occur during transaction validation.
+#[derive(thiserror::Error, Debug)]
+pub enum TransactionValidatorError {
+    /// Failed to communicate with the validation service.
+    #[error("validation service unreachable")]
+    ValidationServiceUnreachable,
+}

--- a/patches/reth-transaction-pool/src/validate/task.rs
+++ b/patches/reth-transaction-pool/src/validate/task.rs
@@ -1,0 +1,380 @@
+//! A validation service for transactions.
+
+use crate::{
+    blobstore::BlobStore,
+    metrics::TxPoolValidatorMetrics,
+    validate::{EthTransactionValidatorBuilder, TransactionValidatorError},
+    EthTransactionValidator, PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
+    TransactionValidator,
+};
+use futures_util::{lock::Mutex, StreamExt};
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_evm::ConfigureEvm;
+use reth_primitives_traits::{HeaderTy, SealedBlock};
+use reth_storage_api::BlockReaderIdExt;
+use reth_tasks::Runtime;
+use std::{future::Future, pin::Pin, sync::Arc};
+use tokio::{
+    sync,
+    sync::{mpsc, oneshot},
+};
+use tokio_stream::wrappers::ReceiverStream;
+
+/// Represents a future outputting unit type and is sendable.
+type ValidationFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Represents a stream of validation futures.
+type ValidationStream = ReceiverStream<ValidationFuture>;
+
+/// A service that performs validation jobs.
+///
+/// This listens for incoming validation jobs and executes them.
+///
+/// This should be spawned as a task: [`ValidationTask::run`]
+#[derive(Clone)]
+pub struct ValidationTask {
+    validation_jobs: Arc<Mutex<ValidationStream>>,
+}
+
+impl ValidationTask {
+    /// Creates a new cloneable task pair.
+    ///
+    /// The sender sends new (transaction) validation tasks to an available validation task.
+    pub fn new() -> (ValidationJobSender, Self) {
+        Self::with_capacity(1)
+    }
+
+    /// Creates a new cloneable task pair with the given channel capacity.
+    pub fn with_capacity(capacity: usize) -> (ValidationJobSender, Self) {
+        let (tx, rx) = mpsc::channel(capacity);
+        let metrics = TxPoolValidatorMetrics::default();
+        (ValidationJobSender { tx, metrics }, Self::with_receiver(rx))
+    }
+
+    /// Creates a new task with the given receiver.
+    pub fn with_receiver(jobs: mpsc::Receiver<Pin<Box<dyn Future<Output = ()> + Send>>>) -> Self {
+        Self { validation_jobs: Arc::new(Mutex::new(ReceiverStream::new(jobs))) }
+    }
+
+    /// Executes all new validation jobs that come in.
+    ///
+    /// This will run as long as the channel is alive and is expected to be spawned as a task.
+    pub async fn run(self) {
+        while let Some(task) = self.validation_jobs.lock().await.next().await {
+            task.await;
+        }
+    }
+}
+
+impl std::fmt::Debug for ValidationTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ValidationTask").field("validation_jobs", &"...").finish()
+    }
+}
+
+/// A sender new type for sending validation jobs to [`ValidationTask`].
+#[derive(Debug)]
+pub struct ValidationJobSender {
+    tx: mpsc::Sender<Pin<Box<dyn Future<Output = ()> + Send>>>,
+    metrics: TxPoolValidatorMetrics,
+}
+
+impl ValidationJobSender {
+    /// Sends the given job to the validation task.
+    pub async fn send(
+        &self,
+        job: Pin<Box<dyn Future<Output = ()> + Send>>,
+    ) -> Result<(), TransactionValidatorError> {
+        self.metrics.inflight_validation_jobs.increment(1);
+        let res = self
+            .tx
+            .send(job)
+            .await
+            .map_err(|_| TransactionValidatorError::ValidationServiceUnreachable);
+        self.metrics.inflight_validation_jobs.decrement(1);
+        res
+    }
+}
+
+/// A [`TransactionValidator`] implementation that validates ethereum transaction.
+/// This validator is non-blocking, all validation work is done in a separate task.
+#[derive(Debug)]
+pub struct TransactionValidationTaskExecutor<V> {
+    /// The validator that will validate transactions on a separate task.
+    pub validator: Arc<V>,
+    /// The sender half to validation tasks that perform the actual validation.
+    pub to_validation_task: Arc<sync::Mutex<ValidationJobSender>>,
+}
+
+impl<V> Clone for TransactionValidationTaskExecutor<V> {
+    fn clone(&self) -> Self {
+        Self {
+            validator: self.validator.clone(),
+            to_validation_task: self.to_validation_task.clone(),
+        }
+    }
+}
+
+// === impl TransactionValidationTaskExecutor ===
+
+impl TransactionValidationTaskExecutor<()> {
+    /// Convenience method to create a [`EthTransactionValidatorBuilder`]
+    pub fn eth_builder<Client, Evm>(
+        client: Client,
+        evm_config: Evm,
+    ) -> EthTransactionValidatorBuilder<Client, Evm>
+    where
+        Client: ChainSpecProvider<ChainSpec: EthereumHardforks>
+            + BlockReaderIdExt<Header = HeaderTy<Evm::Primitives>>,
+        Evm: ConfigureEvm,
+    {
+        EthTransactionValidatorBuilder::new(client, evm_config)
+    }
+}
+
+impl<V> TransactionValidationTaskExecutor<V> {
+    /// Maps the given validator to a new type.
+    pub fn map<F, T>(self, mut f: F) -> TransactionValidationTaskExecutor<T>
+    where
+        F: FnMut(V) -> T,
+    {
+        TransactionValidationTaskExecutor {
+            validator: Arc::new(f(Arc::into_inner(self.validator).unwrap())),
+            to_validation_task: self.to_validation_task,
+        }
+    }
+
+    /// Returns the validator.
+    pub fn validator(&self) -> &V {
+        &self.validator
+    }
+}
+
+impl<Client, Tx, Evm> TransactionValidationTaskExecutor<EthTransactionValidator<Client, Tx, Evm>> {
+    /// Creates a new instance for the given client
+    ///
+    /// This will spawn a single validation tasks that performs the actual validation.
+    /// See [`TransactionValidationTaskExecutor::eth_with_additional_tasks`]
+    pub fn eth<S: BlobStore>(client: Client, evm_config: Evm, blob_store: S, tasks: Runtime) -> Self
+    where
+        Client: ChainSpecProvider<ChainSpec: EthereumHardforks>
+            + BlockReaderIdExt<Header = HeaderTy<Evm::Primitives>>,
+        Evm: ConfigureEvm,
+    {
+        Self::eth_with_additional_tasks(client, evm_config, blob_store, tasks, 0)
+    }
+
+    /// Creates a new instance for the given client
+    ///
+    /// By default this will enable support for:
+    ///   - shanghai
+    ///   - eip1559
+    ///   - eip2930
+    ///
+    /// This will always spawn a validation task that performs the actual validation. It will spawn
+    /// `num_additional_tasks` additional tasks.
+    pub fn eth_with_additional_tasks<S: BlobStore>(
+        client: Client,
+        evm_config: Evm,
+        blob_store: S,
+        tasks: Runtime,
+        num_additional_tasks: usize,
+    ) -> Self
+    where
+        Client: ChainSpecProvider<ChainSpec: EthereumHardforks>
+            + BlockReaderIdExt<Header = HeaderTy<Evm::Primitives>>,
+        Evm: ConfigureEvm,
+    {
+        EthTransactionValidatorBuilder::new(client, evm_config)
+            .with_additional_tasks(num_additional_tasks)
+            .build_with_tasks(tasks, blob_store)
+    }
+}
+
+impl<V> TransactionValidationTaskExecutor<V> {
+    /// Creates a new executor instance with the given validator for transaction validation.
+    ///
+    /// Initializes the executor with the provided validator and sets up communication for
+    /// validation tasks.
+    pub fn new(validator: V) -> (Self, ValidationTask) {
+        let (tx, task) = ValidationTask::new();
+        (
+            Self {
+                validator: Arc::new(validator),
+                to_validation_task: Arc::new(sync::Mutex::new(tx)),
+            },
+            task,
+        )
+    }
+
+    /// Creates a new executor and spawns the validation tasks on the given runtime.
+    ///
+    /// This spawns `additional_tasks` extra blocking tasks plus one critical blocking task
+    /// for the validation service.
+    pub fn spawn(validator: V, tasks: &Runtime, additional_tasks: usize) -> Self {
+        let (tx, task) = ValidationTask::new();
+
+        for _ in 0..additional_tasks {
+            let task = task.clone();
+            tasks.spawn_blocking_task(async move {
+                task.run().await;
+            });
+        }
+
+        tasks.spawn_critical_blocking_task("transaction-validation-service", async move {
+            task.run().await;
+        });
+
+        Self { validator: Arc::new(validator), to_validation_task: Arc::new(sync::Mutex::new(tx)) }
+    }
+}
+
+impl<V> TransactionValidator for TransactionValidationTaskExecutor<V>
+where
+    V: TransactionValidator + 'static,
+{
+    type Transaction = <V as TransactionValidator>::Transaction;
+    type Block = V::Block;
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        let hash = *transaction.hash();
+        let (tx, rx) = oneshot::channel();
+        {
+            let res = {
+                let to_validation_task = self.to_validation_task.clone();
+                let validator = self.validator.clone();
+                let fut = Box::pin(async move {
+                    let res = validator.validate_transaction(origin, transaction).await;
+                    let _ = tx.send(res);
+                });
+                let to_validation_task = to_validation_task.lock().await;
+                to_validation_task.send(fut).await
+            };
+            if res.is_err() {
+                return TransactionValidationOutcome::Error(
+                    hash,
+                    Box::new(TransactionValidatorError::ValidationServiceUnreachable),
+                );
+            }
+        }
+
+        match rx.await {
+            Ok(res) => res,
+            Err(_) => TransactionValidationOutcome::Error(
+                hash,
+                Box::new(TransactionValidatorError::ValidationServiceUnreachable),
+            ),
+        }
+    }
+
+    async fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+            + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        let transactions: Vec<_> = transactions.into_iter().collect();
+        let hashes: Vec<_> = transactions.iter().map(|(_, tx)| *tx.hash()).collect();
+        let (tx, rx) = oneshot::channel();
+        {
+            let res = {
+                let to_validation_task = self.to_validation_task.clone();
+                let validator = self.validator.clone();
+                let fut = Box::pin(async move {
+                    let res = validator.validate_transactions(transactions).await;
+                    let _ = tx.send(res);
+                });
+                let to_validation_task = to_validation_task.lock().await;
+                to_validation_task.send(fut).await
+            };
+            if res.is_err() {
+                return hashes
+                    .into_iter()
+                    .map(|hash| {
+                        TransactionValidationOutcome::Error(
+                            hash,
+                            Box::new(TransactionValidatorError::ValidationServiceUnreachable),
+                        )
+                    })
+                    .collect();
+            }
+        }
+        match rx.await {
+            Ok(res) => res,
+            Err(_) => hashes
+                .into_iter()
+                .map(|hash| {
+                    TransactionValidationOutcome::Error(
+                        hash,
+                        Box::new(TransactionValidatorError::ValidationServiceUnreachable),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
+        self.validator.on_new_head_block(new_tip_block)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_utils::MockTransaction,
+        validate::{TransactionValidationOutcome, ValidTransaction},
+        TransactionOrigin,
+    };
+    use alloy_primitives::{Address, U256};
+
+    #[derive(Debug)]
+    struct NoopValidator;
+
+    impl TransactionValidator for NoopValidator {
+        type Transaction = MockTransaction;
+        type Block = reth_ethereum_primitives::Block;
+
+        async fn validate_transaction(
+            &self,
+            _origin: TransactionOrigin,
+            transaction: Self::Transaction,
+        ) -> TransactionValidationOutcome<Self::Transaction> {
+            TransactionValidationOutcome::Valid {
+                balance: U256::ZERO,
+                state_nonce: 0,
+                bytecode_hash: None,
+                transaction: ValidTransaction::Valid(transaction),
+                propagate: false,
+                authorities: Some(Vec::<Address>::new()),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_new_spawns_and_validates_single() {
+        let validator = NoopValidator;
+        let (executor, task) = TransactionValidationTaskExecutor::new(validator);
+        tokio::spawn(task.run());
+        let tx = MockTransaction::legacy();
+        let out = executor.validate_transaction(TransactionOrigin::External, tx).await;
+        assert!(matches!(out, TransactionValidationOutcome::Valid { .. }));
+    }
+
+    #[tokio::test]
+    async fn executor_new_spawns_and_validates_batch() {
+        let validator = NoopValidator;
+        let (executor, task) = TransactionValidationTaskExecutor::new(validator);
+        tokio::spawn(task.run());
+        let txs = vec![
+            (TransactionOrigin::External, MockTransaction::legacy()),
+            (TransactionOrigin::Local, MockTransaction::legacy()),
+        ];
+        let out = executor.validate_transactions(txs).await;
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|o| matches!(o, TransactionValidationOutcome::Valid { .. })));
+    }
+}


### PR DESCRIPTION
## Problem

The pool's balance/affordability accounting — both the single-tx checks and the **cumulative** pending-balance gating (`PoolInternalTransaction::next_cumulative_cost`) — uses only the intrinsic `PoolTransaction::cost()` (`gas*max_fee + value (+blob)`). That omits the OP **L1 data fee + operator fee**, so multiple pending txs from one sender can be admitted/kept even when the account can't afford them all.

#84 fixed the single-tx admission gate; this PR covers the **cumulative / on-new-block maintenance** path.

`cost()` is intentionally the intrinsic cost (its trait doc), and L1/operator are an OP overlay — so the fix is a generic hook, not a change to `cost()`.

## Change

**reth-core (via `patches/reth-transaction-pool`)** — the `[patch."…/paradigmxyz/reth"]` slot already reserved a `reth-transaction-pool` line:
- Add `PoolTransaction::extra_balance_cost(&self) -> U256` (default `0`) + a `ValidPoolTransaction::extra_balance_cost()` passthrough.
- Add it wherever the pool gates on balance: `next_cumulative_cost` (root of cumulative accounting), the single-tx check, the blob overdraft checks, and `EthTransactionValidator::validate_sender_balance`. `cost()` is untouched, so fee-cap and ordering are unaffected.

**op-reth** — `OpPooledTransaction` stores the overlay (`extra_balance_cost` field + `OpPooledTx::set_extra_balance_cost`), and the validator stashes the L1+operator `cost_addition` it already computes (from #84), so the pool reserves it in cumulative accounting.

Adds the 4 transitive deps the vendored crate needs (`bitflags`, `imbl`, `rustc-hash`, `smallvec`) to the workspace.

## Scope / safety

Pool-admission only — no block-validation / state-root / execution change → no consensus impact. Sequencer-only.

## Temporary bridge

The vendored `patches/reth-transaction-pool` is a bridge until the generic hook lands upstream (paradigmxyz/reth). Once released, drop the patch and implement the trait method directly. Only 4 files diverge from upstream (`traits.rs`, `pool/txpool.rs`, `validate/eth.rs`, `validate/mod.rs`); re-sync those on each reth bump.

## Tests

`just pr` green. op-reth `extra_balance_cost` roundtrip unit test; existing pool tests pass (the `+ extra_balance_cost()` term is `+0` for non-OP txs → no regression). A full-node cumulative integration test is deferred (same as #84's operator-fee integration test).

## Related

Builds on #84 (single-tx operator fee). Upstream tracking: ethereum-optimism/optimism#21608/#21609; the generic reth-core hook will be proposed to paradigmxyz/reth (B4).