### PR TITLE
style: rustfmt txpool doc comment (nightly fmt drift)

### DIFF
--- a/mantle-reth/crates/cli/src/txpool.rs
+++ b/mantle-reth/crates/cli/src/txpool.rs
@@ -51,8 +51,8 @@ impl reth_transaction_pool::error::PoolTransactionError for UnprotectedTxDisable
 ///
 /// - EIP-155 unprotected legacy transactions (type 0 without `chain_id`)
 /// - Legacy `MetaTx` transactions (disabled since `MantleEverest`)
-/// - Transactions whose max fee (`gas_limit * max_fee_per_gas`) exceeds the configured
-///   RPC tx fee cap (`--rpc.txfeecap`), matching op-geth's `RPCTxFeeCap` behavior
+/// - Transactions whose max fee (`gas_limit * max_fee_per_gas`) exceeds the configured RPC tx fee
+///   cap (`--rpc.txfeecap`), matching op-geth's `RPCTxFeeCap` behavior
 ///
 /// All other transactions are forwarded to the inner validator unchanged.
 ///


### PR DESCRIPTION
## What

Re-wraps one doc comment in `mantle-reth/crates/cli/src/txpool.rs:51` to satisfy `cargo +nightly fmt --check`.

## Why

Under the current nightly rustfmt, `just lint` / CI's `fmt --check` flags this line (the doc comment wraps at a different column than when it was last formatted). This is a pure formatting fix — no code/logic change.

Caught while cutting the next op-reth release: `just pr` on `mantle-elysium` reported this as the only `fmt --check` diff. clippy + test-ci + test-doc are otherwise green.

## Test

- `cargo +nightly fmt --all --check` now clean (this was the only drift).
- No behavioral change (doc-comment text unchanged, only wrap column).