### PR TITLE
chore(deps): bump revm-inspectors to include geth bigInt JS-tracer fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10356,7 +10356,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.39.0"
-source = "git+https://github.com/mantle-xyz/revm-inspectors?branch=mantle-elysium#af522533cc11313b25052d3149e85b12d81f98fc"
+source = "git+https://github.com/mantle-xyz/revm-inspectors?branch=mantle-elysium#e635cd090d616a4415ce8dbe35f4f9478c9304f5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",


### PR DESCRIPTION
## What

Bumps the `revm-inspectors` pin (branch `mantle-elysium`) in `Cargo.lock`:

```
af522533 -> e635cd09
```

`e635cd09` is the merge of mantle-xyz/revm-inspectors#11, which cherry-picks upstream paradigmxyz/revm-inspectors#443 (geth BigInteger.js polyfill compatibility shims) onto the 0.39 line.

## Why

op-reth on the v2.2.1 line (e.g. sepolia-qa4, `mantle-op-reth-rpc42/43`) throws `ReferenceError: bigInt is not defined` when a geth-style JS tracer references the camelCase `bigInt` global. The pinned `revm-inspectors@af522533` only registered the lowercase `bigint` alias.

Reproduced live on sepolia-qa4:

| global in tracer | before | after (this bump) |
|---|---|---|
| lowercase `bigint(0)` | ✅ `"0"` | ✅ `"0"` |
| camelCase `bigInt(0)` | ❌ `ReferenceError: bigInt is not defined` | ✅ (fixed) |

## Scope

Single-line `Cargo.lock` change — only the `revm-inspectors` git rev moves. The `revm` family stays pinned at `b4f61822` (the JS-tracer fix touches only `builtins.rs`, no dependency changes). Verified with `cargo tree --locked`.

## Note

The v2.3.3 migration line already moves `revm-inspectors` to crates.io `0.40.1` (which contains #443), so this bump is specific to the v2.2.1 `mantle-elysium` line to fix it now.