### PR TITLE
feat(cli): restore mantle-mainnet as alias for --chain mantle

### DIFF
--- a/mantle-reth/crates/cli/src/chainspec.rs
+++ b/mantle-reth/crates/cli/src/chainspec.rs
@@ -3,11 +3,14 @@ use reth_cli::chainspec::{ChainSpecParser, parse_genesis};
 use reth_optimism_chainspec::OpChainSpec;
 use std::sync::Arc;
 
-const MANTLE_SUPPORTED_CHAINS: &[&str] = &["mantle", "mantle-sepolia"];
+// `mantle` is the canonical mainnet name and stays first so it remains the default.
+// `mantle-mainnet` is a backwards-compatible alias for the pre-elysium chain name.
+const MANTLE_SUPPORTED_CHAINS: &[&str] = &["mantle", "mantle-mainnet", "mantle-sepolia"];
 
 /// Mantle chain specification parser.
 ///
-/// Supports `--chain mantle`, `--chain mantle-sepolia`, and JSON genesis files.
+/// Supports `--chain mantle` (alias `mantle-mainnet`), `--chain mantle-sepolia`, and JSON
+/// genesis files.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct MantleChainSpecParser;
@@ -19,7 +22,7 @@ impl ChainSpecParser for MantleChainSpecParser {
 
     fn parse(s: &str) -> eyre::Result<Arc<Self::ChainSpec>> {
         match s {
-            "mantle" => Ok(MANTLE_MAINNET.clone()),
+            "mantle" | "mantle-mainnet" => Ok(MANTLE_MAINNET.clone()),
             "mantle-sepolia" => Ok(MANTLE_SEPOLIA.clone()),
             _ => {
                 let genesis = parse_genesis(s)?;
@@ -36,6 +39,13 @@ mod tests {
     #[test]
     fn parse_mantle_mainnet() {
         let spec = MantleChainSpecParser::parse("mantle").unwrap();
+        assert_eq!(spec.chain.id(), 5000);
+    }
+
+    #[test]
+    fn parse_mantle_mainnet_alias() {
+        // `mantle-mainnet` is a backwards-compatible alias for `mantle` (pre-elysium name).
+        let spec = MantleChainSpecParser::parse("mantle-mainnet").unwrap();
         assert_eq!(spec.chain.id(), 5000);
     }
 


### PR DESCRIPTION
Pre-elysium reth accepted `--chain mantle-mainnet`. The rewritten `MantleChainSpecParser` only accepted `mantle`, so existing startup scripts and ops templates passing `mantle-mainnet` now fail (the value falls through to genesis-file parsing → `No such file or directory`).

Accept `mantle-mainnet` as an alias mapping to the same `MANTLE_MAINNET` chainspec (chain 5000). `mantle` stays first in `SUPPORTED_CHAINS` so it remains the default; `mantle-mainnet` is also listed so it shows in `--help` and is covered by the existing `parse_known_chains` test.

Added `parse_mantle_mainnet_alias` asserting `--chain mantle-mainnet` resolves to chain 5000.