### PR TITLE
fix(rpc-ext): surface estimate_gas RPC error message in eth_estimateTotalFee

### DIFF
--- a/mantle-reth/crates/rpc-ext/src/lib.rs
+++ b/mantle-reth/crates/rpc-ext/src/lib.rs
@@ -434,7 +434,16 @@ where
         )
         .await
         .map_err(|e| {
-            ErrorObject::owned(-32000, format!("failed to estimate gas: {e}"), None::<()>)
+            // Surface the gas estimator's RPC error message (e.g. "insufficient funds for
+            // transfer") rather than revm's raw Display ("EVM error: OutOfFunds"), matching
+            // op-geth and reth's own eth_estimateGas. `estimate_gas_at` returns the eth-api
+            // error before RPC conversion, so convert it the same way the endpoint does.
+            let rpc_err: ErrorObject<'static> = e.into();
+            ErrorObject::owned(
+                -32000,
+                format!("failed to estimate gas: {}", rpc_err.message()),
+                None::<()>,
+            )
         })?;
 
         let base_fee = U256::from(header.base_fee_per_gas().unwrap_or(0));


### PR DESCRIPTION
## What
`eth_estimateTotalFee` wraps the gas-estimation error with `format!(\"failed to estimate gas: {e}\")`, using revm's **raw Display** (`EVM error: OutOfFunds`) instead of the RPC-converted message. This changes it to convert the eth-api error to its `ErrorObject` form first and use `.message()`, so the message matches op-geth and reth's own `eth_estimateGas` (`insufficient funds for transfer`).

## Why — regression vs the v1.9.3 line
On insufficient balance, error **code** already matches geth (`-32000`); only the **message** diverged:
- geth / **v1.9.3 op-reth** (rpc41 @ sepolia-qa4): `...insufficient funds for transfer: address 0x..`
- **v2.2.1 line** (rc3+, incl rc4/rc5): `...EVM error: OutOfFunds`

The v1.9.3 impl used `e.message()` (RPC-converted); the v2.2.1 rewrite regressed to `{e}` (raw Display). This restores the v1.9.3 behavior. Not consensus/execution — RPC error wording only.

## Fix
`mantle-reth/crates/rpc-ext/src/lib.rs` — convert the `estimate_gas_at` error via `Into<ErrorObject>` (the same conversion the `eth_estimateGas` endpoint uses) before formatting, so the inner message is the geth-style RPC message rather than revm's raw Display.

## Test
- `just pr` green (lint + test-ci + test-doc).
- Acceptance: `tests/rpc_compat` `error_eth_estimateTotalFee_insufficient_balance` (the sole read-only FAIL) should flip to pass/compatible — reth's own `eth_estimateGas` already returns `insufficient funds for transfer` for this case (see `known_diffs.json`), confirming the converted message.