### PR TITLE
feat(cli): enable debug_verbosity/vmodule by gating log reload on debug namespace

### DIFF
--- a/op-reth/crates/cli/src/app.rs
+++ b/op-reth/crates/cli/src/app.rs
@@ -137,7 +137,12 @@ where
             let otlp_status = runner.block_on(self.cli.traces.init_otlp_tracing(&mut layers))?;
             let otlp_logs_status = runner.block_on(self.cli.traces.init_otlp_logs(&mut layers))?;
 
-            self.guard = self.cli.logs.init_tracing_with_layers(layers, false)?;
+            // Install the runtime-reloadable log filter layer only when the `debug` RPC namespace
+            // is enabled, so `debug_verbosity` / `debug_vmodule` work at runtime. Mirrors the
+            // upstream Ethereum CLI; without this op-reth hardcoded `false` and those methods
+            // failed with `-32603 "Log filter reload not available"`.
+            let enable_reload = self.cli.command.debug_namespace_enabled();
+            self.guard = self.cli.logs.init_tracing_with_layers(layers, enable_reload)?;
             info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
 
             match otlp_status {

--- a/op-reth/crates/cli/src/commands/mod.rs
+++ b/op-reth/crates/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ use reth_cli_commands::{
     node::{self, NoArgs},
     p2p, prune, re_execute, stage,
 };
+use reth_rpc_server_types::RethRpcModule;
 use std::{fmt, sync::Arc};
 
 pub mod import;
@@ -91,5 +92,15 @@ impl<
             Self::ReExecute(cmd) => cmd.chain_spec(),
             Self::OpProofs(cmd) => cmd.chain_spec(),
         }
+    }
+
+    /// Returns `true` if this is a `node` command with the `debug` RPC namespace enabled.
+    ///
+    /// Used to decide whether to install the runtime-reloadable log filter layer that backs the
+    /// `debug_verbosity` / `debug_vmodule` RPC methods. Mirrors the upstream Ethereum CLI
+    /// (`reth`'s `Command::debug_namespace_enabled`), which op-reth had not wired up — so those
+    /// methods returned `-32603 "Log filter reload not available"` even with `debug` enabled.
+    pub fn debug_namespace_enabled(&self) -> bool {
+        matches!(self, Self::Node(cmd) if cmd.rpc.is_namespace_enabled(RethRpcModule::Debug))
     }
 }

--- a/op-reth/crates/cli/src/lib.rs
+++ b/op-reth/crates/cli/src/lib.rs
@@ -212,4 +212,59 @@ mod test {
             _ => panic!("unexpected command"),
         }
     }
+
+    /// The `debug` RPC namespace gates whether the runtime-reloadable log filter layer is
+    /// installed (backing `debug_verbosity` / `debug_vmodule`). Guards the wiring in
+    /// `CliApp::init_tracing`, which previously hardcoded `false`.
+    ///
+    /// Note: `is_namespace_enabled` treats IPC (on by default) as exposing every namespace, so
+    /// the negative case must also pass `--ipcdisable`.
+    #[test]
+    fn debug_namespace_gates_log_reload() {
+        // `debug` present in --http.api -> reload enabled
+        let with_debug = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth",
+            "node",
+            "--http",
+            "--http.api",
+            "eth,debug,net",
+        ]);
+        assert!(with_debug.command.debug_namespace_enabled());
+
+        // `debug` present in --ws.api -> reload enabled
+        let with_debug_ws = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth",
+            "node",
+            "--ws",
+            "--ws.api",
+            "eth,debug",
+        ]);
+        assert!(with_debug_ws.command.debug_namespace_enabled());
+
+        // no `debug` on http/ws AND IPC disabled -> reload disabled
+        let without_debug = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth",
+            "node",
+            "--http",
+            "--http.api",
+            "eth,net",
+            "--ipcdisable",
+        ]);
+        assert!(!without_debug.command.debug_namespace_enabled());
+
+        // IPC left enabled (default) exposes all namespaces -> reload enabled even without
+        // `debug` in the http api
+        let ipc_default = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+            "op-reth",
+            "node",
+            "--http",
+            "--http.api",
+            "eth,net",
+        ]);
+        assert!(ipc_default.command.debug_namespace_enabled());
+
+        // non-node command -> reload disabled
+        let non_node = Cli::<OpChainSpecParser, RollupArgs>::parse_from(["op-reth", "config"]);
+        assert!(!non_node.command.debug_namespace_enabled());
+    }
 }


### PR DESCRIPTION
## What

Enable the `debug_verbosity` / `debug_vmodule` RPC methods on op-reth/mantle-reth by installing the runtime-reloadable log filter layer when the `debug` RPC namespace is enabled.

## Why

`CliApp::init_tracing` (op-reth's CLI) called `init_tracing_with_layers(layers, false)` — `enable_reload` hardcoded to `false`. As a result the tracing subscriber was never initialized with a reloadable filter layer, `reth_tracing::log_handle_available()` stayed `false`, and both methods failed at runtime:

```
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Log filter reload not available"}}
```

even when the `debug` namespace was served (the method is registered — hence `-32603` internal error, not `-32601` method-not-found). geth returns `result: null` for the same calls, so this was a geth↔reth divergence observed on hoodi-qa3.

Upstream reth wires this in its Ethereum CLI (`Cli::init_tracing` → `enable_reload = self.command.debug_namespace_enabled()`); op-reth maintains a separate `CliApp` that inlined the tracing init and never picked up that gate. This mirrors the upstream behavior.

## Change

- `commands/mod.rs`: add `Commands::debug_namespace_enabled()` — `true` for a `node` command with the `debug` RPC namespace reachable (`rpc.is_namespace_enabled(RethRpcModule::Debug)`), matching upstream.
- `app.rs`: `CliApp::init_tracing` now passes `enable_reload = self.cli.command.debug_namespace_enabled()` instead of `false`.
- Applies to both the `op-reth` and `mantle-reth` binaries (both route through `reth_optimism_cli::Cli::run` → `CliApp::init_tracing`).

## Behavior

- With `debug` on any transport (or IPC enabled, the default) → reloadable layer installed → `debug_verbosity(level)` / `debug_vmodule(pattern)` return `result: null` and take effect at runtime.
- Otherwise (e.g. `--ipcdisable` and no `debug` in http/ws api) → unchanged, layer not installed.

Note: `is_namespace_enabled` treats IPC (enabled by default) as exposing all namespaces, so on a default node the layer is installed.

## Test

- Unit test `debug_namespace_gates_log_reload` (op-reth cli): covers `debug` in `--http.api`, in `--ws.api`, absent + `--ipcdisable` (→ off), default IPC (→ on), and non-node command (→ off).
- `just pr` green (lint + test-ci + test-doc).
