### PR TITLE
feat(rpc): gate forwarded-tx local pool retention behind --rollup.enable-tx-pool-admission

### DIFF
--- a/mantle-reth/crates/integration-tests/tests/main.rs
+++ b/mantle-reth/crates/integration-tests/tests/main.rs
@@ -8,3 +8,4 @@ mod gas_estimation;
 mod gas_limit;
 mod preconf_forwarding;
 mod txpool;
+mod txpool_admission;

--- a/mantle-reth/crates/integration-tests/tests/txpool_admission.rs
+++ b/mantle-reth/crates/integration-tests/tests/txpool_admission.rs
@@ -1,0 +1,173 @@
+//! Behavior test for `--rollup.enable-tx-pool-admission` on a sequencer-forwarding reth node.
+//!
+//! ## What this pins down
+//!
+//! A reth RPC node with a configured sequencer (`--rollup.sequencer`) forwards
+//! `eth_sendRawTransaction` to the sequencer (`OpEthApi::send_transaction`). Upstream op-reth then
+//! *unconditionally* re-adds the forwarded tx to its local txpool ("for local RPC usage"), which
+//! diverges from op-geth: op-geth gates that retention behind `--rollup.enabletxpooladmission` and
+//! leaves it **off by default** for forwarding nodes (`RollupDisableTxPoolAdmission =
+//! sequencerhttp != "" && !enableFlag`).
+//!
+//! This test asserts the op-geth-aligned behavior we add on top of op-reth:
+//! - **default** (flag off): a forwarded tx is NOT retained in the local pool — `eth_getTransaction
+//!   ByHash` returns null and the `pending` nonce stays at the on-chain nonce.
+//! - **flag on**: the forwarded tx IS retained — queryable locally and reflected in the `pending`
+//!   nonce.
+//!
+//! See `docs/reth_geth_txpool_forwarded_tx_admission.md` in the rde-v3 superproject for the full
+//! investigation.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo test -p mantle-reth-integration-tests --test it \
+//!     --  txpool_admission -- --nocapture
+//! ```
+
+use crate::helpers::{
+    mantle_payload_attributes, mantle_test_chain_spec, with_configured_mantle_node,
+};
+use alloy_network::eip2718::Encodable2718;
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
+use jsonrpsee::{
+    core::client::ClientT,
+    server::{RpcModule, Server, ServerHandle},
+    types::ErrorObjectOwned,
+};
+use mantle_reth_cli::node::MantleNode;
+use reth_chainspec::EthChainSpec;
+use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet};
+use reth_node_api::TreeConfig;
+use reth_optimism_node::args::RollupArgs;
+use serde_json::{Value, json};
+
+/// A mock sequencer that answers `eth_sendRawTransaction` with a fixed hash and echoes it back
+/// regardless of the forwarded params. Returns its `http://` URL plus the handle (kept alive by the
+/// caller — dropping it stops the server).
+async fn start_mock_sequencer(tx_hash: B256) -> (String, ServerHandle) {
+    let server = Server::builder().build("127.0.0.1:0").await.expect("mock sequencer bind");
+    let addr = server.local_addr().expect("mock sequencer local_addr");
+
+    let mut module = RpcModule::new(tx_hash);
+    module
+        .register_async_method("eth_sendRawTransaction", |_params, ctx, _ext| async move {
+            Ok::<Value, ErrorObjectOwned>(json!(*ctx))
+        })
+        .expect("register mock sequencer method");
+
+    let handle = server.start(module);
+    (format!("http://{addr}"), handle)
+}
+
+/// Sign a minimal, pool-acceptable EIP-1559 tx from the default (genesis-funded) wallet. Returns
+/// the 2718-encoded bytes and the tx hash.
+async fn signed_tx(chain_id: u64, wallet: &Wallet, nonce: u64) -> (Bytes, B256) {
+    let request = TransactionRequest {
+        chain_id: Some(chain_id),
+        nonce: Some(nonce),
+        to: Some(TxKind::Call(Address::with_last_byte(0xde))),
+        gas: Some(21_000),
+        max_fee_per_gas: Some(20e9 as u128),
+        max_priority_fee_per_gas: Some(20e9 as u128),
+        value: Some(U256::from(1)),
+        input: TransactionInput::default(),
+        ..Default::default()
+    };
+    let signed = TransactionTestContext::sign_tx(wallet.inner.clone(), request).await;
+    let raw: Bytes = signed.encoded_2718().into();
+    // For every 2718 tx type the tx hash is keccak256 of the 2718 encoding.
+    let hash = keccak256(&raw);
+    (raw, hash)
+}
+
+/// Drives one forwarding node with the given admission flag: submits a forwarded tx and returns
+/// `(getTransactionByHash is present, pending_nonce)` observed on the same node.
+async fn run_case(enable_tx_pool_admission: bool) -> (bool, u64) {
+    let chain_spec = mantle_test_chain_spec();
+    let chain_id = chain_spec.chain().id();
+    let wallet = Wallet::default().with_chain_id(chain_id);
+
+    let (raw_tx, tx_hash) = signed_tx(chain_id, &wallet, 0).await;
+    let from = wallet.inner.address();
+    let (sequencer_url, _sequencer) = start_mock_sequencer(tx_hash).await;
+
+    let node = MantleNode::new(RollupArgs {
+        sequencer: Some(sequencer_url),
+        enable_tx_pool_admission,
+        ..Default::default()
+    });
+
+    let result = std::sync::Arc::new(std::sync::Mutex::new((false, 0u64)));
+    let result_out = result.clone();
+
+    with_configured_mantle_node(
+        node,
+        chain_spec,
+        mantle_payload_attributes,
+        TreeConfig::default(),
+        move |node, client| async move {
+            let _node = node;
+
+            // Submit via the forwarding path. reth forwards to the mock sequencer (which returns
+            // `tx_hash`) and returns that hash to us, regardless of local retention.
+            let returned: B256 = client
+                .request("eth_sendRawTransaction", vec![json!(raw_tx)])
+                .await
+                .expect("forwarded tx must be accepted (mock sequencer returns a hash)");
+            assert_eq!(returned, tx_hash, "node must return the sequencer's tx hash");
+
+            // Is the forwarded tx visible in the local view (pool)? Not mined, no flashblocks, so a
+            // non-null result means it was retained in the local pool.
+            let by_hash: Value = client
+                .request("eth_getTransactionByHash", vec![json!(tx_hash)])
+                .await
+                .expect("eth_getTransactionByHash call");
+            let present = !by_hash.is_null();
+
+            // pending nonce: on-chain nonce (0) unless the consecutive tx sits in the local pool.
+            let count: Value = client
+                .request("eth_getTransactionCount", vec![json!(from), json!("pending")])
+                .await
+                .expect("eth_getTransactionCount call");
+            let pending_nonce = u64::from_str_radix(
+                count.as_str().expect("nonce hex string").trim_start_matches("0x"),
+                16,
+            )
+            .expect("parse pending nonce");
+
+            *result_out.lock().unwrap() = (present, pending_nonce);
+        },
+    )
+    .await;
+
+    *result.lock().unwrap()
+}
+
+/// Default (flag off): a forwarding node does NOT retain the forwarded tx locally — aligning with
+/// op-geth's default. `getTransactionByHash` is null and the pending nonce stays on-chain.
+#[tokio::test(flavor = "multi_thread")]
+async fn forwarded_tx_not_retained_by_default() {
+    let (present, pending_nonce) = run_case(false).await;
+    assert!(
+        !present,
+        "by default a forwarded tx must NOT be retained in the local pool (op-geth parity)",
+    );
+    assert_eq!(
+        pending_nonce, 0,
+        "without local retention the pending nonce must stay at the on-chain nonce",
+    );
+}
+
+/// Flag on: retention is opt-in — the forwarded tx is queryable locally and bumps the pending
+/// nonce, preserving the pre-existing upstream op-reth behavior for operators who want it.
+#[tokio::test(flavor = "multi_thread")]
+async fn forwarded_tx_retained_when_admission_enabled() {
+    let (present, pending_nonce) = run_case(true).await;
+    assert!(
+        present,
+        "with --rollup.enabletxpooladmission the forwarded tx must be retained locally",
+    );
+    assert_eq!(pending_nonce, 1, "a retained consecutive tx must advance the pending nonce by one",);
+}

--- a/op-reth/crates/node/src/args.rs
+++ b/op-reth/crates/node/src/args.rs
@@ -49,6 +49,26 @@ pub struct RollupArgs {
     #[arg(long = "rollup.enable-tx-conditional", default_value = "false")]
     pub enable_tx_conditional: bool,
 
+    /// MANTLE PATCH: add RPC-submitted transactions to the local txpool even when they are
+    /// forwarded to a configured sequencer (`--rollup.sequencer`).
+    ///
+    /// Off by default for forwarding nodes: such a node does not build blocks, so retaining
+    /// forwarded txs in its local pool produces a mempool view — and a `pending` nonce/state —
+    /// that need not match the sequencer. Mirrors op-geth's `--rollup.enabletxpooladmission`.
+    ///
+    /// When no sequencer is configured this flag has no effect: RPC-submitted transactions always
+    /// enter the local pool (that is how sequencer/non-forwarding nodes work).
+    ///
+    /// Upstream op-reth (now at ethereum-optimism/optimism, `rust/op-reth/`) still retains
+    /// unconditionally; requested upstream in paradigmxyz/reth#15868 / #15893 (closed on repo
+    /// migration, not on merit). Upstream candidate — keep this marker for re-sync.
+    #[arg(
+        long = "rollup.enabletxpooladmission",
+        alias = "rollup.enable-tx-pool-admission",
+        default_value_t = false
+    )]
+    pub enable_tx_pool_admission: bool,
+
     /// Enable experimental SDM support for integration tests.
     ///
     /// SDM is not scheduled for Jovian or Karst; leave this disabled for production networks.
@@ -179,6 +199,7 @@ impl Default for RollupArgs {
             compute_pending_block: false,
             discovery_v4: false,
             enable_tx_conditional: false,
+            enable_tx_pool_admission: false,
             sdm_enabled: false,
             supervisor_http: None,
             supervisor_safety_level: SafetyLevel::CrossUnsafe,

--- a/op-reth/crates/node/src/node.rs
+++ b/op-reth/crates/node/src/node.rs
@@ -268,6 +268,7 @@ impl OpNode {
             .with_historical_rpc(self.args.historical_rpc.clone())
             .with_flashblocks(self.args.flashblocks_url.clone())
             .with_flashblock_consensus(self.args.flashblock_consensus)
+            .with_tx_pool_admission(self.args.enable_tx_pool_admission)
     }
 
     /// Instantiates the [`ProviderFactoryBuilder`] for an opstack node.
@@ -825,6 +826,9 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     flashblocks_url: Option<Url>,
     /// Enable flashblock consensus client to drive chain forward.
     flashblock_consensus: bool,
+    /// Add RPC-submitted txs to the local pool even when forwarded to a sequencer. Off by default
+    /// for forwarding nodes; mirrors op-geth's `--rollup.enabletxpooladmission`.
+    enable_tx_pool_admission: bool,
 }
 
 impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
@@ -843,6 +847,7 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
             tokio_runtime: None,
             flashblocks_url: None,
             flashblock_consensus: false,
+            enable_tx_pool_admission: false,
         }
     }
 }
@@ -920,6 +925,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             _nt,
             flashblocks_url,
             flashblock_consensus,
+            enable_tx_pool_admission,
             ..
         } = self;
         OpAddOnsBuilder {
@@ -936,6 +942,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             tokio_runtime,
             flashblocks_url,
             flashblock_consensus,
+            enable_tx_pool_admission,
         }
     }
 
@@ -948,6 +955,12 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     /// With a flashblock consensus client to drive chain forward.
     pub const fn with_flashblock_consensus(mut self, flashblock_consensus: bool) -> Self {
         self.flashblock_consensus = flashblock_consensus;
+        self
+    }
+
+    /// Retain RPC-submitted txs in the local pool even when they are forwarded to a sequencer.
+    pub const fn with_tx_pool_admission(mut self, enable_tx_pool_admission: bool) -> Self {
+        self.enable_tx_pool_admission = enable_tx_pool_admission;
         self
     }
 }
@@ -977,6 +990,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             tokio_runtime,
             flashblocks_url,
             flashblock_consensus,
+            enable_tx_pool_admission,
             ..
         } = self;
 
@@ -988,7 +1002,8 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
                     .with_min_suggested_priority_fee(min_suggested_priority_fee)
                     .with_sdm_enabled(sdm_enabled)
                     .with_flashblocks(flashblocks_url)
-                    .with_flashblock_consensus(flashblock_consensus),
+                    .with_flashblock_consensus(flashblock_consensus)
+                    .with_tx_pool_admission(enable_tx_pool_admission),
                 PVB::default(),
                 EB::default(),
                 EVB::default(),

--- a/op-reth/crates/rpc/src/eth/mod.rs
+++ b/op-reth/crates/rpc/src/eth/mod.rs
@@ -93,12 +93,14 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
         flashblocks: Option<FlashblocksListeners<N::Primitives>>,
+        enable_tx_pool_admission: bool,
     ) -> Self {
         let inner = Arc::new(OpEthApiInner {
             eth_api,
             sequencer_client,
             min_suggested_priority_fee,
             flashblocks,
+            enable_tx_pool_admission,
         });
         Self { inner }
     }
@@ -415,6 +417,10 @@ pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     ///
     /// If set, provides receivers for pending blocks, flashblock sequences, and build status.
     flashblocks: Option<FlashblocksListeners<N::Primitives>>,
+    /// Whether RPC-submitted txs are retained in the local pool after being forwarded to a
+    /// sequencer. Off by default for forwarding nodes; mirrors op-geth's
+    /// `--rollup.enabletxpooladmission`. Consulted in `send_transaction`.
+    enable_tx_pool_admission: bool,
 }
 
 impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApiInner<N, Rpc> {
@@ -432,6 +438,11 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApiInner<N, Rpc> {
     /// Returns the configured sequencer client, if any.
     const fn sequencer_client(&self) -> Option<&SequencerClient> {
         self.sequencer_client.as_ref()
+    }
+
+    /// Whether RPC-submitted txs are retained in the local pool after forwarding to a sequencer.
+    const fn tx_pool_admission_enabled(&self) -> bool {
+        self.enable_tx_pool_admission
     }
 }
 
@@ -469,6 +480,9 @@ pub struct OpEthApiBuilder<NetworkT = Optimism> {
     flashblock_consensus: bool,
     /// Whether SDM is explicitly enabled for integration tests.
     sdm_enabled: bool,
+    /// Retain RPC-submitted txs in the local pool even when forwarded to a sequencer. Off by
+    /// default for forwarding nodes; mirrors op-geth's `--rollup.enabletxpooladmission`.
+    enable_tx_pool_admission: bool,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
 }
@@ -482,6 +496,7 @@ impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
             flashblocks_url: None,
             flashblock_consensus: false,
             sdm_enabled: false,
+            enable_tx_pool_admission: false,
             _nt: PhantomData,
         }
     }
@@ -497,6 +512,7 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
             flashblocks_url: None,
             flashblock_consensus: false,
             sdm_enabled: false,
+            enable_tx_pool_admission: false,
             _nt: PhantomData,
         }
     }
@@ -537,6 +553,14 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
         self.sdm_enabled = sdm_enabled;
         self
     }
+
+    /// Retain RPC-submitted txs in the local pool even when they are forwarded to a sequencer.
+    /// Off by default for forwarding nodes; mirrors op-geth's `--rollup.enabletxpooladmission`.
+    #[must_use]
+    pub const fn with_tx_pool_admission(mut self, enable_tx_pool_admission: bool) -> Self {
+        self.enable_tx_pool_admission = enable_tx_pool_admission;
+        self
+    }
 }
 
 impl<N, NetworkT> EthApiBuilder<N> for OpEthApiBuilder<NetworkT>
@@ -573,6 +597,7 @@ where
             flashblocks_url,
             flashblock_consensus,
             sdm_enabled,
+            enable_tx_pool_admission,
             ..
         } = self;
         let rpc_converter = RpcConverter::new(
@@ -637,6 +662,7 @@ where
             sequencer_client,
             U256::from(min_suggested_priority_fee),
             flashblocks,
+            enable_tx_pool_admission,
         ))
     }
 }

--- a/op-reth/crates/rpc/src/eth/transaction.rs
+++ b/op-reth/crates/rpc/src/eth/transaction.rs
@@ -73,10 +73,15 @@ where
                     tracing::debug!(target: "rpc::eth", %err, hash=% *pool_transaction.hash(), "failed to forward raw transaction");
                 })?;
 
-            // Retain tx in local tx pool after forwarding, for local RPC usage.
-            let _ = self.inner.eth_api.add_pool_transaction(origin, pool_transaction).await.inspect_err(|err| {
-                tracing::warn!(target: "rpc::eth", %err, %hash, "successfully sent tx to sequencer, but failed to persist in local tx pool");
-            });
+            // MANTLE PATCH: gate local-pool retention of forwarded txs. Upstream op-reth retains
+            // unconditionally here; a forwarding node does not build blocks, so by default we do
+            // NOT keep forwarded txs in the local pool (its mempool view / `pending` nonce need not
+            // match the sequencer). Enable with `--rollup.enabletxpooladmission`; mirrors op-geth.
+            if self.inner.tx_pool_admission_enabled() {
+                let _ = self.inner.eth_api.add_pool_transaction(origin, pool_transaction).await.inspect_err(|err| {
+                    tracing::warn!(target: "rpc::eth", %err, %hash, "successfully sent tx to sequencer, but failed to persist in local tx pool");
+                });
+            }
 
             return Ok(hash);
         }


### PR DESCRIPTION
## What

Adds `--rollup.enabletxpooladmission` (alias `--rollup.enable-tx-pool-admission`) to gate whether RPC-submitted transactions are retained in the **local** txpool after being forwarded to a sequencer. **Off by default** for forwarding nodes — aligning reth with op-geth.

## Why

A reth node with `--rollup.sequencer` set forwards `eth_sendRawTransaction` to the sequencer, then **unconditionally** re-adds the tx to its local pool (`OpEthApi::send_transaction`, "Retain tx in local tx pool after forwarding, for local RPC usage").

op-geth does the same *retention* but gates it behind `--rollup.enabletxpooladmission`, defaulting it **off** for forwarding nodes:

```go
// op-geth cmd/utils/flags.go
cfg.RollupDisableTxPoolAdmission = cfg.RollupSequencerHTTP != "" && !ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)
```

So an op-geth forwarding RPC node keeps an empty local pool, while a reth one exposes the relayed tx. Always retaining on a node that does not build blocks is misleading:

- `txpool_content` / `_status` / `_inspect` expose txs the node merely relayed to the sequencer;
- `eth_getTransactionCount(addr, "pending")` and `fill_transaction`'s auto-nonce get bumped by a **consecutive** forwarded tx (`get_highest_consecutive_transaction_by_sender`), so the *same* request returns a different nonce on a reth vs an op-geth forwarding RPC node.

## Behavior

| sequencer configured | flag | forwarded tx enters local pool |
|---|---|---|
| no  | any | yes (unchanged — non-forwarding/sequencer nodes; flag not consulted) |
| yes | off (default) | **no** (op-geth parity) |
| yes | on  | yes (previous upstream behavior, opt-in) |

## How

Plumbed `RollupArgs.enable_tx_pool_admission` → `OpAddOnsBuilder` → `OpEthApiBuilder` → `OpEthApi`, consulted at the single retention site in `OpEthApi::send_transaction` (inside the forwarding branch only). No behavior change for nodes without a sequencer.

## Test plan

- New integration test `txpool_admission` (node-spawning `it` harness) with a mock sequencer:
  - `forwarded_tx_not_retained_by_default` — default: `eth_getTransactionByHash` is null, pending nonce stays on-chain.
  - `forwarded_tx_retained_when_admission_enabled` — flag on: tx is queryable locally, pending nonce advances.
- `cargo clippy -p reth-optimism-node -p reth-optimism-rpc -- -D warnings` — clean.
- `cargo test -p reth-optimism-node args` — RollupArgs parsing (alias, default) — pass.
- Full `it` suite — 15 passed, 0 failed (no regressions).
- CI still runs the full `just pr` gate (`--all-features` clippy + doctests).

## Upstream

This gates behavior that matches current upstream op-reth, which still retains unconditionally and has no such flag. op-reth has **moved out of `paradigmxyz/reth`** (that repo removed `crates/optimism/` in paradigmxyz/reth#21532) and now lives at **`ethereum-optimism/optimism`** under `rust/op-reth/`.

The exact feature was already requested and attempted upstream:

- Issue paradigmxyz/reth#15868 — "Add disable txpool setting to OpEthApi" ("mirror op-geth 1:1 on eth_sendrawtx … we need a disable_txpool_admission setting").
- PR paradigmxyz/reth#15893 — "feat: added disable-tx-pool-admission args" (same approach + flag name as here).

Both were closed **only because op-reth was migrating repos** (not on merit); the maintainer invited re-opening in the new op-reth repo. So the sensible upstream target is `ethereum-optimism/optimism` (`rust/op-reth/`), not `paradigmxyz/reth` — worth upstreaming so Mantle does not carry a local divergence long-term.
