### PR TITLE
chore: bump revm dependency to revm-ghsa (align mantle-elysium with rc5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "bitvec",
  "phf",
@@ -10263,7 +10263,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10279,7 +10279,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10294,7 +10294,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -10307,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "auto_impl",
  "either",
@@ -10320,7 +10320,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "auto_impl",
  "either",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10386,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10422,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#b4f618225ddf5cc808080a47fe9065339704fcb7"
+source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
 dependencies = [
  "alloy-eip7928",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,18 +224,19 @@ reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdeb
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4", default-features = false }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4" }
 
-# ==================== REVM (Mantle fork: mantle-elysium branch) ====================
-# TODO: Switch to tag once mantle-elysium is tagged (e.g., v107-mantle-elysium.1)
-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-database = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-state = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-context = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+# ==================== REVM (Mantle fork: revm-ghsa private fork, pinned by rev) ====================
+# Release-line pin: revm family points at the private GHSA fork (embargoed advisory fixes),
+# fixed by rev to keep the pin reproducible. revm-inspectors stays on the public fork below.
+revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
 
 # ==================== REVM-INSPECTORS (Mantle fork: mantle-elysium branch) ====================
 # TODO: Switch to tag once mantle-elysium is tagged
@@ -249,8 +250,8 @@ alloy-evm = { version = "0.34.0", default-features = false }
 alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
 alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
 
-# ==================== OP-REVM (Mantle fork: mantle-elysium branch, same repo as revm) ====================
-op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+# ==================== OP-REVM (Mantle fork: revm-ghsa private fork, same repo as revm) ====================
+op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
 
 # ==================== OP-ALLOY (Mantle: mantle-xyz/mantle-v2) ====================
 # TODO: Switch to tag once mantle-v2 Rust crates are tagged
@@ -417,21 +418,21 @@ reth-transaction-pool = { path = "patches/reth-transaction-pool" }
 # Without this, paradigmxyz/reth uses crates.io revm while we use git revm,
 # creating incompatible duplicate types in the dependency graph.
 [patch.crates-io]
-# revm family: mantle-xyz/revm mantle-elysium branch
-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-database = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-state = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-context = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+# revm family: revm-ghsa private fork, pinned by rev
+revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
 # revm-inspectors: mantle-xyz/revm-inspectors mantle-elysium branch
 revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "mantle-elysium" }
-# op-revm: mantle-xyz/revm (same as workspace dep)
-op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+# op-revm: revm-ghsa private fork (same as workspace dep)
+op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
 # alloy-op-evm / alloy-op-hardforks: mantle-xyz/mantle-v2 (Mantle version)
 alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
@@ -441,3 +442,23 @@ op-alloy-network = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "
 op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 op-alloy-rpc-jsonrpsee = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
+
+# ==================== [patch."https://github.com/mantle-xyz/revm"] — transitive pin ====================
+# revm-inspectors (a separate repo) still depends on mantle-xyz/revm branch mantle-elysium
+# transitively. Without redirecting that source too, cargo pulls a SECOND public revm into the
+# graph and reth-rpc-eth-api fails with Inspector trait-bound errors. Pin the transitive source
+# to the same revm-ghsa rev so exactly one revm exists in the graph.
+[patch."https://github.com/mantle-xyz/revm"]
+revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-handler = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-precompile = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }


### PR DESCRIPTION
## What

Pin the `revm` / `op-revm` dependency family on `mantle-elysium` to the private
GHSA fork `mantle-xyz/revm-ghsa-5vfr-x84h-hmvf` at rev `99707e9f`, matching the
pin previously carried only by the release tag `op-reth-v2.2.1-mantle-arsia.1-rc5`.

This lands the pin on the branch itself so `mantle-elysium` HEAD is release-ready
and consistent with rc5 — instead of applying it on a throwaway off-branch bump
commit at tag time.

## Changes

Single commit `chore: bump revm dependency` — `Cargo.toml` + `Cargo.lock` only:

- `[workspace.dependencies]`: 10 `revm-*` crates + `op-revm` → revm-ghsa `99707e9f`
- `[patch.crates-io]`: same 10 `revm-*` + `op-revm` → revm-ghsa `99707e9f`
- new `[patch."https://github.com/mantle-xyz/revm"]` transitive patch block, so
  `revm-inspectors` (a separate repo) does not drag a second public revm into the
  graph
- `revm-inspectors` itself is unchanged (different repo, still on `mantle-elysium`)
- `Cargo.lock` regenerated: zero public `mantle-xyz/revm` refs remain; exactly one
  revm family source in the graph (the ghsa fork)

## Test plan

- [x] `cargo verify-project` → valid
- [x] `Cargo.lock`: `mantle-xyz/revm?branch=mantle-elysium` refs = 0; revm-ghsa refs present
- [x] `just build` (jemalloc asm-keccak min-debug-logs) → `Finished release in 5m 36s`, `op-reth --version` OK
- [ ] CI on GitHub requires the runner to have read access to the private
      `revm-ghsa-5vfr-x84h-hmvf` repo (the public checkout has no credentials for it)
