### PR TITLE
fix(rpc-ext): preserve sequencer's null preconf receipt logs shape

### DIFF
--- a/mantle-reth/crates/integration-tests/Cargo.toml
+++ b/mantle-reth/crates/integration-tests/Cargo.toml
@@ -70,4 +70,4 @@ op-revm = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 eyre = { workspace = true }
 serde_json = { workspace = true }
-jsonrpsee = { workspace = true, features = ["http-client"] }
+jsonrpsee = { workspace = true, features = ["http-client", "server"] }

--- a/mantle-reth/crates/integration-tests/tests/helpers.rs
+++ b/mantle-reth/crates/integration-tests/tests/helpers.rs
@@ -69,6 +69,33 @@ pub(crate) async fn with_mantle_node<F, Fut>(
     F: FnOnce(NodeHelperType<MantleNode>, HttpClient) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
+    with_configured_mantle_node(
+        MantleNode::default(),
+        chain_spec,
+        attributes_generator,
+        tree_config,
+        test,
+    )
+    .await;
+}
+
+/// Same as [`with_mantle_node`], but launches an explicitly-configured [`MantleNode`] instead of
+/// `MantleNode::default()`.
+///
+/// This is the seam tests use to exercise node configuration that only takes effect through the
+/// node's `RollupArgs` / add-ons — most notably a configured sequencer URL, which is what wires up
+/// `MantleRpcExt`'s `SequencerClient` and therefore the `eth_sendRawTransactionWithPreconf`
+/// forwarding path.
+pub(crate) async fn with_configured_mantle_node<F, Fut>(
+    node: MantleNode,
+    chain_spec: Arc<OpChainSpec>,
+    attributes_generator: fn(u64) -> OpPayloadAttrs,
+    tree_config: TreeConfig,
+    test: F,
+) where
+    F: FnOnce(NodeHelperType<MantleNode>, HttpClient) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
     reth_tracing::init_test_tracing();
 
     let mut config: NodeConfig<OpChainSpec> = NodeConfig::new(chain_spec)
@@ -92,8 +119,8 @@ pub(crate) async fn with_mantle_node<F, Fut>(
     let node_handle = NodeBuilder::new(config)
         .with_database(db)
         .with_types_and_provider::<MantleNode, BlockchainProvider<_>>()
-        .with_components(MantleNode::default().components())
-        .with_add_ons(MantleNode::default().add_ons())
+        .with_components(node.components())
+        .with_add_ons(node.add_ons())
         .launch_with_fn(|builder| {
             let launcher =
                 EngineNodeLauncher::new(runtime.clone(), builder.config.datadir(), tree_config);

--- a/mantle-reth/crates/integration-tests/tests/main.rs
+++ b/mantle-reth/crates/integration-tests/tests/main.rs
@@ -6,4 +6,5 @@ mod estimate_total_fee_token_ratio;
 mod fill_transaction;
 mod gas_estimation;
 mod gas_limit;
+mod preconf_forwarding;
 mod txpool;

--- a/mantle-reth/crates/integration-tests/tests/preconf_forwarding.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf_forwarding.rs
@@ -1,0 +1,122 @@
+//! Regression test for the `eth_sendRawTransactionWithPreconf` sequencer-forwarding path.
+//!
+//! ## The bug
+//!
+//! A reth RPC node with a configured sequencer (`--rollup.sequencer-http`) forwards
+//! `eth_sendRawTransactionWithPreconf` to the sequencer and deserializes the sequencer's JSON
+//! response into `mantle_reth_rpc_ext::PreconfTxEvent` (see `MantleRpcExt`). An **op-geth**
+//! sequencer serializes `receipt.logs` as JSON `null` (Go nil slice) whenever the transaction has
+//! no logs — most importantly for a **reverted** transaction (`core/events.go`:
+//! `Logs []*Log json:"logs"`).
+//!
+//! Before the fix, `PreconfTxReceipt.logs` used `#[serde(default)]`, which only substitutes a
+//! default for a *missing* field, not a present-but-`null` one. So reth failed to deserialize the
+//! response and returned:
+//!
+//! ```text
+//! -32000 failed to deserialise preconf event from sequencer:
+//!        invalid type: null, expected a sequence
+//! ```
+//!
+//! The client therefore never learned the transaction had reverted — it saw an opaque node error
+//! instead of the preconfirmation's `failed` status and revert reason. The fix models
+//! `PreconfTxReceipt.logs` as `Option<Vec<PreconfLog>>`, which deserializes `null`→`None` and
+//! re-serializes `None`→`null`, so a forwarding reth node echoes the sequencer's exact JSON shape.
+//!
+//! ## Why a node test (not just the rpc-ext unit test)
+//!
+//! `mantle-reth-rpc-ext` has a unit test that deserializes the exact `logs: null` payload. This
+//! test covers the *other half*: that the real forwarding path — reth's `SequencerClient` calling
+//! a live sequencer over HTTP, then `MantleRpcExt` deserializing the response inside the running
+//! RPC server — surfaces the sequencer's preconf event to the caller instead of a `-32000`. We
+//! stand up a mock sequencer that returns the op-geth-shaped `logs: null` response and drive the
+//! reth node's real RPC.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo test -p mantle-reth-integration-tests --test it \
+//!     preconf_forward_accepts_null_logs_from_sequencer -- --nocapture
+//! ```
+
+use crate::helpers::{
+    mantle_payload_attributes, mantle_test_chain_spec, with_configured_mantle_node,
+};
+use jsonrpsee::{
+    core::client::ClientT,
+    server::{RpcModule, Server, ServerHandle},
+    types::ErrorObjectOwned,
+};
+use mantle_reth_cli::node::MantleNode;
+use reth_node_api::TreeConfig;
+use reth_optimism_node::args::RollupArgs;
+use serde_json::{Value, json};
+
+/// Starts a mock sequencer that answers `eth_sendRawTransactionWithPreconf` with a fixed JSON
+/// value, and returns its `http://` URL plus the server handle (kept alive by the caller).
+async fn start_mock_sequencer(response: Value) -> (String, ServerHandle) {
+    let server = Server::builder().build("127.0.0.1:0").await.expect("mock sequencer bind");
+    let addr = server.local_addr().expect("mock sequencer local_addr");
+
+    // The module context IS the canned response; the handler just echoes it back regardless of the
+    // forwarded raw-tx params (reth forwards the hex-encoded bytes; the mock ignores them).
+    let mut module = RpcModule::new(response);
+    module
+        .register_async_method(
+            "eth_sendRawTransactionWithPreconf",
+            |_params, ctx, _ext| async move { Ok::<Value, ErrorObjectOwned>((*ctx).clone()) },
+        )
+        .expect("register mock sequencer method");
+
+    let handle = server.start(module);
+    (format!("http://{addr}"), handle)
+}
+
+/// A reverted tx on an op-geth sequencer yields `receipt.logs == null`. reth must forward,
+/// deserialize, and return the preconfirmation `failed` status + revert reason — not a `-32000`
+/// deserialization error.
+#[tokio::test(flavor = "multi_thread")]
+async fn preconf_forward_accepts_null_logs_from_sequencer() {
+    let reason = "execution reverted: ERC20: insufficient balance";
+    let seq_response = json!({
+        "txHash": "0x66199f44ede67884fa62012bde48a4e7823c2ce6a827f4c33e28d001a9c37cf3",
+        "status": "failed",
+        "reason": reason,
+        "blockHeight": "0xe9be5",
+        "receipt": { "logs": null }, // <-- op-geth shape for a no-log / reverted tx
+    });
+    let (sequencer_url, _sequencer) = start_mock_sequencer(seq_response).await;
+
+    let node = MantleNode::new(RollupArgs { sequencer: Some(sequencer_url), ..Default::default() });
+
+    with_configured_mantle_node(
+        node,
+        mantle_test_chain_spec(),
+        mantle_payload_attributes,
+        TreeConfig::default(),
+        move |node, client| async move {
+            // Keep the node (and its RPC server) alive for the duration of the test.
+            let _node = node;
+
+            // reth's forwarding path only hex-decodes the bytes and forwards them; the mock
+            // sequencer ignores the payload, so any valid hex works here.
+            let raw_tx = json!("0x02f8");
+            let event: Value =
+                client.request("eth_sendRawTransactionWithPreconf", vec![raw_tx]).await.expect(
+                    "reth must deserialize a sequencer preconf response with logs:null and return \
+                     the event, not a -32000 deserialization error",
+                );
+
+            assert_eq!(event["status"], "failed", "preconf status must be forwarded");
+            assert_eq!(event["reason"], reason, "revert reason must be forwarded");
+            assert_eq!(event["blockHeight"], "0xe9be5", "predicted block height must be forwarded");
+            assert!(
+                event["receipt"]["logs"].is_null(),
+                "sequencer's null logs must round-trip back to null (byte-parity with op-geth), \
+                 got {}",
+                event["receipt"]["logs"]
+            );
+        },
+    )
+    .await;
+}

--- a/mantle-reth/crates/rpc-ext/src/lib.rs
+++ b/mantle-reth/crates/rpc-ext/src/lib.rs
@@ -78,9 +78,16 @@ pub enum PreconfStatus {
 /// Preconfirmation transaction receipt
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PreconfTxReceipt {
-    /// Event logs
+    /// Event logs, echoed verbatim from the sequencer.
+    ///
+    /// Modeled as `Option` so the sequencer's exact JSON shape round-trips. An op-geth sequencer
+    /// emits `"logs": null` for a reverted tx (Go nil slice) and `"logs": []` / `[..]` otherwise.
+    /// A plain `Vec<PreconfLog>` with `#[serde(default)]` both rejected an explicit `null` on the
+    /// wire (`invalid type: null, expected a sequence`) *and* would re-serialize an empty result
+    /// as `[]`, diverging from geth. `Option<Vec<_>>` deserializes null→None and re-serializes
+    /// None→null, so a forwarding reth node returns byte-identical shape to the geth sequencer.
     #[serde(default)]
-    pub logs: Vec<PreconfLog>,
+    pub logs: Option<Vec<PreconfLog>>,
 }
 
 /// Preconfirmation log entry
@@ -796,5 +803,56 @@ mod tests {
             result.is_err(),
             "a provider error while reading token_ratio must propagate, not silently yield 0"
         );
+    }
+
+    // ─── preconf event deserialization ──────────────────────────────────
+
+    #[test]
+    fn preconf_receipt_accepts_null_logs() {
+        // The sequencer sends `"logs": null` (not `[]`) for reverted transactions. Before the
+        // `Option<Vec<_>>` change this failed with "invalid type: null, expected a sequence".
+        let json = r#"{
+            "txHash": "0x66199f44ede67884fa62012bde48a4e7823c2ce6a827f4c33e28d001a9c37cf3",
+            "status": "failed",
+            "reason": "execution reverted: ERC20: insufficient balance",
+            "blockHeight": "0xe9be5",
+            "receipt": { "logs": null }
+        }"#;
+        let event: PreconfTxEvent = serde_json::from_str(json).expect("null logs must deserialize");
+        assert_eq!(event.status, PreconfStatus::Failed);
+        assert_eq!(event.receipt.logs, None);
+        // Byte-parity with geth: null must round-trip back to null (not []).
+        let reser = serde_json::to_value(&event).unwrap();
+        assert!(reser["receipt"]["logs"].is_null(), "null logs must re-serialize as null");
+    }
+
+    #[test]
+    fn preconf_receipt_accepts_missing_logs() {
+        let json = r#"{
+            "txHash": "0x66199f44ede67884fa62012bde48a4e7823c2ce6a827f4c33e28d001a9c37cf3",
+            "status": "success",
+            "reason": "",
+            "blockHeight": "0xe9be5",
+            "receipt": {}
+        }"#;
+        let event: PreconfTxEvent = serde_json::from_str(json).expect("missing logs must default");
+        assert_eq!(event.receipt.logs, None);
+    }
+
+    #[test]
+    fn preconf_receipt_roundtrips_empty_and_populated_logs() {
+        // Empty array stays an empty array (a successful, log-less tx), and a populated array is
+        // preserved — reth echoes the sequencer's exact shape in every case.
+        let empty: PreconfTxReceipt = serde_json::from_str(r#"{ "logs": [] }"#).unwrap();
+        assert_eq!(empty.logs, Some(vec![]));
+        assert_eq!(serde_json::to_value(&empty).unwrap()["logs"].to_string(), "[]");
+
+        let json = r#"{ "logs": [{
+            "address": "0x5bec7df4940345b717361664c4847bb3b794eaca",
+            "topics": ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],
+            "data": "0x000000000000000000000000000000000000000000000000000000000000000a"
+        }] }"#;
+        let populated: PreconfTxReceipt = serde_json::from_str(json).unwrap();
+        assert_eq!(populated.logs.as_ref().map(Vec::len), Some(1));
     }
 }


### PR DESCRIPTION
## Problem

A reth RPC node with a configured sequencer (`--rollup.sequencer-http`) forwards `eth_sendRawTransactionWithPreconf` to the sequencer and deserializes the response into `mantle_reth_rpc_ext::PreconfTxEvent`.

`PreconfTxReceipt.logs` was `Vec<PreconfLog>` with `#[serde(default)]`, which only covers a **missing** field — not a present-but-`null` one. An **op-geth** sequencer serializes `receipt.logs` as JSON `null` (Go nil slice) for a **reverted** preconf tx (`core/events.go`: `Logs []*Log`, left nil on the revert path). So the reth node failed to deserialize and returned:

```
-32000 failed to deserialise preconf event from sequencer: invalid type: null, expected a sequence
```

The caller never learned the tx had reverted — it saw an opaque node error instead of the preconf `failed` status + revert reason. Observed on `op-reth-rpc42` against an op-geth sequencer.

## Fix

Model `logs` as `Option<Vec<PreconfLog>>` so a forwarding node **echoes the sequencer's exact JSON shape**:

| sequencer sends | reth returns |
|---|---|
| `null` (reverted tx) | `null` |
| `[]` (success, no logs) | `[]` |
| `[..]` | `[..]` |

This both fixes the deserialization crash **and** keeps reth byte-identical to the op-geth sequencer (which emits `null` for reverted txs) — rather than normalizing empty logs to `[]`.

## Tests

- **rpc-ext unit tests**: `null` / missing → `None` and re-serialize back to `null`; `[]` and populated arrays round-trip unchanged. (The `null` case reproduces the exact `-32000` before the fix.)
- **integration test** (`preconf_forwarding`): a mock jsonrpsee sequencer returns `logs:null`; the real forward+deserialize path in a running node returns `logs:null` (not `-32000`, not `[]`). Adds a `with_configured_mantle_node` helper (inject a sequencer URL) and the jsonrpsee `server` dev-feature for the mock.

`just pr` (lint + test-ci + `--all-features` doctests) is green.