### PR TITLE
fix(provider): read accounts from hashed tables on the execution path for hashed-only-snapshot DBs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3551,8 +3557,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4062,7 +4068,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4426,6 +4432,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -9357,18 +9372,19 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=88505c7fcbfdebfd3b56d88c86b62e950043c6c4#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "assert_matches",
  "eyre",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "metrics",
  "notify",
  "parking_lot",
+ "rand 0.9.4",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9390,12 +9406,16 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tasks",
+ "reth-testing-utils",
+ "reth-tracing",
  "reth-trie",
  "reth-trie-db",
  "revm-database",
+ "revm-database-interface",
  "revm-state",
  "rocksdb",
  "strum",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,16 @@ lto = "thin"
 # ==================== WORKSPACE DEPENDENCIES ====================
 [workspace.dependencies]
 
+# Transitive deps pulled in by the vendored `patches/reth-provider` (versions match
+# paradigmxyz/reth rev 88505c7). Remove once the hashed-snapshot exec-read fix lands upstream
+# and the [patch] entry for reth-provider is dropped.
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4" }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4", default-features = false }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4" }
+notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
+rocksdb = { version = "0.24" }
+
 # Transitive deps pulled in by the vendored `patches/reth-transaction-pool` (versions match
 # paradigmxyz/reth rev 88505c7). Remove once the extra_balance_cost hook lands upstream and the
 # patch is dropped.
@@ -413,6 +423,7 @@ url = "2.5"
 reth-trie-common = { path = "patches/reth-trie-common" }
 # reth-rpc = { path = "patches/reth-rpc" }
 reth-transaction-pool = { path = "patches/reth-transaction-pool" }
+reth-provider = { path = "patches/reth-provider" }
 
 # ==================== [patch.crates-io] — Force all deps to use our git versions ====================
 # Without this, paradigmxyz/reth uses crates.io revm while we use git revm,

--- a/patches/reth-provider/Cargo.toml
+++ b/patches/reth-provider/Cargo.toml
@@ -1,0 +1,107 @@
+[package]
+name = "reth-provider"
+version = "2.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Reth storage provider. [MANTLE PATCH: hashed-snapshot exec-read fallback]"
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-chainspec.workspace = true
+reth-execution-types.workspace = true
+reth-ethereum-primitives = { workspace = true, features = ["reth-codec"] }
+reth-primitives-traits = { workspace = true, features = ["reth-codec", "secp256k1", "dashmap"] }
+reth-errors.workspace = true
+reth-storage-errors.workspace = true
+reth-storage-api = { workspace = true, features = ["std", "db-api"] }
+reth-db = { workspace = true, features = ["mdbx"] }
+reth-db-api.workspace = true
+reth-prune-types.workspace = true
+reth-stages-types.workspace = true
+reth-tasks = { workspace = true, features = ["rayon"] }
+reth-trie = { workspace = true, features = ["metrics"] }
+reth-trie-db = { workspace = true, features = ["metrics"] }
+reth-nippy-jar.workspace = true
+reth-codecs.workspace = true
+reth-chain-state.workspace = true
+reth-node-types.workspace = true
+reth-static-file-types = { workspace = true, features = ["std"] }
+reth-fs-util.workspace = true
+
+# ethereum
+alloy-eips.workspace = true
+alloy-genesis.workspace = true
+alloy-primitives.workspace = true
+alloy-rpc-types-engine.workspace = true
+alloy-consensus.workspace = true
+revm-database.workspace = true
+revm-state = { workspace = true, optional = true }
+
+# tracing
+tracing.workspace = true
+
+# metrics
+reth-metrics.workspace = true
+metrics.workspace = true
+
+# misc
+itertools.workspace = true
+notify = { workspace = true, default-features = false, features = ["macos_fsevent"] }
+parking_lot.workspace = true
+strum.workspace = true
+eyre.workspace = true
+
+# test-utils
+reth-ethereum-engine-primitives = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync"], optional = true }
+
+# parallel utils
+rayon.workspace = true
+
+rocksdb.workspace = true
+
+[dev-dependencies]
+reth-db = { workspace = true, features = ["test-utils"] }
+reth-primitives-traits = { workspace = true, features = ["arbitrary", "test-utils"] }
+reth-chain-state = { workspace = true, features = ["test-utils"] }
+reth-trie = { workspace = true, features = ["test-utils"] }
+reth-testing-utils.workspace = true
+reth-ethereum-engine-primitives.workspace = true
+reth-ethereum-primitives.workspace = true
+reth-tracing.workspace = true
+
+revm-database-interface.workspace = true
+revm-state.workspace = true
+
+tempfile.workspace = true
+assert_matches.workspace = true
+rand.workspace = true
+
+tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
+
+[features]
+jemalloc = ["rocksdb/jemalloc"]
+test-utils = [
+    "reth-db/test-utils",
+    "reth-nippy-jar/test-utils",
+    "reth-trie/test-utils",
+    "reth-chain-state/test-utils",
+    "reth-ethereum-engine-primitives",
+    "reth-ethereum-primitives/test-utils",
+    "reth-chainspec/test-utils",
+    "reth-primitives-traits/test-utils",
+    "reth-codecs/test-utils",
+    "reth-db-api/test-utils",
+    "reth-trie-db/test-utils",
+    "reth-prune-types/test-utils",
+    "reth-stages-types/test-utils",
+    "revm-state",
+    "tokio",
+    "reth-tasks/test-utils",
+]

--- a/patches/reth-provider/src/bal.rs
+++ b/patches/reth-provider/src/bal.rs
@@ -1,0 +1,109 @@
+use alloy_primitives::{BlockHash, BlockNumber, Bytes};
+use parking_lot::RwLock;
+use reth_storage_api::{BalStore, GetBlockAccessListLimit};
+use reth_storage_errors::provider::ProviderResult;
+use std::{collections::HashMap, sync::Arc};
+
+/// Basic in-memory BAL store keyed by block hash.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryBalStore {
+    entries: Arc<RwLock<HashMap<BlockHash, Bytes>>>,
+}
+
+impl BalStore for InMemoryBalStore {
+    fn insert(
+        &self,
+        block_hash: BlockHash,
+        _block_number: BlockNumber,
+        bal: Bytes,
+    ) -> ProviderResult<()> {
+        self.entries.write().insert(block_hash, bal);
+        Ok(())
+    }
+
+    fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
+        let entries = self.entries.read();
+        let mut result = Vec::with_capacity(block_hashes.len());
+
+        for hash in block_hashes {
+            result.push(entries.get(hash).cloned());
+        }
+
+        Ok(result)
+    }
+
+    fn append_by_hashes_with_limit(
+        &self,
+        block_hashes: &[BlockHash],
+        limit: GetBlockAccessListLimit,
+        out: &mut Vec<Bytes>,
+    ) -> ProviderResult<()> {
+        let entries = self.entries.read();
+        let mut size = 0;
+
+        for hash in block_hashes {
+            let bal = entries.get(hash).cloned().unwrap_or_else(|| Bytes::from_static(&[0xc0]));
+            size += bal.len();
+            out.push(bal);
+
+            if limit.exceeds(size) {
+                break
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn insert_and_lookup_by_hash() {
+        let store = InMemoryBalStore::default();
+        let hash = B256::random();
+        let missing = B256::random();
+        let bal = Bytes::from_static(b"bal");
+
+        store.insert(hash, 1, bal.clone()).unwrap();
+
+        assert_eq!(store.get_by_hashes(&[hash, missing]).unwrap(), vec![Some(bal), None]);
+    }
+
+    #[test]
+    fn range_lookup_is_empty() {
+        let store = InMemoryBalStore::default();
+
+        assert!(store.get_by_range(1, 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn limited_lookup_returns_prefix() {
+        let store = InMemoryBalStore::default();
+        let hash0 = B256::random();
+        let hash1 = B256::random();
+        let hash2 = B256::random();
+        let bal0 = Bytes::from_static(&[0xc1, 0x01]);
+        let bal1 = Bytes::from_static(&[0xc1, 0x02]);
+        let bal2 = Bytes::from_static(&[0xc1, 0x03]);
+
+        store.insert(hash0, 1, bal0.clone()).unwrap();
+        store.insert(hash1, 2, bal1.clone()).unwrap();
+        store.insert(hash2, 3, bal2).unwrap();
+
+        let limited = store
+            .get_by_hashes_with_limit(
+                &[hash0, hash1, hash2],
+                GetBlockAccessListLimit::ResponseSizeSoftLimit(2),
+            )
+            .unwrap();
+
+        assert_eq!(limited, vec![bal0, bal1]);
+    }
+}

--- a/patches/reth-provider/src/changeset_walker.rs
+++ b/patches/reth-provider/src/changeset_walker.rs
@@ -1,0 +1,176 @@
+//! Account/storage changeset iteration support for walking through historical state changes in
+//! static files.
+
+use crate::ProviderResult;
+use alloy_primitives::BlockNumber;
+use reth_db::models::AccountBeforeTx;
+use reth_db_api::models::BlockNumberAddress;
+use reth_primitives_traits::StorageEntry;
+use reth_storage_api::{ChangeSetReader, StorageChangeSetReader};
+use std::ops::{Bound, RangeBounds};
+
+/// Iterator that walks account changesets from static files in a block range.
+///
+/// This iterator fetches changesets block by block to avoid loading everything into memory.
+#[derive(Debug)]
+pub struct StaticFileAccountChangesetWalker<P> {
+    /// Static file provider
+    provider: P,
+    /// End block (exclusive). `None` means iterate until exhausted.
+    end_block: Option<BlockNumber>,
+    /// Current block being processed
+    current_block: BlockNumber,
+    /// Changesets for current block
+    current_changesets: Vec<AccountBeforeTx>,
+    /// Index within current block's changesets
+    changeset_index: usize,
+}
+
+impl<P> StaticFileAccountChangesetWalker<P> {
+    /// Create a new static file changeset walker.
+    ///
+    /// Accepts any range type that implements `RangeBounds<BlockNumber>`, including:
+    /// - `Range<BlockNumber>` (e.g., `0..100`)
+    /// - `RangeInclusive<BlockNumber>` (e.g., `0..=99`)
+    /// - `RangeFrom<BlockNumber>` (e.g., `0..`) - iterates until exhausted
+    ///
+    /// If there is no start bound, 0 is used as the start block.
+    pub fn new(provider: P, range: impl RangeBounds<BlockNumber>) -> Self {
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let end_block = match range.end_bound() {
+            Bound::Included(&n) => Some(n + 1),
+            Bound::Excluded(&n) => Some(n),
+            Bound::Unbounded => None,
+        };
+
+        Self {
+            provider,
+            end_block,
+            current_block: start,
+            current_changesets: Vec::new(),
+            changeset_index: 0,
+        }
+    }
+}
+
+impl<P> Iterator for StaticFileAccountChangesetWalker<P>
+where
+    P: ChangeSetReader,
+{
+    type Item = ProviderResult<(BlockNumber, AccountBeforeTx)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Yield remaining changesets from current block
+        if let Some(changeset) = self.current_changesets.get(self.changeset_index).cloned() {
+            self.changeset_index += 1;
+            return Some(Ok((self.current_block, changeset)));
+        }
+
+        // Advance to next block if we exhausted the previous one
+        //
+        // If we do not return from the previous condition, but the current changesets are
+        // non-empty, then we have run past the current changeset and must fetch the next
+        // changeset.
+        if !self.current_changesets.is_empty() {
+            self.current_block += 1;
+        }
+
+        // Load next block with changesets
+        while self.end_block.is_none_or(|end| self.current_block < end) {
+            match self.provider.account_block_changeset(self.current_block) {
+                Ok(changesets) if !changesets.is_empty() => {
+                    self.current_changesets = changesets;
+                    self.changeset_index = 1;
+                    return Some(Ok((self.current_block, self.current_changesets[0].clone())));
+                }
+                Ok(_) => self.current_block += 1,
+                Err(e) => {
+                    self.current_block += 1;
+                    return Some(Err(e));
+                }
+            }
+        }
+
+        None
+    }
+}
+
+/// Iterator that walks storage changesets from static files in a block range.
+#[derive(Debug)]
+pub struct StaticFileStorageChangesetWalker<P> {
+    /// Static file provider
+    provider: P,
+    /// End block (exclusive). `None` means iterate until exhausted.
+    end_block: Option<BlockNumber>,
+    /// Current block being processed
+    current_block: BlockNumber,
+    /// Changesets for current block
+    current_changesets: Vec<(BlockNumberAddress, StorageEntry)>,
+    /// Index within current block's changesets
+    changeset_index: usize,
+}
+
+impl<P> StaticFileStorageChangesetWalker<P> {
+    /// Create a new static file storage changeset walker.
+    pub fn new(provider: P, range: impl RangeBounds<BlockNumber>) -> Self {
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let end_block = match range.end_bound() {
+            Bound::Included(&n) => Some(n + 1),
+            Bound::Excluded(&n) => Some(n),
+            Bound::Unbounded => None,
+        };
+
+        Self {
+            provider,
+            end_block,
+            current_block: start,
+            current_changesets: Vec::new(),
+            changeset_index: 0,
+        }
+    }
+}
+
+impl<P> Iterator for StaticFileStorageChangesetWalker<P>
+where
+    P: StorageChangeSetReader,
+{
+    type Item = ProviderResult<(BlockNumberAddress, StorageEntry)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(changeset) = self.current_changesets.get(self.changeset_index).copied() {
+            self.changeset_index += 1;
+            return Some(Ok(changeset));
+        }
+
+        if !self.current_changesets.is_empty() {
+            self.current_block += 1;
+        }
+
+        while self.end_block.is_none_or(|end| self.current_block < end) {
+            match self.provider.storage_changeset(self.current_block) {
+                Ok(changesets) if !changesets.is_empty() => {
+                    self.current_changesets = changesets;
+                    self.changeset_index = 1;
+                    return Some(Ok(self.current_changesets[0]));
+                }
+                Ok(_) => self.current_block += 1,
+                Err(e) => {
+                    self.current_block += 1;
+                    return Some(Err(e));
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/patches/reth-provider/src/changesets_utils/mod.rs
+++ b/patches/reth-provider/src/changesets_utils/mod.rs
@@ -1,0 +1,4 @@
+//! This module contains helpful utilities related to populating changesets tables.
+
+mod state_reverts;
+pub use state_reverts::StorageRevertsIter;

--- a/patches/reth-provider/src/changesets_utils/state_reverts.rs
+++ b/patches/reth-provider/src/changesets_utils/state_reverts.rs
@@ -1,0 +1,180 @@
+use alloy_primitives::{B256, U256};
+use revm_database::states::RevertToSlot;
+use std::iter::Peekable;
+
+/// Iterator over storage reverts.
+/// See [`StorageRevertsIter::next`] for more details.
+#[expect(missing_debug_implementations)]
+pub struct StorageRevertsIter<R: Iterator, W: Iterator> {
+    reverts: Peekable<R>,
+    wiped: Peekable<W>,
+}
+
+impl<R, W> StorageRevertsIter<R, W>
+where
+    R: Iterator<Item = (B256, RevertToSlot)>,
+    W: Iterator<Item = (B256, U256)>,
+{
+    /// Create a new iterator over storage reverts.
+    pub fn new(
+        reverts: impl IntoIterator<IntoIter = R>,
+        wiped: impl IntoIterator<IntoIter = W>,
+    ) -> Self {
+        Self { reverts: reverts.into_iter().peekable(), wiped: wiped.into_iter().peekable() }
+    }
+
+    /// Consume next revert and return it.
+    fn next_revert(&mut self) -> Option<(B256, U256)> {
+        self.reverts.next().map(|(key, revert)| (key, revert.to_previous_value()))
+    }
+
+    /// Consume next wiped storage and return it.
+    fn next_wiped(&mut self) -> Option<(B256, U256)> {
+        self.wiped.next()
+    }
+}
+
+impl<R, W> Iterator for StorageRevertsIter<R, W>
+where
+    R: Iterator<Item = (B256, RevertToSlot)>,
+    W: Iterator<Item = (B256, U256)>,
+{
+    type Item = (B256, U256);
+
+    /// Iterate over storage reverts and wiped entries and return items in the sorted order.
+    /// NOTE: The implementation assumes that inner iterators are already sorted.
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.reverts.peek(), self.wiped.peek()) {
+            (Some(revert), Some(wiped)) => {
+                // Compare the keys and return the lesser.
+                use std::cmp::Ordering;
+                match revert.0.cmp(&wiped.0) {
+                    Ordering::Less => self.next_revert(),
+                    Ordering::Greater => self.next_wiped(),
+                    Ordering::Equal => {
+                        // Keys are the same, decide which one to return.
+                        let (key, revert_to) = *revert;
+
+                        let value = match revert_to {
+                            // If the slot is some, prefer the revert value.
+                            RevertToSlot::Some(value) => value,
+                            // If the slot was destroyed, prefer the database value.
+                            RevertToSlot::Destroyed => wiped.1,
+                        };
+
+                        // Consume both values from inner iterators.
+                        self.next_revert();
+                        self.next_wiped();
+
+                        Some((key, value))
+                    }
+                }
+            }
+            (Some(_revert), None) => self.next_revert(),
+            (None, Some(_wiped)) => self.next_wiped(),
+            (None, None) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_reverts_iter_empty() {
+        // Create empty sample data for reverts and wiped entries.
+        let reverts: Vec<(B256, RevertToSlot)> = vec![];
+        let wiped: Vec<(B256, U256)> = vec![];
+
+        // Create the iterator with the empty data.
+        let iter = StorageRevertsIter::new(reverts, wiped);
+
+        // Iterate and collect results into a vector for verification.
+        let results: Vec<_> = iter.collect();
+
+        // Verify that the results are empty.
+        assert_eq!(results, vec![]);
+    }
+
+    #[test]
+    fn test_storage_reverts_iter_reverts_only() {
+        // Create sample data for only reverts.
+        let reverts = vec![
+            (B256::from_slice(&[4; 32]), RevertToSlot::Destroyed),
+            (B256::from_slice(&[5; 32]), RevertToSlot::Some(U256::from(40))),
+        ];
+
+        // Create the iterator with only reverts and no wiped entries.
+        let iter = StorageRevertsIter::new(reverts, vec![]);
+
+        // Iterate and collect results into a vector for verification.
+        let results: Vec<_> = iter.collect();
+
+        // Verify the output order and values.
+        assert_eq!(
+            results,
+            vec![
+                (B256::from_slice(&[4; 32]), U256::ZERO), // Revert slot previous value
+                (B256::from_slice(&[5; 32]), U256::from(40)), // Only revert present.
+            ]
+        );
+    }
+
+    #[test]
+    fn test_storage_reverts_iter_wiped_only() {
+        // Create sample data for only wiped entries.
+        let wiped = vec![
+            (B256::from_slice(&[6; 32]), U256::from(50)),
+            (B256::from_slice(&[7; 32]), U256::from(60)),
+        ];
+
+        // Create the iterator with only wiped entries and no reverts.
+        let iter = StorageRevertsIter::new(vec![], wiped);
+
+        // Iterate and collect results into a vector for verification.
+        let results: Vec<_> = iter.collect();
+
+        // Verify the output order and values.
+        assert_eq!(
+            results,
+            vec![
+                (B256::from_slice(&[6; 32]), U256::from(50)), // Only wiped present.
+                (B256::from_slice(&[7; 32]), U256::from(60)), // Only wiped present.
+            ]
+        );
+    }
+
+    #[test]
+    fn test_storage_reverts_iter_interleaved() {
+        // Create sample data for interleaved reverts and wiped entries.
+        let reverts = vec![
+            (B256::from_slice(&[8; 32]), RevertToSlot::Some(U256::from(70))),
+            (B256::from_slice(&[9; 32]), RevertToSlot::Some(U256::from(80))),
+            // Some higher key than wiped
+            (B256::from_slice(&[15; 32]), RevertToSlot::Some(U256::from(90))),
+        ];
+
+        let wiped = vec![
+            (B256::from_slice(&[8; 32]), U256::from(75)), // Same key as revert
+            (B256::from_slice(&[10; 32]), U256::from(85)), // Wiped with new key
+        ];
+
+        // Create the iterator with the sample data.
+        let iter = StorageRevertsIter::new(reverts, wiped);
+
+        // Iterate and collect results into a vector for verification.
+        let results: Vec<_> = iter.collect();
+
+        // Verify the output order and values.
+        assert_eq!(
+            results,
+            vec![
+                (B256::from_slice(&[8; 32]), U256::from(70)), // Revert takes priority.
+                (B256::from_slice(&[9; 32]), U256::from(80)), // Only revert present.
+                (B256::from_slice(&[10; 32]), U256::from(85)), // Wiped entry.
+                (B256::from_slice(&[15; 32]), U256::from(90)), // Greater revert entry
+            ]
+        );
+    }
+}

--- a/patches/reth-provider/src/either_writer.rs
+++ b/patches/reth-provider/src/either_writer.rs
@@ -1,0 +1,1826 @@
+//! Generic reader and writer abstractions for interacting with either database tables or static
+//! files.
+
+use std::{
+    collections::BTreeSet,
+    marker::PhantomData,
+    ops::{Range, RangeInclusive},
+};
+
+use crate::{
+    providers::{
+        history_info, rocksdb::RocksDBBatch, HistoryInfo, StaticFileProvider,
+        StaticFileProviderRWRefMut,
+    },
+    StaticFileProviderFactory,
+};
+use alloy_primitives::{map::HashMap, Address, BlockNumber, TxHash, TxNumber, B256};
+use rayon::slice::ParallelSliceMut;
+use reth_db::{
+    cursor::{DbCursorRO, DbDupCursorRW},
+    models::{AccountBeforeTx, StorageBeforeTx},
+    static_file::TransactionSenderMask,
+    table::Value,
+    transaction::{CursorMutTy, CursorTy, DbTx, DbTxMut, DupCursorMutTy, DupCursorTy},
+};
+use reth_db_api::{
+    cursor::DbCursorRW,
+    models::{storage_sharded_key::StorageShardedKey, BlockNumberAddress, ShardedKey},
+    tables,
+    tables::BlockNumberList,
+};
+use reth_errors::ProviderError;
+use reth_node_types::NodePrimitives;
+use reth_primitives_traits::{ReceiptTy, StorageEntry};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{ChangeSetReader, DBProvider, NodePrimitivesProvider, StorageSettingsCache};
+use reth_storage_errors::provider::ProviderResult;
+use strum::{Display, EnumIs};
+
+/// Type alias for [`EitherReader`] constructors.
+type EitherReaderTy<'a, P, T> =
+    EitherReader<'a, CursorTy<<P as DBProvider>::Tx, T>, <P as NodePrimitivesProvider>::Primitives>;
+
+/// Type alias for [`EitherReader`] constructors.
+type DupEitherReaderTy<'a, P, T> = EitherReader<
+    'a,
+    DupCursorTy<<P as DBProvider>::Tx, T>,
+    <P as NodePrimitivesProvider>::Primitives,
+>;
+
+/// Type alias for dup [`EitherWriter`] constructors.
+type DupEitherWriterTy<'a, P, T> = EitherWriter<
+    'a,
+    DupCursorMutTy<<P as DBProvider>::Tx, T>,
+    <P as NodePrimitivesProvider>::Primitives,
+>;
+
+/// Type alias for [`EitherWriter`] constructors.
+type EitherWriterTy<'a, P, T> = EitherWriter<
+    'a,
+    CursorMutTy<<P as DBProvider>::Tx, T>,
+    <P as NodePrimitivesProvider>::Primitives,
+>;
+
+/// Helper type for `RocksDB` batch argument in writer constructors.
+pub type RocksBatchArg<'a> = crate::providers::rocksdb::RocksDBBatch<'a>;
+
+/// The raw `RocksDB` batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
+pub type RawRocksDBBatch = rocksdb::WriteBatchWithTransaction<true>;
+
+/// Helper type for `RocksDB` snapshot argument in reader constructors.
+///
+/// The `Option` allows callers to skip `RocksDB` access when it isn't needed
+/// (e.g., on legacy MDBX-only nodes).
+pub type RocksDBRefArg<'a> = Option<crate::providers::rocksdb::RocksReadSnapshot<'a>>;
+
+/// Represents a destination for writing data, either to database, static files, or `RocksDB`.
+#[derive(Debug, Display)]
+pub enum EitherWriter<'a, CURSOR, N> {
+    /// Write to database table via cursor
+    Database(CURSOR),
+    /// Write to static file
+    StaticFile(StaticFileProviderRWRefMut<'a, N>),
+    /// Write to `RocksDB` using a write-only batch (historical tables).
+    RocksDB(RocksDBBatch<'a>),
+}
+
+impl<'a> EitherWriter<'a, (), ()> {
+    /// Creates a new [`EitherWriter`] for receipts based on storage settings and prune modes.
+    pub fn new_receipts<P>(
+        provider: &'a P,
+        block_number: BlockNumber,
+    ) -> ProviderResult<EitherWriterTy<'a, P, tables::Receipts<ReceiptTy<P::Primitives>>>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
+        P::Tx: DbTxMut,
+        ReceiptTy<P::Primitives>: Value,
+    {
+        if Self::receipts_destination(provider).is_static_file() {
+            Ok(EitherWriter::StaticFile(
+                provider.get_static_file_writer(block_number, StaticFileSegment::Receipts)?,
+            ))
+        } else {
+            Ok(EitherWriter::Database(
+                provider.tx_ref().cursor_write::<tables::Receipts<ReceiptTy<P::Primitives>>>()?,
+            ))
+        }
+    }
+
+    /// Creates a new [`EitherWriter`] for senders based on storage settings.
+    pub fn new_senders<P>(
+        provider: &'a P,
+        block_number: BlockNumber,
+    ) -> ProviderResult<EitherWriterTy<'a, P, tables::TransactionSenders>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
+        P::Tx: DbTxMut,
+    {
+        if EitherWriterDestination::senders(provider).is_static_file() {
+            Ok(EitherWriter::StaticFile(
+                provider
+                    .get_static_file_writer(block_number, StaticFileSegment::TransactionSenders)?,
+            ))
+        } else {
+            Ok(EitherWriter::Database(
+                provider.tx_ref().cursor_write::<tables::TransactionSenders>()?,
+            ))
+        }
+    }
+
+    /// Creates a new [`EitherWriter`] for account changesets based on storage settings and prune
+    /// modes.
+    pub fn new_account_changesets<P>(
+        provider: &'a P,
+        block_number: BlockNumber,
+    ) -> ProviderResult<DupEitherWriterTy<'a, P, tables::AccountChangeSets>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
+        P::Tx: DbTxMut,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            Ok(EitherWriter::StaticFile(
+                provider
+                    .get_static_file_writer(block_number, StaticFileSegment::AccountChangeSets)?,
+            ))
+        } else {
+            Ok(EitherWriter::Database(
+                provider.tx_ref().cursor_dup_write::<tables::AccountChangeSets>()?,
+            ))
+        }
+    }
+
+    /// Creates a new [`EitherWriter`] for storage changesets based on storage settings.
+    pub fn new_storage_changesets<P>(
+        provider: &'a P,
+        block_number: BlockNumber,
+    ) -> ProviderResult<DupEitherWriterTy<'a, P, tables::StorageChangeSets>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
+        P::Tx: DbTxMut,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            Ok(EitherWriter::StaticFile(
+                provider
+                    .get_static_file_writer(block_number, StaticFileSegment::StorageChangeSets)?,
+            ))
+        } else {
+            Ok(EitherWriter::Database(
+                provider.tx_ref().cursor_dup_write::<tables::StorageChangeSets>()?,
+            ))
+        }
+    }
+
+    /// Returns the destination for writing receipts.
+    ///
+    /// The rules are as follows:
+    /// - If the node should not always write receipts to static files, and any receipt pruning is
+    ///   enabled, write to the database.
+    /// - If the node should always write receipts to static files, but receipt log filter pruning
+    ///   is enabled, write to the database.
+    /// - Otherwise, write to static files.
+    pub fn receipts_destination<P: DBProvider + StorageSettingsCache>(
+        provider: &P,
+    ) -> EitherWriterDestination {
+        let receipts_in_static_files = provider.cached_storage_settings().storage_v2;
+        let prune_modes = provider.prune_modes_ref();
+
+        if !receipts_in_static_files && prune_modes.has_receipts_pruning() ||
+            // TODO: support writing receipts to static files with log filter pruning enabled
+            receipts_in_static_files && !prune_modes.receipts_log_filter.is_empty()
+        {
+            EitherWriterDestination::Database
+        } else {
+            EitherWriterDestination::StaticFile
+        }
+    }
+
+    /// Returns the destination for writing account changesets.
+    ///
+    /// This determines the destination based solely on storage settings.
+    pub fn account_changesets_destination<P: DBProvider + StorageSettingsCache>(
+        provider: &P,
+    ) -> EitherWriterDestination {
+        if provider.cached_storage_settings().storage_v2 {
+            EitherWriterDestination::StaticFile
+        } else {
+            EitherWriterDestination::Database
+        }
+    }
+
+    /// Returns the destination for writing storage changesets.
+    ///
+    /// This determines the destination based solely on storage settings.
+    pub fn storage_changesets_destination<P: DBProvider + StorageSettingsCache>(
+        provider: &P,
+    ) -> EitherWriterDestination {
+        if provider.cached_storage_settings().storage_v2 {
+            EitherWriterDestination::StaticFile
+        } else {
+            EitherWriterDestination::Database
+        }
+    }
+
+    /// Creates a new [`EitherWriter`] for storages history based on storage settings.
+    pub fn new_storages_history<P>(
+        provider: &P,
+        _rocksdb_batch: RocksBatchArg<'a>,
+    ) -> ProviderResult<EitherWriterTy<'a, P, tables::StoragesHistory>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
+        P::Tx: DbTxMut,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            return Ok(EitherWriter::RocksDB(_rocksdb_batch));
+        }
+
+        Ok(EitherWriter::Database(provider.tx_ref().cursor_write::<tables::StoragesHistory>()?))
+    }
+
+    /// Creates a new [`EitherWriter`] for transaction hash numbers based on storage settings.
+    pub fn new_transaction_hash_numbers<P>(
+        provider: &P,
+        _rocksdb_batch: RocksBatchArg<'a>,
+    ) -> ProviderResult<EitherWriterTy<'a, P, tables::TransactionHashNumbers>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
+        P::Tx: DbTxMut,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            return Ok(EitherWriter::RocksDB(_rocksdb_batch));
+        }
+
+        Ok(EitherWriter::Database(
+            provider.tx_ref().cursor_write::<tables::TransactionHashNumbers>()?,
+        ))
+    }
+
+    /// Creates a new [`EitherWriter`] for account history based on storage settings.
+    pub fn new_accounts_history<P>(
+        provider: &P,
+        _rocksdb_batch: RocksBatchArg<'a>,
+    ) -> ProviderResult<EitherWriterTy<'a, P, tables::AccountsHistory>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
+        P::Tx: DbTxMut,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            return Ok(EitherWriter::RocksDB(_rocksdb_batch));
+        }
+
+        Ok(EitherWriter::Database(provider.tx_ref().cursor_write::<tables::AccountsHistory>()?))
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {
+    /// Extracts the raw `RocksDB` write batch from this writer, if it contains one.
+    ///
+    /// Returns `Some(WriteBatchWithTransaction)` for [`Self::RocksDB`] variant,
+    /// `None` for other variants.
+    ///
+    /// This is used to defer `RocksDB` commits to the provider level, ensuring all
+    /// storage commits (MDBX, static files, `RocksDB`) happen atomically in a single place.
+    pub fn into_raw_rocksdb_batch(self) -> Option<rocksdb::WriteBatchWithTransaction<true>> {
+        match self {
+            Self::Database(_) | Self::StaticFile(_) => None,
+            Self::RocksDB(batch) => Some(batch.into_inner()),
+        }
+    }
+
+    /// Increment the block number.
+    ///
+    /// Relevant only for [`Self::StaticFile`]. It is a no-op for [`Self::Database`].
+    pub fn increment_block(&mut self, expected_block_number: BlockNumber) -> ProviderResult<()> {
+        match self {
+            Self::Database(_) => Ok(()),
+            Self::StaticFile(writer) => writer.increment_block(expected_block_number),
+            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+
+    /// Ensures that the writer is positioned at the specified block number.
+    ///
+    /// If the writer is positioned at a greater block number than the specified one, the writer
+    /// will NOT be unwound and the error will be returned.
+    ///
+    /// Relevant only for [`Self::StaticFile`]. It is a no-op for [`Self::Database`].
+    pub fn ensure_at_block(&mut self, block_number: BlockNumber) -> ProviderResult<()> {
+        match self {
+            Self::Database(_) => Ok(()),
+            Self::StaticFile(writer) => writer.ensure_at_block(block_number),
+            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    N::Receipt: Value,
+    CURSOR: DbCursorRW<tables::Receipts<N::Receipt>>,
+{
+    /// Append a transaction receipt.
+    pub fn append_receipt(&mut self, tx_num: TxNumber, receipt: &N::Receipt) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.append(tx_num, receipt)?),
+            Self::StaticFile(writer) => writer.append_receipt(tx_num, receipt),
+            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    CURSOR: DbCursorRW<tables::TransactionSenders>,
+{
+    /// Append a transaction sender to the destination
+    pub fn append_sender(&mut self, tx_num: TxNumber, sender: &Address) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.append(tx_num, sender)?),
+            Self::StaticFile(writer) => writer.append_transaction_sender(tx_num, sender),
+            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+
+    /// Append transaction senders to the destination
+    pub fn append_senders<I>(&mut self, senders: I) -> ProviderResult<()>
+    where
+        I: Iterator<Item = (TxNumber, Address)>,
+    {
+        match self {
+            Self::Database(cursor) => {
+                for (tx_num, sender) in senders {
+                    cursor.append(tx_num, &sender)?;
+                }
+                Ok(())
+            }
+            Self::StaticFile(writer) => writer.append_transaction_senders(senders),
+            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+
+    /// Removes all transaction senders above the given transaction number, and stops at the given
+    /// block number.
+    pub fn prune_senders(
+        &mut self,
+        unwind_tx_from: TxNumber,
+        block: BlockNumber,
+    ) -> ProviderResult<()>
+    where
+        CURSOR: DbCursorRO<tables::TransactionSenders>,
+    {
+        match self {
+            Self::Database(cursor) => {
+                let mut walker = cursor.walk_range(unwind_tx_from..)?;
+                while walker.next().transpose()?.is_some() {
+                    walker.delete_current()?;
+                }
+            }
+            Self::StaticFile(writer) => {
+                let static_file_transaction_sender_num = writer
+                    .reader()
+                    .get_highest_static_file_tx(StaticFileSegment::TransactionSenders);
+
+                let to_delete = static_file_transaction_sender_num
+                    .map(|static_num| (static_num + 1).saturating_sub(unwind_tx_from))
+                    .unwrap_or_default();
+
+                writer.prune_transaction_senders(to_delete, block)?;
+            }
+            Self::RocksDB(_) => return Err(ProviderError::UnsupportedProvider),
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    CURSOR: DbCursorRW<tables::TransactionHashNumbers> + DbCursorRO<tables::TransactionHashNumbers>,
+{
+    /// Puts a transaction hash number mapping.
+    ///
+    /// When `append_only` is true, uses `cursor.append()` which is significantly faster
+    /// but requires entries to be inserted in order and the table to be empty.
+    /// When false, uses `cursor.upsert()` which handles arbitrary insertion order and duplicates.
+    pub fn put_transaction_hash_number(
+        &mut self,
+        hash: TxHash,
+        tx_num: TxNumber,
+        append_only: bool,
+    ) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => {
+                if append_only {
+                    Ok(cursor.append(hash, &tx_num)?)
+                } else {
+                    Ok(cursor.upsert(hash, &tx_num)?)
+                }
+            }
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.put::<tables::TransactionHashNumbers>(hash, &tx_num),
+        }
+    }
+
+    /// Puts multiple transaction hash number mappings in a batch.
+    ///
+    /// Accepts a vector of `(TxHash, TxNumber)` tuples and writes them all using the same cursor.
+    /// This is more efficient than calling `put_transaction_hash_number` repeatedly.
+    ///
+    /// When `append_only` is true, uses `cursor.append()` which requires entries to be
+    /// pre-sorted and the table to be empty or have only lower keys.
+    /// When false, uses `cursor.upsert()` which handles arbitrary insertion order.
+    pub fn put_transaction_hash_numbers_batch(
+        &mut self,
+        entries: Vec<(TxHash, TxNumber)>,
+        append_only: bool,
+    ) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => {
+                for (hash, tx_num) in entries {
+                    if append_only {
+                        cursor.append(hash, &tx_num)?;
+                    } else {
+                        cursor.upsert(hash, &tx_num)?;
+                    }
+                }
+                Ok(())
+            }
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => {
+                for (hash, tx_num) in entries {
+                    batch.put::<tables::TransactionHashNumbers>(hash, &tx_num)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Deletes a transaction hash number mapping.
+    pub fn delete_transaction_hash_number(&mut self, hash: TxHash) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => {
+                if cursor.seek_exact(hash)?.is_some() {
+                    cursor.delete_current()?;
+                }
+                Ok(())
+            }
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.delete::<tables::TransactionHashNumbers>(hash),
+        }
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    CURSOR: DbCursorRW<tables::StoragesHistory> + DbCursorRO<tables::StoragesHistory>,
+{
+    /// Puts a storage history entry.
+    pub fn put_storage_history(
+        &mut self,
+        key: StorageShardedKey,
+        value: &BlockNumberList,
+    ) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.upsert(key, value)?),
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.put::<tables::StoragesHistory>(key, value),
+        }
+    }
+
+    /// Deletes a storage history entry.
+    pub fn delete_storage_history(&mut self, key: StorageShardedKey) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => {
+                if cursor.seek_exact(key)?.is_some() {
+                    cursor.delete_current()?;
+                }
+                Ok(())
+            }
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.delete::<tables::StoragesHistory>(key),
+        }
+    }
+
+    /// Appends a storage history entry (for first sync - more efficient).
+    pub fn append_storage_history(
+        &mut self,
+        key: StorageShardedKey,
+        value: &BlockNumberList,
+    ) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.append(key, value)?),
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.put::<tables::StoragesHistory>(key, value),
+        }
+    }
+
+    /// Upserts a storage history entry (for incremental sync).
+    pub fn upsert_storage_history(
+        &mut self,
+        key: StorageShardedKey,
+        value: &BlockNumberList,
+    ) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.upsert(key, value)?),
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.put::<tables::StoragesHistory>(key, value),
+        }
+    }
+
+    /// Gets the last shard for an address and storage key (keyed with `u64::MAX`).
+    pub fn get_last_storage_history_shard(
+        &mut self,
+        address: Address,
+        storage_key: B256,
+    ) -> ProviderResult<Option<BlockNumberList>> {
+        let key = StorageShardedKey::last(address, storage_key);
+        match self {
+            Self::Database(cursor) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.get::<tables::StoragesHistory>(key),
+        }
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    CURSOR: DbCursorRW<tables::AccountsHistory> + DbCursorRO<tables::AccountsHistory>,
+{
+    /// Appends an account history entry (for first sync - more efficient).
+    pub fn append_account_history(
+        &mut self,
+        key: ShardedKey<Address>,
+        value: &BlockNumberList,
+    ) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.append(key, value)?),
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.put::<tables::AccountsHistory>(key, value),
+        }
+    }
+
+    /// Upserts an account history entry (for incremental sync).
+    pub fn upsert_account_history(
+        &mut self,
+        key: ShardedKey<Address>,
+        value: &BlockNumberList,
+    ) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.upsert(key, value)?),
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.put::<tables::AccountsHistory>(key, value),
+        }
+    }
+
+    /// Gets the last shard for an address (keyed with `u64::MAX`).
+    pub fn get_last_account_history_shard(
+        &mut self,
+        address: Address,
+    ) -> ProviderResult<Option<BlockNumberList>> {
+        match self {
+            Self::Database(cursor) => {
+                Ok(cursor.seek_exact(ShardedKey::last(address))?.map(|(_, v)| v))
+            }
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.get::<tables::AccountsHistory>(ShardedKey::last(address)),
+        }
+    }
+
+    /// Deletes an account history entry.
+    pub fn delete_account_history(&mut self, key: ShardedKey<Address>) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => {
+                if cursor.seek_exact(key)?.is_some() {
+                    cursor.delete_current()?;
+                }
+                Ok(())
+            }
+            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(batch) => batch.delete::<tables::AccountsHistory>(key),
+        }
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    CURSOR: DbDupCursorRW<tables::AccountChangeSets>,
+{
+    /// Append account changeset for a block.
+    ///
+    /// NOTE: This _sorts_ the changesets by address before appending
+    pub fn append_account_changeset(
+        &mut self,
+        block_number: BlockNumber,
+        mut changeset: Vec<AccountBeforeTx>,
+    ) -> ProviderResult<()> {
+        // First sort the changesets
+        changeset.par_sort_by_key(|a| a.address);
+        match self {
+            Self::Database(cursor) => {
+                for change in changeset {
+                    cursor.append_dup(block_number, change)?;
+                }
+            }
+            Self::StaticFile(writer) => {
+                writer.append_account_changeset(changeset, block_number)?;
+            }
+            Self::RocksDB(_) => return Err(ProviderError::UnsupportedProvider),
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    CURSOR: DbDupCursorRW<tables::StorageChangeSets>,
+{
+    /// Append storage changeset for a block.
+    ///
+    /// NOTE: This _sorts_ the changesets by address and storage key before appending.
+    pub fn append_storage_changeset(
+        &mut self,
+        block_number: BlockNumber,
+        mut changeset: Vec<StorageBeforeTx>,
+    ) -> ProviderResult<()> {
+        changeset.par_sort_by_key(|change| (change.address, change.key));
+
+        match self {
+            Self::Database(cursor) => {
+                for change in changeset {
+                    let storage_id = BlockNumberAddress((block_number, change.address));
+                    cursor.append_dup(
+                        storage_id,
+                        StorageEntry { key: change.key, value: change.value },
+                    )?;
+                }
+            }
+            Self::StaticFile(writer) => {
+                writer.append_storage_changeset(changeset, block_number)?;
+            }
+            Self::RocksDB(_) => return Err(ProviderError::UnsupportedProvider),
+        }
+
+        Ok(())
+    }
+}
+
+/// Represents a source for reading data, either from database, static files, or `RocksDB`.
+#[derive(Debug, Display)]
+pub enum EitherReader<'a, CURSOR, N> {
+    /// Read from database table via cursor
+    Database(CURSOR, PhantomData<&'a ()>),
+    /// Read from static file
+    StaticFile(StaticFileProvider<N>, PhantomData<&'a ()>),
+    /// Read from `RocksDB` snapshot (works in both read-only and read-write modes)
+    RocksDB(crate::providers::rocksdb::RocksReadSnapshot<'a>),
+}
+
+impl<'a> EitherReader<'a, (), ()> {
+    /// Creates a new [`EitherReader`] for senders based on storage settings.
+    pub fn new_senders<P>(
+        provider: &P,
+    ) -> ProviderResult<EitherReaderTy<'a, P, tables::TransactionSenders>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
+        P::Tx: DbTx,
+    {
+        if EitherWriterDestination::senders(provider).is_static_file() {
+            Ok(EitherReader::StaticFile(provider.static_file_provider(), PhantomData))
+        } else {
+            Ok(EitherReader::Database(
+                provider.tx_ref().cursor_read::<tables::TransactionSenders>()?,
+                PhantomData,
+            ))
+        }
+    }
+
+    /// Creates a new [`EitherReader`] for storages history based on storage settings.
+    pub fn new_storages_history<P>(
+        provider: &P,
+        rocksdb: RocksDBRefArg<'a>,
+    ) -> ProviderResult<EitherReaderTy<'a, P, tables::StoragesHistory>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
+        P::Tx: DbTx,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            return Ok(EitherReader::RocksDB(
+                rocksdb.expect("storages_history_in_rocksdb requires rocksdb snapshot"),
+            ));
+        }
+
+        Ok(EitherReader::Database(
+            provider.tx_ref().cursor_read::<tables::StoragesHistory>()?,
+            PhantomData,
+        ))
+    }
+
+    /// Creates a new [`EitherReader`] for transaction hash numbers based on storage settings.
+    pub fn new_transaction_hash_numbers<P>(
+        provider: &P,
+        rocksdb: RocksDBRefArg<'a>,
+    ) -> ProviderResult<EitherReaderTy<'a, P, tables::TransactionHashNumbers>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
+        P::Tx: DbTx,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            return Ok(EitherReader::RocksDB(
+                rocksdb.expect("transaction_hash_numbers_in_rocksdb requires rocksdb snapshot"),
+            ));
+        }
+
+        Ok(EitherReader::Database(
+            provider.tx_ref().cursor_read::<tables::TransactionHashNumbers>()?,
+            PhantomData,
+        ))
+    }
+
+    /// Creates a new [`EitherReader`] for account history based on storage settings.
+    pub fn new_accounts_history<P>(
+        provider: &P,
+        rocksdb: RocksDBRefArg<'a>,
+    ) -> ProviderResult<EitherReaderTy<'a, P, tables::AccountsHistory>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
+        P::Tx: DbTx,
+    {
+        if provider.cached_storage_settings().storage_v2 {
+            return Ok(EitherReader::RocksDB(
+                rocksdb.expect("account_history_in_rocksdb requires rocksdb snapshot"),
+            ));
+        }
+
+        Ok(EitherReader::Database(
+            provider.tx_ref().cursor_read::<tables::AccountsHistory>()?,
+            PhantomData,
+        ))
+    }
+
+    /// Creates a new [`EitherReader`] for account changesets based on storage settings.
+    pub fn new_account_changesets<P>(
+        provider: &P,
+    ) -> ProviderResult<DupEitherReaderTy<'a, P, tables::AccountChangeSets>>
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
+        P::Tx: DbTx,
+    {
+        if EitherWriterDestination::account_changesets(provider).is_static_file() {
+            Ok(EitherReader::StaticFile(provider.static_file_provider(), PhantomData))
+        } else {
+            Ok(EitherReader::Database(
+                provider.tx_ref().cursor_dup_read::<tables::AccountChangeSets>()?,
+                PhantomData,
+            ))
+        }
+    }
+}
+
+impl<CURSOR, N: NodePrimitives> EitherReader<'_, CURSOR, N>
+where
+    CURSOR: DbCursorRO<tables::TransactionSenders>,
+{
+    /// Fetches the senders for a range of transactions.
+    pub fn senders_by_tx_range(
+        &mut self,
+        range: Range<TxNumber>,
+    ) -> ProviderResult<HashMap<TxNumber, Address>> {
+        match self {
+            Self::Database(cursor, _) => cursor
+                .walk_range(range)?
+                .map(|result| result.map_err(ProviderError::from))
+                .collect::<ProviderResult<HashMap<_, _>>>(),
+            Self::StaticFile(provider, _) => range
+                .clone()
+                .zip(provider.fetch_range_iter(
+                    StaticFileSegment::TransactionSenders,
+                    range,
+                    |cursor, number| cursor.get_one::<TransactionSenderMask>(number.into()),
+                )?)
+                .filter_map(|(tx_num, sender)| {
+                    let result = sender.transpose()?;
+                    Some(result.map(|sender| (tx_num, sender)))
+                })
+                .collect::<ProviderResult<HashMap<_, _>>>(),
+            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+}
+
+impl<CURSOR, N: NodePrimitives> EitherReader<'_, CURSOR, N>
+where
+    CURSOR: DbCursorRO<tables::TransactionHashNumbers>,
+{
+    /// Gets a transaction number by its hash.
+    pub fn get_transaction_hash_number(
+        &mut self,
+        hash: TxHash,
+    ) -> ProviderResult<Option<TxNumber>> {
+        match self {
+            Self::Database(cursor, _) => Ok(cursor.seek_exact(hash)?.map(|(_, v)| v)),
+            Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(snapshot) => snapshot.get::<tables::TransactionHashNumbers>(hash),
+        }
+    }
+}
+
+impl<CURSOR, N: NodePrimitives> EitherReader<'_, CURSOR, N>
+where
+    CURSOR: DbCursorRO<tables::StoragesHistory>,
+{
+    /// Gets a storage history shard entry for the given [`StorageShardedKey`], if present.
+    pub fn get_storage_history(
+        &mut self,
+        key: StorageShardedKey,
+    ) -> ProviderResult<Option<BlockNumberList>> {
+        match self {
+            Self::Database(cursor, _) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
+            Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(snapshot) => snapshot.get::<tables::StoragesHistory>(key),
+        }
+    }
+
+    /// Lookup storage history and return [`HistoryInfo`].
+    pub fn storage_history_info(
+        &mut self,
+        address: Address,
+        storage_key: alloy_primitives::B256,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+        visible_tip: BlockNumber,
+    ) -> ProviderResult<HistoryInfo> {
+        match self {
+            Self::Database(cursor, _) => {
+                let key = StorageShardedKey::new(address, storage_key, block_number);
+                history_info::<tables::StoragesHistory, _, _>(
+                    cursor,
+                    key,
+                    block_number,
+                    |k| k.address == address && k.sharded_key.key == storage_key,
+                    lowest_available_block_number,
+                )
+            }
+            Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(snapshot) => snapshot.storage_history_info(
+                address,
+                storage_key,
+                block_number,
+                lowest_available_block_number,
+                visible_tip,
+            ),
+        }
+    }
+}
+
+impl<CURSOR, N: NodePrimitives> EitherReader<'_, CURSOR, N>
+where
+    CURSOR: DbCursorRO<tables::AccountsHistory>,
+{
+    /// Gets an account history shard entry for the given [`ShardedKey`], if present.
+    pub fn get_account_history(
+        &mut self,
+        key: ShardedKey<Address>,
+    ) -> ProviderResult<Option<BlockNumberList>> {
+        match self {
+            Self::Database(cursor, _) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
+            Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(snapshot) => snapshot.get::<tables::AccountsHistory>(key),
+        }
+    }
+
+    /// Lookup account history and return [`HistoryInfo`].
+    pub fn account_history_info(
+        &mut self,
+        address: Address,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+        visible_tip: BlockNumber,
+    ) -> ProviderResult<HistoryInfo> {
+        match self {
+            Self::Database(cursor, _) => {
+                let key = ShardedKey::new(address, block_number);
+                history_info::<tables::AccountsHistory, _, _>(
+                    cursor,
+                    key,
+                    block_number,
+                    |k| k.key == address,
+                    lowest_available_block_number,
+                )
+            }
+            Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
+            Self::RocksDB(snapshot) => snapshot.account_history_info(
+                address,
+                block_number,
+                lowest_available_block_number,
+                visible_tip,
+            ),
+        }
+    }
+}
+
+impl<CURSOR, N: NodePrimitives> EitherReader<'_, CURSOR, N>
+where
+    CURSOR: DbCursorRO<tables::AccountChangeSets>,
+{
+    /// Iterate over account changesets and return all account address that were changed.
+    pub fn changed_accounts_with_range(
+        &mut self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<BTreeSet<Address>> {
+        match self {
+            Self::StaticFile(provider, _) => {
+                let highest_static_block =
+                    provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
+
+                let Some(highest) = highest_static_block else {
+                    return Err(ProviderError::MissingHighestStaticFileBlock(
+                        StaticFileSegment::AccountChangeSets,
+                    ))
+                };
+
+                let start = *range.start();
+                let static_end = (*range.end()).min(highest);
+
+                let mut changed_accounts = BTreeSet::default();
+                if start <= static_end {
+                    for block in start..=static_end {
+                        let block_changesets = provider.account_block_changeset(block)?;
+                        for changeset in block_changesets {
+                            changed_accounts.insert(changeset.address);
+                        }
+                    }
+                }
+
+                Ok(changed_accounts)
+            }
+            Self::Database(provider, _) => provider
+                .walk_range(range)?
+                .map(|entry| {
+                    entry.map(|(_, account_before)| account_before.address).map_err(Into::into)
+                })
+                .collect(),
+            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+}
+
+/// Destination for writing data.
+#[derive(Debug, EnumIs)]
+pub enum EitherWriterDestination {
+    /// Write to database table
+    Database,
+    /// Write to static file
+    StaticFile,
+    /// Write to `RocksDB`
+    RocksDB,
+}
+
+impl EitherWriterDestination {
+    /// Returns the destination for writing senders based on storage settings.
+    pub fn senders<P>(provider: &P) -> Self
+    where
+        P: StorageSettingsCache,
+    {
+        // Write senders to static files only if they're explicitly enabled
+        if provider.cached_storage_settings().storage_v2 {
+            Self::StaticFile
+        } else {
+            Self::Database
+        }
+    }
+
+    /// Returns the destination for writing account changesets based on storage settings.
+    pub fn account_changesets<P>(provider: &P) -> Self
+    where
+        P: StorageSettingsCache,
+    {
+        // Write account changesets to static files only if they're explicitly enabled
+        if provider.cached_storage_settings().storage_v2 {
+            Self::StaticFile
+        } else {
+            Self::Database
+        }
+    }
+
+    /// Returns the destination for writing storage changesets based on storage settings.
+    pub fn storage_changesets<P>(provider: &P) -> Self
+    where
+        P: StorageSettingsCache,
+    {
+        // Write storage changesets to static files only if they're explicitly enabled
+        if provider.cached_storage_settings().storage_v2 {
+            Self::StaticFile
+        } else {
+            Self::Database
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{test_utils::create_test_provider_factory, StaticFileWriter};
+
+    use super::*;
+    use alloy_primitives::Address;
+    use reth_db::models::AccountBeforeTx;
+    use reth_static_file_types::StaticFileSegment;
+    use reth_storage_api::{DatabaseProviderFactory, StorageSettings};
+
+    /// Verifies that `changed_accounts_with_range` correctly caps the query range to the
+    /// static file tip when the requested range extends beyond it.
+    ///
+    /// This test documents the fix for an off-by-one bug where the code computed
+    /// `static_end = range.end().min(highest + 1)` instead of `min(highest)`.
+    /// The bug allowed iteration to attempt reading block `highest + 1` which doesn't
+    /// exist (silently returning empty results due to `MissingStaticFileBlock` handling).
+    ///
+    /// While the bug was masked by error handling, it caused:
+    /// 1. Unnecessary iteration/lookup for non-existent blocks
+    /// 2. Potential overflow when `highest == u64::MAX`
+    #[test]
+    fn test_changed_accounts_with_range_caps_at_static_file_tip() {
+        let factory = create_test_provider_factory();
+        let highest_block = 5u64;
+
+        let addresses: Vec<Address> = (0..=highest_block)
+            .map(|i| {
+                let mut addr = Address::ZERO;
+                addr.0[0] = i as u8;
+                addr
+            })
+            .collect();
+
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            for block_num in 0..=highest_block {
+                let changeset =
+                    vec![AccountBeforeTx { address: addresses[block_num as usize], info: None }];
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
+        assert_eq!(sf_tip, Some(highest_block));
+
+        let mut reader = EitherReader::new_account_changesets(&provider).unwrap();
+        assert!(matches!(reader, EitherReader::StaticFile(_, _)));
+
+        // Query range 0..=10 when tip is 5 - should return only accounts from blocks 0-5
+        let result = reader.changed_accounts_with_range(0..=10).unwrap();
+
+        let expected: BTreeSet<Address> = addresses.into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_reader_senders_by_tx_range() {
+        let factory = create_test_provider_factory();
+
+        // Insert senders only from 1 to 4, but we will query from 0 to 5.
+        let senders = [
+            (1, Address::random()),
+            (2, Address::random()),
+            (3, Address::random()),
+            (4, Address::random()),
+        ];
+
+        for transaction_senders_in_static_files in [false, true] {
+            factory.set_storage_settings_cache(if transaction_senders_in_static_files {
+                StorageSettings::v2()
+            } else {
+                StorageSettings::v1()
+            });
+
+            let provider = factory.database_provider_rw().unwrap();
+            let mut writer = EitherWriter::new_senders(&provider, 0).unwrap();
+            if transaction_senders_in_static_files {
+                assert!(matches!(writer, EitherWriter::StaticFile(_)));
+            } else {
+                assert!(matches!(writer, EitherWriter::Database(_)));
+            }
+
+            writer.increment_block(0).unwrap();
+            writer.append_senders(senders.iter().copied()).unwrap();
+            drop(writer);
+            provider.commit().unwrap();
+
+            let provider = factory.database_provider_ro().unwrap();
+            let mut reader = EitherReader::new_senders(&provider).unwrap();
+            if transaction_senders_in_static_files {
+                assert!(matches!(reader, EitherReader::StaticFile(_, _)));
+            } else {
+                assert!(matches!(reader, EitherReader::Database(_, _)));
+            }
+
+            assert_eq!(
+                reader.senders_by_tx_range(0..6).unwrap(),
+                senders.iter().copied().collect::<HashMap<_, _>>(),
+                "{reader}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod rocksdb_tests {
+    use super::*;
+    use crate::{
+        providers::rocksdb::{RocksDBBuilder, RocksDBProvider},
+        test_utils::create_test_provider_factory,
+        RocksDBProviderFactory,
+    };
+    use alloy_primitives::{Address, B256};
+    use reth_db_api::{
+        models::{storage_sharded_key::StorageShardedKey, IntegerList, ShardedKey},
+        tables,
+        transaction::DbTxMut,
+    };
+    use reth_ethereum_primitives::EthPrimitives;
+    use reth_storage_api::{DatabaseProviderFactory, StorageSettings};
+    use std::marker::PhantomData;
+    use tempfile::TempDir;
+
+    fn create_rocksdb_provider() -> (TempDir, RocksDBProvider) {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .with_table::<tables::StoragesHistory>()
+            .with_table::<tables::AccountsHistory>()
+            .build()
+            .unwrap();
+        (temp_dir, provider)
+    }
+
+    /// Test that `EitherWriter::new_transaction_hash_numbers` creates a `RocksDB` writer
+    /// when the storage setting is enabled, and that put operations followed by commit
+    /// persist the data to `RocksDB`.
+    #[test]
+    fn test_either_writer_transaction_hash_numbers_with_rocksdb() {
+        let factory = create_test_provider_factory();
+
+        // Enable RocksDB for transaction hash numbers
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let hash1 = B256::from([1u8; 32]);
+        let hash2 = B256::from([2u8; 32]);
+        let tx_num1 = 100u64;
+        let tx_num2 = 200u64;
+
+        // Get the RocksDB batch from the provider
+        let rocksdb = factory.rocksdb_provider();
+        let batch = rocksdb.batch();
+
+        // Create EitherWriter with RocksDB
+        let provider = factory.database_provider_rw().unwrap();
+        let mut writer = EitherWriter::new_transaction_hash_numbers(&provider, batch).unwrap();
+
+        // Verify we got a RocksDB writer
+        assert!(matches!(writer, EitherWriter::RocksDB(_)));
+
+        // Write transaction hash numbers (append_only=false since we're using RocksDB)
+        writer.put_transaction_hash_number(hash1, tx_num1, false).unwrap();
+        writer.put_transaction_hash_number(hash2, tx_num2, false).unwrap();
+
+        // Extract the batch and register with provider for commit
+        if let Some(batch) = writer.into_raw_rocksdb_batch() {
+            provider.set_pending_rocksdb_batch(batch);
+        }
+
+        // Commit via provider - this commits RocksDB batch too
+        provider.commit().unwrap();
+
+        // Verify data was written to RocksDB
+        let rocksdb = factory.rocksdb_provider();
+        assert_eq!(rocksdb.get::<tables::TransactionHashNumbers>(hash1).unwrap(), Some(tx_num1));
+        assert_eq!(rocksdb.get::<tables::TransactionHashNumbers>(hash2).unwrap(), Some(tx_num2));
+    }
+
+    /// Test that `EitherWriter::delete_transaction_hash_number` works with `RocksDB`.
+    #[test]
+    fn test_either_writer_delete_transaction_hash_number_with_rocksdb() {
+        let factory = create_test_provider_factory();
+
+        // Enable RocksDB for transaction hash numbers
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let hash = B256::from([1u8; 32]);
+        let tx_num = 100u64;
+
+        // First, write a value directly to RocksDB
+        let rocksdb = factory.rocksdb_provider();
+        rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_num).unwrap();
+        assert_eq!(rocksdb.get::<tables::TransactionHashNumbers>(hash).unwrap(), Some(tx_num));
+
+        // Now delete using EitherWriter
+        let batch = rocksdb.batch();
+        let provider = factory.database_provider_rw().unwrap();
+        let mut writer = EitherWriter::new_transaction_hash_numbers(&provider, batch).unwrap();
+        writer.delete_transaction_hash_number(hash).unwrap();
+
+        // Extract the batch and commit via provider
+        if let Some(batch) = writer.into_raw_rocksdb_batch() {
+            provider.set_pending_rocksdb_batch(batch);
+        }
+        provider.commit().unwrap();
+
+        // Verify deletion
+        let rocksdb = factory.rocksdb_provider();
+        assert_eq!(rocksdb.get::<tables::TransactionHashNumbers>(hash).unwrap(), None);
+    }
+
+    #[test]
+    fn test_rocksdb_batch_transaction_hash_numbers() {
+        let (_temp_dir, provider) = create_rocksdb_provider();
+
+        let hash1 = B256::from([1u8; 32]);
+        let hash2 = B256::from([2u8; 32]);
+        let tx_num1 = 100u64;
+        let tx_num2 = 200u64;
+
+        // Write via RocksDBBatch (same as EitherWriter::RocksDB would use internally)
+        let mut batch = provider.batch();
+        batch.put::<tables::TransactionHashNumbers>(hash1, &tx_num1).unwrap();
+        batch.put::<tables::TransactionHashNumbers>(hash2, &tx_num2).unwrap();
+        batch.commit().unwrap();
+
+        // Read via RocksTx (same as EitherReader::RocksDB would use internally)
+        let tx = provider.tx();
+        assert_eq!(tx.get::<tables::TransactionHashNumbers>(hash1).unwrap(), Some(tx_num1));
+        assert_eq!(tx.get::<tables::TransactionHashNumbers>(hash2).unwrap(), Some(tx_num2));
+
+        // Test missing key
+        let missing_hash = B256::from([99u8; 32]);
+        assert_eq!(tx.get::<tables::TransactionHashNumbers>(missing_hash).unwrap(), None);
+    }
+
+    #[test]
+    fn test_rocksdb_batch_storage_history() {
+        let (_temp_dir, provider) = create_rocksdb_provider();
+
+        let address = Address::random();
+        let storage_key = B256::from([1u8; 32]);
+        let key = StorageShardedKey::new(address, storage_key, 1000);
+        let value = IntegerList::new([1, 5, 10, 50]).unwrap();
+
+        // Write via RocksDBBatch
+        let mut batch = provider.batch();
+        batch.put::<tables::StoragesHistory>(key.clone(), &value).unwrap();
+        batch.commit().unwrap();
+
+        // Read via RocksTx
+        let tx = provider.tx();
+        let result = tx.get::<tables::StoragesHistory>(key).unwrap();
+        assert_eq!(result, Some(value));
+
+        // Test missing key
+        let missing_key = StorageShardedKey::new(Address::random(), B256::ZERO, 0);
+        assert_eq!(tx.get::<tables::StoragesHistory>(missing_key).unwrap(), None);
+    }
+
+    #[test]
+    fn test_rocksdb_batch_account_history() {
+        let (_temp_dir, provider) = create_rocksdb_provider();
+
+        let address = Address::random();
+        let key = ShardedKey::new(address, 1000);
+        let value = IntegerList::new([1, 10, 100, 500]).unwrap();
+
+        // Write via RocksDBBatch
+        let mut batch = provider.batch();
+        batch.put::<tables::AccountsHistory>(key.clone(), &value).unwrap();
+        batch.commit().unwrap();
+
+        // Read via RocksTx
+        let tx = provider.tx();
+        let result = tx.get::<tables::AccountsHistory>(key).unwrap();
+        assert_eq!(result, Some(value));
+
+        // Test missing key
+        let missing_key = ShardedKey::new(Address::random(), 0);
+        assert_eq!(tx.get::<tables::AccountsHistory>(missing_key).unwrap(), None);
+    }
+
+    #[test]
+    fn test_rocksdb_batch_delete_transaction_hash_number() {
+        let (_temp_dir, provider) = create_rocksdb_provider();
+
+        let hash = B256::from([1u8; 32]);
+        let tx_num = 100u64;
+
+        // First write
+        provider.put::<tables::TransactionHashNumbers>(hash, &tx_num).unwrap();
+        assert_eq!(provider.get::<tables::TransactionHashNumbers>(hash).unwrap(), Some(tx_num));
+
+        // Delete via RocksDBBatch
+        let mut batch = provider.batch();
+        batch.delete::<tables::TransactionHashNumbers>(hash).unwrap();
+        batch.commit().unwrap();
+
+        // Verify deletion
+        assert_eq!(provider.get::<tables::TransactionHashNumbers>(hash).unwrap(), None);
+    }
+
+    #[test]
+    fn test_rocksdb_batch_delete_storage_history() {
+        let (_temp_dir, provider) = create_rocksdb_provider();
+
+        let address = Address::random();
+        let storage_key = B256::from([1u8; 32]);
+        let key = StorageShardedKey::new(address, storage_key, 1000);
+        let value = IntegerList::new([1, 5, 10]).unwrap();
+
+        // First write
+        provider.put::<tables::StoragesHistory>(key.clone(), &value).unwrap();
+        assert!(provider.get::<tables::StoragesHistory>(key.clone()).unwrap().is_some());
+
+        // Delete via RocksDBBatch
+        let mut batch = provider.batch();
+        batch.delete::<tables::StoragesHistory>(key.clone()).unwrap();
+        batch.commit().unwrap();
+
+        // Verify deletion
+        assert_eq!(provider.get::<tables::StoragesHistory>(key).unwrap(), None);
+    }
+
+    #[test]
+    fn test_rocksdb_batch_delete_account_history() {
+        let (_temp_dir, provider) = create_rocksdb_provider();
+
+        let address = Address::random();
+        let key = ShardedKey::new(address, 1000);
+        let value = IntegerList::new([1, 10, 100]).unwrap();
+
+        // First write
+        provider.put::<tables::AccountsHistory>(key.clone(), &value).unwrap();
+        assert!(provider.get::<tables::AccountsHistory>(key.clone()).unwrap().is_some());
+
+        // Delete via RocksDBBatch
+        let mut batch = provider.batch();
+        batch.delete::<tables::AccountsHistory>(key.clone()).unwrap();
+        batch.commit().unwrap();
+
+        // Verify deletion
+        assert_eq!(provider.get::<tables::AccountsHistory>(key).unwrap(), None);
+    }
+
+    // ==================== Parametrized Backend Equivalence Tests ====================
+    //
+    // These tests verify that MDBX and RocksDB produce identical results for history lookups.
+    // Each scenario sets up the same data in both backends and asserts identical HistoryInfo.
+
+    /// Query parameters for a history lookup test case.
+    struct HistoryQuery {
+        block_number: BlockNumber,
+        lowest_available: Option<BlockNumber>,
+        expected: HistoryInfo,
+    }
+
+    // Type aliases for cursor types (needed for EitherWriter/EitherReader type inference)
+    type AccountsHistoryWriteCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RW, tables::AccountsHistory>;
+    type StoragesHistoryWriteCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RW, tables::StoragesHistory>;
+    type AccountsHistoryReadCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RO, tables::AccountsHistory>;
+    type StoragesHistoryReadCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RO, tables::StoragesHistory>;
+
+    /// Runs the same account history queries against both MDBX and `RocksDB` backends,
+    /// asserting they produce identical results.
+    fn run_account_history_scenario(
+        scenario_name: &str,
+        address: Address,
+        shards: &[(BlockNumber, Vec<BlockNumber>)], // (shard_highest_block, blocks_in_shard)
+        queries: &[HistoryQuery],
+    ) {
+        // Setup MDBX and RocksDB with identical data using EitherWriter
+        let factory = create_test_provider_factory();
+        let mdbx_provider = factory.database_provider_rw().unwrap();
+        let (temp_dir, rocks_provider) = create_rocksdb_provider();
+
+        // Create writers for both backends
+        let mut mdbx_writer: EitherWriter<'_, AccountsHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::Database(
+                mdbx_provider.tx_ref().cursor_write::<tables::AccountsHistory>().unwrap(),
+            );
+        let mut rocks_writer: EitherWriter<'_, AccountsHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::RocksDB(rocks_provider.batch());
+
+        // Write identical data to both backends in a single loop
+        for (highest_block, blocks) in shards {
+            let key = ShardedKey::new(address, *highest_block);
+            let value = IntegerList::new(blocks.clone()).unwrap();
+            mdbx_writer.upsert_account_history(key.clone(), &value).unwrap();
+            rocks_writer.upsert_account_history(key, &value).unwrap();
+        }
+
+        // Commit both backends
+        drop(mdbx_writer);
+        mdbx_provider.commit().unwrap();
+        if let EitherWriter::RocksDB(batch) = rocks_writer {
+            batch.commit().unwrap();
+        }
+
+        // Run queries against both backends using EitherReader
+        let mdbx_ro = factory.database_provider_ro().unwrap();
+        let rocks_snapshot = rocks_provider.snapshot();
+
+        for (i, query) in queries.iter().enumerate() {
+            // MDBX query via EitherReader
+            let mut mdbx_reader: EitherReader<'_, AccountsHistoryReadCursor, EthPrimitives> =
+                EitherReader::Database(
+                    mdbx_ro.tx_ref().cursor_read::<tables::AccountsHistory>().unwrap(),
+                    PhantomData,
+                );
+            let mdbx_result = mdbx_reader
+                .account_history_info(address, query.block_number, query.lowest_available, u64::MAX)
+                .unwrap();
+
+            // RocksDB query via EitherReader — reuse snapshot for consistent view
+            let rocks_result = rocks_snapshot
+                .account_history_info(address, query.block_number, query.lowest_available, u64::MAX)
+                .unwrap();
+
+            // Assert both backends produce identical results
+            assert_eq!(
+                mdbx_result,
+                rocks_result,
+                "Backend mismatch in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 MDBX: {:?}, RocksDB: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                rocks_result
+            );
+
+            // Also verify against expected result
+            assert_eq!(
+                mdbx_result,
+                query.expected,
+                "Unexpected result in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 Got: {:?}, Expected: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                query.expected
+            );
+        }
+
+        drop(temp_dir);
+    }
+
+    /// Runs the same storage history queries against both MDBX and `RocksDB` backends,
+    /// asserting they produce identical results.
+    fn run_storage_history_scenario(
+        scenario_name: &str,
+        address: Address,
+        storage_key: B256,
+        shards: &[(BlockNumber, Vec<BlockNumber>)], // (shard_highest_block, blocks_in_shard)
+        queries: &[HistoryQuery],
+    ) {
+        // Setup MDBX and RocksDB with identical data using EitherWriter
+        let factory = create_test_provider_factory();
+        let mdbx_provider = factory.database_provider_rw().unwrap();
+        let (temp_dir, rocks_provider) = create_rocksdb_provider();
+
+        // Create writers for both backends
+        let mut mdbx_writer: EitherWriter<'_, StoragesHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::Database(
+                mdbx_provider.tx_ref().cursor_write::<tables::StoragesHistory>().unwrap(),
+            );
+        let mut rocks_writer: EitherWriter<'_, StoragesHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::RocksDB(rocks_provider.batch());
+
+        // Write identical data to both backends in a single loop
+        for (highest_block, blocks) in shards {
+            let key = StorageShardedKey::new(address, storage_key, *highest_block);
+            let value = IntegerList::new(blocks.clone()).unwrap();
+            mdbx_writer.put_storage_history(key.clone(), &value).unwrap();
+            rocks_writer.put_storage_history(key, &value).unwrap();
+        }
+
+        // Commit both backends
+        drop(mdbx_writer);
+        mdbx_provider.commit().unwrap();
+        if let EitherWriter::RocksDB(batch) = rocks_writer {
+            batch.commit().unwrap();
+        }
+
+        // Run queries against both backends using EitherReader
+        let mdbx_ro = factory.database_provider_ro().unwrap();
+        let rocks_snapshot = rocks_provider.snapshot();
+
+        for (i, query) in queries.iter().enumerate() {
+            // MDBX query via EitherReader
+            let mut mdbx_reader: EitherReader<'_, StoragesHistoryReadCursor, EthPrimitives> =
+                EitherReader::Database(
+                    mdbx_ro.tx_ref().cursor_read::<tables::StoragesHistory>().unwrap(),
+                    PhantomData,
+                );
+            let mdbx_result = mdbx_reader
+                .storage_history_info(
+                    address,
+                    storage_key,
+                    query.block_number,
+                    query.lowest_available,
+                    u64::MAX,
+                )
+                .unwrap();
+
+            // RocksDB query via snapshot — reuse for consistent view
+            let rocks_result = rocks_snapshot
+                .storage_history_info(
+                    address,
+                    storage_key,
+                    query.block_number,
+                    query.lowest_available,
+                    u64::MAX,
+                )
+                .unwrap();
+
+            // Assert both backends produce identical results
+            assert_eq!(
+                mdbx_result,
+                rocks_result,
+                "Backend mismatch in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 MDBX: {:?}, RocksDB: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                rocks_result
+            );
+
+            // Also verify against expected result
+            assert_eq!(
+                mdbx_result,
+                query.expected,
+                "Unexpected result in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 Got: {:?}, Expected: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                query.expected
+            );
+        }
+
+        drop(temp_dir);
+    }
+
+    /// Tests account history lookups across both MDBX and `RocksDB` backends.
+    ///
+    /// Covers the following scenarios from PR2's `RocksDB`-only tests:
+    /// 1. Single shard - basic lookups within one shard
+    /// 2. Multiple shards - `prev()` shard detection and transitions
+    /// 3. No history - query address with no entries
+    /// 4. Pruning boundary - `lowest_available` boundary behavior (block at/after boundary)
+    #[test]
+    fn test_account_history_info_both_backends() {
+        let address = Address::from([0x42; 20]);
+
+        // Scenario 1: Single shard with blocks [100, 200, 300]
+        run_account_history_scenario(
+            "single_shard",
+            address,
+            &[(u64::MAX, vec![100, 200, 300])],
+            &[
+                // Before first entry -> NotYetWritten
+                HistoryQuery {
+                    block_number: 50,
+                    lowest_available: None,
+                    expected: HistoryInfo::NotYetWritten,
+                },
+                // Between entries -> InChangeset(next_write)
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(200),
+                },
+                // Exact match on entry -> InChangeset(same_block)
+                HistoryQuery {
+                    block_number: 300,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(300),
+                },
+                // After last entry in last shard -> InPlainState
+                HistoryQuery {
+                    block_number: 500,
+                    lowest_available: None,
+                    expected: HistoryInfo::InPlainState,
+                },
+            ],
+        );
+
+        // Scenario 2: Multiple shards - tests prev() shard detection
+        run_account_history_scenario(
+            "multiple_shards",
+            address,
+            &[
+                (500, vec![100, 200, 300, 400, 500]), // First shard ends at 500
+                (u64::MAX, vec![600, 700, 800]),      // Last shard
+            ],
+            &[
+                // Before first shard, no prev -> NotYetWritten
+                HistoryQuery {
+                    block_number: 50,
+                    lowest_available: None,
+                    expected: HistoryInfo::NotYetWritten,
+                },
+                // Within first shard
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(200),
+                },
+                // Between shards - prev() should find first shard
+                HistoryQuery {
+                    block_number: 550,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(600),
+                },
+                // After all entries
+                HistoryQuery {
+                    block_number: 900,
+                    lowest_available: None,
+                    expected: HistoryInfo::InPlainState,
+                },
+            ],
+        );
+
+        // Scenario 3: No history for address
+        let address_without_history = Address::from([0x43; 20]);
+        run_account_history_scenario(
+            "no_history",
+            address_without_history,
+            &[], // No shards for this address
+            &[HistoryQuery {
+                block_number: 150,
+                lowest_available: None,
+                expected: HistoryInfo::NotYetWritten,
+            }],
+        );
+
+        // Scenario 4: Query at pruning boundary
+        // Note: We test block >= lowest_available because HistoricalStateProviderRef
+        // errors on blocks below the pruning boundary before doing the lookup.
+        // The RocksDB implementation doesn't have this check at the same level.
+        // This tests that when pruning IS available, both backends agree.
+        run_account_history_scenario(
+            "with_pruning_boundary",
+            address,
+            &[(u64::MAX, vec![100, 200, 300])],
+            &[
+                // At pruning boundary -> InChangeset(first entry after block)
+                HistoryQuery {
+                    block_number: 100,
+                    lowest_available: Some(100),
+                    expected: HistoryInfo::InChangeset(100),
+                },
+                // After pruning boundary, between entries
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: Some(100),
+                    expected: HistoryInfo::InChangeset(200),
+                },
+            ],
+        );
+    }
+
+    /// Tests storage history lookups across both MDBX and `RocksDB` backends.
+    #[test]
+    fn test_storage_history_info_both_backends() {
+        let address = Address::from([0x42; 20]);
+        let storage_key = B256::from([0x01; 32]);
+        let other_storage_key = B256::from([0x02; 32]);
+
+        // Single shard with blocks [100, 200, 300]
+        run_storage_history_scenario(
+            "storage_single_shard",
+            address,
+            storage_key,
+            &[(u64::MAX, vec![100, 200, 300])],
+            &[
+                // Before first entry -> NotYetWritten
+                HistoryQuery {
+                    block_number: 50,
+                    lowest_available: None,
+                    expected: HistoryInfo::NotYetWritten,
+                },
+                // Between entries -> InChangeset(next_write)
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(200),
+                },
+                // After last entry -> InPlainState
+                HistoryQuery {
+                    block_number: 500,
+                    lowest_available: None,
+                    expected: HistoryInfo::InPlainState,
+                },
+            ],
+        );
+
+        // No history for different storage key
+        run_storage_history_scenario(
+            "storage_no_history",
+            address,
+            other_storage_key,
+            &[], // No shards for this storage key
+            &[HistoryQuery {
+                block_number: 150,
+                lowest_available: None,
+                expected: HistoryInfo::NotYetWritten,
+            }],
+        );
+    }
+
+    /// Test that `RocksDB` batches created via `EitherWriter` are only made visible when
+    /// `provider.commit()` is called, not when the writer is dropped.
+    #[test]
+    fn test_rocksdb_commits_at_provider_level() {
+        let factory = create_test_provider_factory();
+
+        // Enable RocksDB for transaction hash numbers
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let hash1 = B256::from([1u8; 32]);
+        let hash2 = B256::from([2u8; 32]);
+        let tx_num1 = 100u64;
+        let tx_num2 = 200u64;
+
+        // Get the RocksDB batch from the provider
+        let rocksdb = factory.rocksdb_provider();
+        let batch = rocksdb.batch();
+
+        // Create provider and EitherWriter
+        let provider = factory.database_provider_rw().unwrap();
+        let mut writer = EitherWriter::new_transaction_hash_numbers(&provider, batch).unwrap();
+
+        // Write transaction hash numbers (append_only=false since we're using RocksDB)
+        writer.put_transaction_hash_number(hash1, tx_num1, false).unwrap();
+        writer.put_transaction_hash_number(hash2, tx_num2, false).unwrap();
+
+        // Extract the raw batch from the writer and register it with the provider
+        let raw_batch = writer.into_raw_rocksdb_batch();
+        if let Some(batch) = raw_batch {
+            provider.set_pending_rocksdb_batch(batch);
+        }
+
+        // Data should NOT be visible yet (batch not committed)
+        let rocksdb = factory.rocksdb_provider();
+        assert_eq!(
+            rocksdb.get::<tables::TransactionHashNumbers>(hash1).unwrap(),
+            None,
+            "Data should not be visible before provider.commit()"
+        );
+
+        // Commit the provider - this should commit both MDBX and RocksDB
+        provider.commit().unwrap();
+
+        // Now data should be visible in RocksDB
+        let rocksdb = factory.rocksdb_provider();
+        assert_eq!(
+            rocksdb.get::<tables::TransactionHashNumbers>(hash1).unwrap(),
+            Some(tx_num1),
+            "Data should be visible after provider.commit()"
+        );
+        assert_eq!(
+            rocksdb.get::<tables::TransactionHashNumbers>(hash2).unwrap(),
+            Some(tx_num2),
+            "Data should be visible after provider.commit()"
+        );
+    }
+
+    /// Test that `EitherReader::new_accounts_history` panics when settings require
+    /// `RocksDB` but no snapshot is given (`None`). This is an invariant violation that
+    /// indicates a bug - `with_rocksdb_snapshot` should always provide a snapshot when needed.
+    #[test]
+    #[should_panic(expected = "account_history_in_rocksdb requires rocksdb snapshot")]
+    fn test_settings_mismatch_panics() {
+        let factory = create_test_provider_factory();
+
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let provider = factory.database_provider_ro().unwrap();
+        let _ = EitherReader::<(), ()>::new_accounts_history(&provider, None);
+    }
+}

--- a/patches/reth-provider/src/init.rs
+++ b/patches/reth-provider/src/init.rs
@@ -1,0 +1,145 @@
+use crate::{
+    ChainSpecProvider, DBProvider, EitherWriter, HistoryWriter, NodePrimitivesProvider,
+    ProviderResult, RocksDBProviderFactory, StorageSettingsCache,
+};
+use alloy_consensus::BlockHeader;
+use alloy_genesis::GenesisAccount;
+use alloy_primitives::Address;
+use reth_chainspec::EthChainSpec;
+use reth_db::{
+    models::{storage_sharded_key::StorageShardedKey, ShardedKey},
+    transaction::DbTxMut,
+    BlockNumberList,
+};
+use tracing::trace;
+
+/// Inserts history indices for genesis accounts and storage.
+///
+/// Writes to either MDBX or `RocksDB` based on storage settings configuration,
+/// using [`EitherWriter`] to abstract over the storage backend.
+pub fn insert_genesis_history<'a, 'b, Provider>(
+    provider: &Provider,
+    alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)> + Clone,
+) -> ProviderResult<()>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + ChainSpecProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider,
+{
+    let genesis_block_number = provider.chain_spec().genesis_header().number();
+    insert_history(provider, alloc, genesis_block_number)
+}
+
+/// Inserts account history indices for genesis accounts.
+pub fn insert_genesis_account_history<'a, 'b, Provider>(
+    provider: &Provider,
+    alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
+) -> ProviderResult<()>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + ChainSpecProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider,
+{
+    let genesis_block_number = provider.chain_spec().genesis_header().number();
+    insert_account_history(provider, alloc, genesis_block_number)
+}
+
+/// Inserts storage history indices for genesis accounts.
+pub fn insert_genesis_storage_history<'a, 'b, Provider>(
+    provider: &Provider,
+    alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
+) -> ProviderResult<()>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + ChainSpecProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider,
+{
+    let genesis_block_number = provider.chain_spec().genesis_header().number();
+    insert_storage_history(provider, alloc, genesis_block_number)
+}
+
+/// Inserts history indices for genesis accounts and storage.
+///
+/// Writes to either MDBX or `RocksDB` based on storage settings configuration,
+/// using [`EitherWriter`] to abstract over the storage backend.
+pub fn insert_history<'a, 'b, Provider>(
+    provider: &Provider,
+    alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)> + Clone,
+    block: u64,
+) -> ProviderResult<()>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider,
+{
+    insert_account_history(provider, alloc.clone(), block)?;
+    insert_storage_history(provider, alloc, block)?;
+    Ok(())
+}
+
+/// Inserts account history indices at the given block.
+pub fn insert_account_history<'a, 'b, Provider>(
+    provider: &Provider,
+    alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
+    block: u64,
+) -> ProviderResult<()>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider,
+{
+    provider.with_rocksdb_batch(|batch| {
+        let mut writer = EitherWriter::new_accounts_history(provider, batch)?;
+        let list = BlockNumberList::new([block]).expect("single block always fits");
+        for (addr, _) in alloc {
+            writer.upsert_account_history(ShardedKey::last(*addr), &list)?;
+        }
+        trace!(target: "reth::provider", "Inserted account history");
+        Ok(((), writer.into_raw_rocksdb_batch()))
+    })?;
+
+    Ok(())
+}
+
+/// Inserts storage history indices at the given block.
+pub fn insert_storage_history<'a, 'b, Provider>(
+    provider: &Provider,
+    alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
+    block: u64,
+) -> ProviderResult<()>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider,
+{
+    provider.with_rocksdb_batch(|batch| {
+        let mut writer = EitherWriter::new_storages_history(provider, batch)?;
+        let list = BlockNumberList::new([block]).expect("single block always fits");
+        for (addr, account) in alloc {
+            if let Some(storage) = &account.storage {
+                for key in storage.keys() {
+                    writer.upsert_storage_history(StorageShardedKey::last(*addr, *key), &list)?;
+                }
+            }
+        }
+        trace!(target: "reth::cli", "Inserted storage history");
+        Ok(((), writer.into_raw_rocksdb_batch()))
+    })?;
+
+    Ok(())
+}

--- a/patches/reth-provider/src/lib.rs
+++ b/patches/reth-provider/src/lib.rs
@@ -1,0 +1,77 @@
+//! Collection of traits and trait implementations for common database operations.
+//!
+//! ## Feature Flags
+//!
+//! - `test-utils`: Export utilities for testing
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+/// Utility functions for initializing the database.
+pub mod init;
+
+/// Various provider traits.
+mod traits;
+pub use traits::*;
+
+/// Provider trait implementations.
+pub mod providers;
+pub use providers::{
+    DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
+    HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
+    PruneShardOutcome, PrunedIndices, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
+    StaticFileWriteCtx, StaticFileWriter,
+};
+
+pub mod changeset_walker;
+pub mod changesets_utils;
+
+#[cfg(any(test, feature = "test-utils"))]
+/// Common test helpers for mocking the Provider.
+pub mod test_utils;
+
+pub mod either_writer;
+pub use either_writer::*;
+
+mod bal;
+pub use bal::InMemoryBalStore;
+
+pub use reth_chain_state::{
+    CanonStateNotification, CanonStateNotificationSender, CanonStateNotificationStream,
+    CanonStateNotifications, CanonStateSubscriptions,
+};
+pub use reth_execution_types::*;
+/// Re-export `OriginalValuesKnown`
+pub use revm_database::states::OriginalValuesKnown;
+// reexport traits to avoid breaking changes
+pub use reth_static_file_types as static_file;
+pub use reth_storage_api::{
+    BalProvider, BalStore, BalStoreHandle, GetBlockAccessListLimit, HistoryWriter,
+    MetadataProvider, MetadataWriter, NoopBalStore, StateWriteConfig, StatsReader, StorageSettings,
+    StorageSettingsCache,
+};
+/// Re-export provider error.
+pub use reth_storage_errors::provider::{ProviderError, ProviderResult};
+pub use static_file::StaticFileSegment;
+
+/// Converts a [`RangeBounds`](std::ops::RangeBounds) into a concrete [`Range`](std::ops::Range)
+pub fn to_range<R: std::ops::RangeBounds<u64>>(bounds: R) -> std::ops::Range<u64> {
+    let start = match bounds.start_bound() {
+        std::ops::Bound::Included(&v) => v,
+        std::ops::Bound::Excluded(&v) => v + 1,
+        std::ops::Bound::Unbounded => 0,
+    };
+
+    let end = match bounds.end_bound() {
+        std::ops::Bound::Included(&v) => v + 1,
+        std::ops::Bound::Excluded(&v) => v,
+        std::ops::Bound::Unbounded => u64::MAX,
+    };
+
+    start..end
+}

--- a/patches/reth-provider/src/providers/blockchain_provider.rs
+++ b/patches/reth-provider/src/providers/blockchain_provider.rs
@@ -1,0 +1,2607 @@
+use crate::{
+    providers::{
+        ConsistentProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider,
+        StaticFileProviderRWRefMut,
+    },
+    AccountReader, BalProvider, BalStoreHandle, BlockHashReader, BlockIdReader, BlockNumReader,
+    BlockReader, BlockReaderIdExt, BlockSource, CanonChainTracker, CanonStateNotifications,
+    CanonStateSubscriptions, ChainSpecProvider, ChainStateBlockReader, ChangeSetReader,
+    DatabaseProviderFactory, HashedPostStateProvider, HeaderProvider, InMemoryBalStore,
+    ProviderError, ProviderFactory, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
+    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateProviderFactory,
+    StateReader, StaticFileProviderFactory, TransactionVariant, TransactionsProvider,
+};
+use alloy_consensus::transaction::TransactionMeta;
+use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use alloy_rpc_types_engine::ForkchoiceState;
+use reth_chain_state::{
+    BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
+    MemoryOverlayStateProvider, PersistedBlockNotifications, PersistedBlockSubscriptions,
+};
+use reth_chainspec::ChainInfo;
+use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
+use reth_execution_types::ExecutionOutcome;
+use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
+use reth_primitives_traits::{Account, RecoveredBlock, SealedHeader, StorageEntry};
+use reth_prune_types::{PruneCheckpoint, PruneSegment};
+use reth_stages_types::{StageCheckpoint, StageId};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{BlockBodyIndicesProvider, NodePrimitivesProvider, StorageChangeSetReader};
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::{HashedPostState, KeccakKeyHasher};
+use revm_database::BundleState;
+use std::{
+    ops::{RangeBounds, RangeInclusive},
+    sync::Arc,
+    time::Instant,
+};
+use tracing::trace;
+
+/// The main type for interacting with the blockchain.
+///
+/// This type serves as the main entry point for interacting with the blockchain and provides data
+/// from database storage and from the blockchain tree (pending state etc.) It is a simple wrapper
+/// type that holds an instance of the database and the blockchain tree.
+#[derive(Debug)]
+pub struct BlockchainProvider<N: NodeTypesWithDB> {
+    /// Provider factory used to access the database.
+    pub(crate) database: ProviderFactory<N>,
+    /// Tracks the chain info wrt forkchoice updates and in memory canonical
+    /// state.
+    pub(crate) canonical_in_memory_state: CanonicalInMemoryState<N::Primitives>,
+    /// Store for BALs associated with this provider view.
+    pub(crate) bal_store: BalStoreHandle,
+}
+
+impl<N: NodeTypesWithDB> Clone for BlockchainProvider<N> {
+    fn clone(&self) -> Self {
+        Self {
+            database: self.database.clone(),
+            canonical_in_memory_state: self.canonical_in_memory_state.clone(),
+            bal_store: self.bal_store.clone(),
+        }
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockchainProvider<N> {
+    /// Create a new [`BlockchainProvider`] using only the storage, fetching the latest
+    /// header from the database to initialize the provider.
+    pub fn new(storage: ProviderFactory<N>) -> ProviderResult<Self> {
+        let provider = storage.provider()?;
+        let best = provider.chain_info()?;
+        match provider.header_by_number(best.best_number)? {
+            Some(header) => {
+                drop(provider);
+                Ok(Self::with_latest(storage, SealedHeader::new(header, best.best_hash))?)
+            }
+            None => Err(ProviderError::HeaderNotFound(best.best_number.into())),
+        }
+    }
+
+    /// Create new provider instance that wraps the database and the blockchain tree, using the
+    /// provided latest header to initialize the chain info tracker.
+    ///
+    /// This returns a `ProviderResult` since it tries the retrieve the last finalized header from
+    /// `database`.
+    pub fn with_latest(
+        storage: ProviderFactory<N>,
+        latest: SealedHeader<HeaderTy<N>>,
+    ) -> ProviderResult<Self> {
+        let provider = storage.provider()?;
+        let finalized_header = provider
+            .last_finalized_block_number()?
+            .map(|num| provider.sealed_header(num))
+            .transpose()?
+            .flatten();
+        let safe_header = provider
+            .last_safe_block_number()?
+            .or_else(|| {
+                // for the purpose of this we can also use the finalized block if we don't have the
+                // safe block
+                provider.last_finalized_block_number().ok().flatten()
+            })
+            .map(|num| provider.sealed_header(num))
+            .transpose()?
+            .flatten();
+        Ok(Self {
+            database: storage,
+            canonical_in_memory_state: CanonicalInMemoryState::with_head(
+                latest,
+                finalized_header,
+                safe_header,
+            ),
+            bal_store: BalStoreHandle::new(InMemoryBalStore::default()),
+        })
+    }
+
+    /// Gets a clone of `canonical_in_memory_state`.
+    pub fn canonical_in_memory_state(&self) -> CanonicalInMemoryState<N::Primitives> {
+        self.canonical_in_memory_state.clone()
+    }
+
+    /// Returns a provider with a created `DbTx` inside, which allows fetching data from the
+    /// database using different types of providers. Example: [`HeaderProvider`]
+    /// [`BlockHashReader`]. This may fail if the inner read database transaction fails to open.
+    #[track_caller]
+    pub fn consistent_provider(&self) -> ProviderResult<ConsistentProvider<N>> {
+        ConsistentProvider::new(self.database.clone(), self.canonical_in_memory_state())
+    }
+
+    /// This uses a given [`BlockState`] to initialize a state provider for that block.
+    fn block_state_provider(
+        &self,
+        state: &BlockState<N::Primitives>,
+    ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
+        let anchor_hash = state.anchor().hash;
+        let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
+        Ok(state.state_provider(latest_historical))
+    }
+}
+
+impl<N: NodeTypesWithDB> NodePrimitivesProvider for BlockchainProvider<N> {
+    type Primitives = N::Primitives;
+}
+
+impl<N: NodeTypesWithDB> BalProvider for BlockchainProvider<N> {
+    fn bal_store(&self) -> &BalStoreHandle {
+        &self.bal_store
+    }
+}
+
+impl<N: ProviderNodeTypes> DatabaseProviderFactory for BlockchainProvider<N> {
+    type DB = N::DB;
+    type Provider = <ProviderFactory<N> as DatabaseProviderFactory>::Provider;
+    type ProviderRW = <ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW;
+
+    fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
+        self.database.database_provider_ro()
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
+        self.database.database_provider_rw()
+    }
+}
+
+impl<N: ProviderNodeTypes> StaticFileProviderFactory for BlockchainProvider<N> {
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
+        self.database.static_file_provider()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        self.database.get_static_file_writer(block, segment)
+    }
+}
+
+impl<N: ProviderNodeTypes> RocksDBProviderFactory for BlockchainProvider<N> {
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        self.database.rocksdb_provider()
+    }
+
+    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
+        unimplemented!("BlockchainProvider wraps ProviderFactory - use DatabaseProvider::set_pending_rocksdb_batch instead")
+    }
+
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+        unimplemented!("BlockchainProvider wraps ProviderFactory - use DatabaseProvider::commit_pending_rocksdb_batches instead")
+    }
+}
+
+impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider<N> {
+    type Header = HeaderTy<N>;
+
+    fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        self.consistent_provider()?.header(block_hash)
+    }
+
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+        self.consistent_provider()?.header_by_number(num)
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
+        self.consistent_provider()?.headers_range(range)
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        self.consistent_provider()?.sealed_header(number)
+    }
+
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.consistent_provider()?.sealed_headers_range(range)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.consistent_provider()?.sealed_headers_while(range, predicate)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockHashReader for BlockchainProvider<N> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.consistent_provider()?.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.consistent_provider()?.canonical_hashes_range(start, end)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockNumReader for BlockchainProvider<N> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        Ok(self.canonical_in_memory_state.chain_info())
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        Ok(self.canonical_in_memory_state.get_canonical_block_number())
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.database.last_block_number()
+    }
+
+    fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.database.earliest_block_number()
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        self.consistent_provider()?.block_number(hash)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockIdReader for BlockchainProvider<N> {
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        Ok(self.canonical_in_memory_state.pending_block_num_hash())
+    }
+
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        Ok(self.canonical_in_memory_state.get_safe_num_hash())
+    }
+
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        Ok(self.canonical_in_memory_state.get_finalized_num_hash())
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockReader for BlockchainProvider<N> {
+    type Block = BlockTy<N>;
+
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        source: BlockSource,
+    ) -> ProviderResult<Option<Self::Block>> {
+        self.consistent_provider()?.find_block_by_hash(hash, source)
+    }
+
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+        self.consistent_provider()?.block(id)
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(self.canonical_in_memory_state.pending_recovered_block())
+    }
+
+    fn pending_block_and_receipts(
+        &self,
+    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<Self::Receipt>)>> {
+        Ok(self.canonical_in_memory_state.pending_block_and_receipts())
+    }
+
+    /// Returns the block with senders with matching number or hash from database.
+    ///
+    /// **NOTE: If [`TransactionVariant::NoHash`] is provided then the transactions have invalid
+    /// hashes, since they would need to be calculated on the spot, and we want fast querying.**
+    ///
+    /// Returns `None` if block is not found.
+    fn recovered_block(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.consistent_provider()?.recovered_block(id, transaction_kind)
+    }
+
+    fn sealed_block_with_senders(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.consistent_provider()?.sealed_block_with_senders(id, transaction_kind)
+    }
+
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
+        self.consistent_provider()?.block_range(range)
+    }
+
+    fn block_with_senders_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.consistent_provider()?.block_with_senders_range(range)
+    }
+
+    fn recovered_block_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.consistent_provider()?.recovered_block_range(range)
+    }
+
+    fn block_by_transaction_id(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        self.consistent_provider()?.block_by_transaction_id(id)
+    }
+}
+
+impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
+    type Transaction = TxTy<N>;
+
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        self.consistent_provider()?.transaction_id(tx_hash)
+    }
+
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        self.consistent_provider()?.transaction_by_id(id)
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        id: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        self.consistent_provider()?.transaction_by_id_unhashed(id)
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        self.consistent_provider()?.transaction_by_hash(hash)
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        self.consistent_provider()?.transaction_by_hash_with_meta(tx_hash)
+    }
+
+    fn transactions_by_block(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        self.consistent_provider()?.transactions_by_block(id)
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        self.consistent_provider()?.transactions_by_block_range(range)
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        self.consistent_provider()?.transactions_by_tx_range(range)
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        self.consistent_provider()?.senders_by_tx_range(range)
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        self.consistent_provider()?.transaction_sender(id)
+    }
+}
+
+impl<N: ProviderNodeTypes> ReceiptProvider for BlockchainProvider<N> {
+    type Receipt = ReceiptTy<N>;
+
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+        self.consistent_provider()?.receipt(id)
+    }
+
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+        self.consistent_provider()?.receipt_by_hash(hash)
+    }
+
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        self.consistent_provider()?.receipts_by_block(block)
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Receipt>> {
+        self.consistent_provider()?.receipts_by_tx_range(range)
+    }
+
+    fn receipts_by_block_range(
+        &self,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+        self.consistent_provider()?.receipts_by_block_range(block_range)
+    }
+}
+
+impl<N: ProviderNodeTypes> ReceiptProviderIdExt for BlockchainProvider<N> {
+    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        self.consistent_provider()?.receipts_by_block_id(block)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for BlockchainProvider<N> {
+    fn block_body_indices(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        self.consistent_provider()?.block_body_indices(number)
+    }
+
+    fn block_body_indices_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        self.consistent_provider()?.block_body_indices_range(range)
+    }
+}
+
+impl<N: ProviderNodeTypes> StageCheckpointReader for BlockchainProvider<N> {
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
+        self.consistent_provider()?.get_stage_checkpoint(id)
+    }
+
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>> {
+        self.consistent_provider()?.get_stage_checkpoint_progress(id)
+    }
+
+    fn get_all_checkpoints(&self) -> ProviderResult<Vec<(String, StageCheckpoint)>> {
+        self.consistent_provider()?.get_all_checkpoints()
+    }
+}
+
+impl<N: ProviderNodeTypes> PruneCheckpointReader for BlockchainProvider<N> {
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
+        self.consistent_provider()?.get_prune_checkpoint(segment)
+    }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        self.consistent_provider()?.get_prune_checkpoints()
+    }
+}
+
+impl<N: NodeTypesWithDB> ChainSpecProvider for BlockchainProvider<N> {
+    type ChainSpec = N::ChainSpec;
+
+    fn chain_spec(&self) -> Arc<N::ChainSpec> {
+        self.database.chain_spec()
+    }
+}
+
+impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
+    /// Storage provider for latest block
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
+        trace!(target: "providers::blockchain", "Getting latest block state provider");
+        // use latest state provider if the head state exists
+        if let Some(state) = self.canonical_in_memory_state.head_state() {
+            trace!(target: "providers::blockchain", "Using head state for latest state provider");
+            Ok(self.block_state_provider(&state)?.boxed())
+        } else {
+            trace!(target: "providers::blockchain", "Using database state for latest state provider");
+            self.database.latest()
+        }
+    }
+
+    /// Returns a [`StateProviderBox`] indexed by the given block number or tag.
+    fn state_by_block_number_or_tag(
+        &self,
+        number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
+        match number_or_tag {
+            BlockNumberOrTag::Latest => self.latest(),
+            BlockNumberOrTag::Finalized => {
+                // we can only get the finalized state by hash, not by num
+                let hash =
+                    self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
+                self.state_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Safe => {
+                // we can only get the safe state by hash, not by num
+                let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
+                self.state_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Earliest => {
+                self.history_by_block_number(self.earliest_block_number()?)
+            }
+            BlockNumberOrTag::Pending => self.pending(),
+            BlockNumberOrTag::Number(num) => {
+                let hash = self
+                    .block_hash(num)?
+                    .ok_or_else(|| ProviderError::HeaderNotFound(num.into()))?;
+                self.state_by_block_hash(hash)
+            }
+        }
+    }
+
+    fn history_by_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<StateProviderBox> {
+        trace!(target: "providers::blockchain", ?block_number, "Getting history by block number");
+        let provider = self.consistent_provider()?;
+        let hash = provider
+            .block_hash(block_number)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;
+        provider.into_state_provider_at_block_hash(hash)
+    }
+
+    fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox> {
+        trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
+        self.consistent_provider()?.into_state_provider_at_block_hash(block_hash)
+    }
+
+    fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {
+        trace!(target: "providers::blockchain", ?hash, "Getting state by block hash");
+        if let Ok(state) = self.history_by_block_hash(hash) {
+            // This could be tracked by a historical block
+            Ok(state)
+        } else if let Ok(Some(pending)) = self.pending_state_by_hash(hash) {
+            // .. or this could be the pending state
+            Ok(pending)
+        } else {
+            // if we couldn't find it anywhere, then we should return an error
+            Err(ProviderError::StateForHashNotFound(hash))
+        }
+    }
+
+    /// Returns the state provider for pending state.
+    ///
+    /// If there's no pending block available then the latest state provider is returned:
+    /// [`Self::latest`]
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
+        trace!(target: "providers::blockchain", "Getting provider for pending state");
+
+        if let Some(pending) = self.canonical_in_memory_state.pending_state() {
+            // we have a pending block
+            return Ok(Box::new(self.block_state_provider(&pending)?));
+        }
+
+        // fallback to latest state if the pending block is not available
+        self.latest()
+    }
+
+    fn pending_state_by_hash(&self, block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
+        if let Some(pending) = self.canonical_in_memory_state.pending_state() &&
+            pending.hash() == block_hash
+        {
+            return Ok(Some(Box::new(self.block_state_provider(&pending)?)));
+        }
+        Ok(None)
+    }
+
+    fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>> {
+        if let Some(pending) = self.canonical_in_memory_state.pending_state() {
+            return Ok(Some(Box::new(self.block_state_provider(&pending)?)))
+        }
+
+        Ok(None)
+    }
+}
+
+impl<N: NodeTypesWithDB> HashedPostStateProvider for BlockchainProvider<N> {
+    fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+}
+
+impl<N: ProviderNodeTypes> CanonChainTracker for BlockchainProvider<N> {
+    type Header = HeaderTy<N>;
+
+    fn on_forkchoice_update_received(&self, _update: &ForkchoiceState) {
+        // update timestamp
+        self.canonical_in_memory_state.on_forkchoice_update_received();
+    }
+
+    fn last_received_update_timestamp(&self) -> Option<Instant> {
+        self.canonical_in_memory_state.last_received_update_timestamp()
+    }
+
+    fn set_canonical_head(&self, header: SealedHeader<Self::Header>) {
+        self.canonical_in_memory_state.set_canonical_head(header);
+    }
+
+    fn set_safe(&self, header: SealedHeader<Self::Header>) {
+        self.canonical_in_memory_state.set_safe(header);
+    }
+
+    fn set_finalized(&self, header: SealedHeader<Self::Header>) {
+        self.canonical_in_memory_state.set_finalized(header);
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockReaderIdExt for BlockchainProvider<N>
+where
+    Self: ReceiptProviderIdExt,
+{
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Block>> {
+        self.consistent_provider()?.block_by_id(id)
+    }
+
+    fn header_by_number_or_tag(
+        &self,
+        id: BlockNumberOrTag,
+    ) -> ProviderResult<Option<Self::Header>> {
+        self.consistent_provider()?.header_by_number_or_tag(id)
+    }
+
+    fn sealed_header_by_number_or_tag(
+        &self,
+        id: BlockNumberOrTag,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        self.consistent_provider()?.sealed_header_by_number_or_tag(id)
+    }
+
+    fn sealed_header_by_id(
+        &self,
+        id: BlockId,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        self.consistent_provider()?.sealed_header_by_id(id)
+    }
+
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Header>> {
+        self.consistent_provider()?.header_by_id(id)
+    }
+}
+
+impl<N: ProviderNodeTypes> CanonStateSubscriptions for BlockchainProvider<N> {
+    fn subscribe_to_canonical_state(&self) -> CanonStateNotifications<Self::Primitives> {
+        self.canonical_in_memory_state.subscribe_canon_state()
+    }
+}
+
+impl<N: ProviderNodeTypes> ForkChoiceSubscriptions for BlockchainProvider<N> {
+    type Header = HeaderTy<N>;
+
+    fn subscribe_safe_block(&self) -> ForkChoiceNotifications<Self::Header> {
+        let receiver = self.canonical_in_memory_state.subscribe_safe_block();
+        ForkChoiceNotifications(receiver)
+    }
+
+    fn subscribe_finalized_block(&self) -> ForkChoiceNotifications<Self::Header> {
+        let receiver = self.canonical_in_memory_state.subscribe_finalized_block();
+        ForkChoiceNotifications(receiver)
+    }
+}
+
+impl<N: ProviderNodeTypes> PersistedBlockSubscriptions for BlockchainProvider<N> {
+    fn subscribe_persisted_block(&self) -> PersistedBlockNotifications {
+        let receiver = self.canonical_in_memory_state.subscribe_persisted_block();
+        PersistedBlockNotifications(receiver)
+    }
+}
+
+impl<N: ProviderNodeTypes> StorageChangeSetReader for BlockchainProvider<N> {
+    fn storage_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        self.consistent_provider()?.storage_changeset(block_number)
+    }
+
+    fn get_storage_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+        storage_key: B256,
+    ) -> ProviderResult<Option<StorageEntry>> {
+        self.consistent_provider()?.get_storage_before_block(block_number, address, storage_key)
+    }
+
+    fn storage_changesets_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        self.consistent_provider()?.storage_changesets_range(range)
+    }
+}
+
+impl<N: ProviderNodeTypes> ChangeSetReader for BlockchainProvider<N> {
+    fn account_block_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
+        self.consistent_provider()?.account_block_changeset(block_number)
+    }
+
+    fn get_account_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+    ) -> ProviderResult<Option<AccountBeforeTx>> {
+        self.consistent_provider()?.get_account_before_block(block_number, address)
+    }
+
+    fn account_changesets_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
+        self.consistent_provider()?.account_changesets_range(range)
+    }
+}
+
+impl<N: ProviderNodeTypes> AccountReader for BlockchainProvider<N> {
+    /// Get basic account information.
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        self.consistent_provider()?.basic_account(address)
+    }
+}
+
+impl<N: ProviderNodeTypes> StateReader for BlockchainProvider<N> {
+    type Receipt = ReceiptTy<N>;
+
+    /// Re-constructs the [`ExecutionOutcome`] from in-memory and database state, if necessary.
+    ///
+    /// If data for the block does not exist, this will return [`None`].
+    ///
+    /// NOTE: This cannot be called safely in a loop outside of the blockchain tree thread. This is
+    /// because the [`CanonicalInMemoryState`] could change during a reorg, causing results to be
+    /// inconsistent. Currently this can safely be called within the blockchain tree thread,
+    /// because the tree thread is responsible for modifying the [`CanonicalInMemoryState`] in the
+    /// first place.
+    fn get_state(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+        self.consistent_provider()?.get_state(block)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        providers::BlockchainProvider,
+        test_utils::{
+            create_test_provider_factory, create_test_provider_factory_with_chain_spec,
+            MockNodeTypesWithDB,
+        },
+        BlockWriter, CanonChainTracker, ProviderFactory, SaveBlocksMode,
+    };
+    use alloy_eips::{BlockHashOrNumber, BlockNumHash, BlockNumberOrTag};
+    use alloy_primitives::{BlockNumber, TxNumber, B256};
+    use itertools::Itertools;
+    use rand::Rng;
+    use reth_chain_state::{
+        test_utils::TestBlockBuilder, CanonStateNotification, CanonStateSubscriptions,
+        CanonicalInMemoryState, ExecutedBlock, NewCanonicalChain,
+    };
+    use reth_chainspec::{ChainSpec, MAINNET};
+    use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
+    use reth_errors::ProviderError;
+    use reth_ethereum_primitives::{Block, Receipt};
+    use reth_execution_types::{
+        BlockExecutionOutput, BlockExecutionResult, Chain, ExecutionOutcome,
+    };
+    use reth_primitives_traits::{RecoveredBlock, SealedBlock, SignerRecoverable};
+    use reth_storage_api::{
+        BlockBodyIndicesProvider, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
+        BlockReaderIdExt, BlockSource, ChangeSetReader, DBProvider, DatabaseProviderFactory,
+        HeaderProvider, ReceiptProvider, ReceiptProviderIdExt, StateProviderFactory,
+        StateWriteConfig, StateWriter, TransactionVariant, TransactionsProvider,
+    };
+    use reth_testing_utils::generators::{
+        self, random_block, random_block_range, random_changeset_range, random_eoa_accounts,
+        random_receipt, BlockParams, BlockRangeParams,
+    };
+    use revm_database::{BundleState, OriginalValuesKnown};
+    use std::{
+        collections::BTreeMap,
+        ops::{Bound, Range, RangeBounds},
+        sync::Arc,
+    };
+
+    const TEST_BLOCKS_COUNT: usize = 5;
+
+    const TEST_TRANSACTIONS_COUNT: u8 = 4;
+
+    fn random_blocks(
+        rng: &mut impl Rng,
+        database_blocks: usize,
+        in_memory_blocks: usize,
+        requests_count: Option<Range<u8>>,
+        withdrawals_count: Option<Range<u8>>,
+        tx_count: impl RangeBounds<u8>,
+    ) -> (Vec<SealedBlock<Block>>, Vec<SealedBlock<Block>>) {
+        let block_range = (database_blocks + in_memory_blocks - 1) as u64;
+
+        let tx_start = match tx_count.start_bound() {
+            Bound::Included(&n) | Bound::Excluded(&n) => n,
+            Bound::Unbounded => u8::MIN,
+        };
+        let tx_end = match tx_count.end_bound() {
+            Bound::Included(&n) | Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => u8::MAX,
+        };
+
+        let blocks = random_block_range(
+            rng,
+            0..=block_range,
+            BlockRangeParams {
+                parent: Some(B256::ZERO),
+                tx_count: tx_start..tx_end,
+                requests_count,
+                withdrawals_count,
+            },
+        );
+        let (database_blocks, in_memory_blocks) = blocks.split_at(database_blocks);
+        (database_blocks.to_vec(), in_memory_blocks.to_vec())
+    }
+
+    #[expect(clippy::type_complexity)]
+    fn provider_with_chain_spec_and_random_blocks(
+        rng: &mut impl Rng,
+        chain_spec: Arc<ChainSpec>,
+        database_blocks: usize,
+        in_memory_blocks: usize,
+        block_range_params: BlockRangeParams,
+    ) -> eyre::Result<(
+        BlockchainProvider<MockNodeTypesWithDB>,
+        Vec<SealedBlock<Block>>,
+        Vec<SealedBlock<Block>>,
+        Vec<Vec<Receipt>>,
+    )> {
+        let (database_blocks, in_memory_blocks) = random_blocks(
+            rng,
+            database_blocks,
+            in_memory_blocks,
+            block_range_params.requests_count,
+            block_range_params.withdrawals_count,
+            block_range_params.tx_count,
+        );
+
+        let receipts: Vec<Vec<_>> = database_blocks
+            .iter()
+            .chain(in_memory_blocks.iter())
+            .map(|block| block.body().transactions.iter())
+            .map(|tx| tx.map(|tx| random_receipt(rng, tx, Some(2), None)).collect())
+            .collect();
+
+        let factory = create_test_provider_factory_with_chain_spec(chain_spec);
+        let provider_rw = factory.database_provider_rw()?;
+
+        // Insert blocks into the database
+        for block in &database_blocks {
+            provider_rw.insert_block(
+                &block.clone().try_recover().expect("failed to seal block with senders"),
+            )?;
+        }
+
+        // Insert receipts into the database
+        if let Some(first_block) = database_blocks.first() {
+            provider_rw.write_state(
+                &ExecutionOutcome {
+                    first_block: first_block.number,
+                    receipts: receipts.iter().take(database_blocks.len()).cloned().collect(),
+                    ..Default::default()
+                },
+                OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )?;
+        }
+
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+
+        // Insert the rest of the blocks and receipts into the in-memory state
+        let chain = NewCanonicalChain::Commit {
+            new: in_memory_blocks
+                .iter()
+                .map(|block| {
+                    let senders = block.senders().expect("failed to recover senders");
+                    let block_receipts = receipts.get(block.number as usize).unwrap().clone();
+                    let execution_outcome = BlockExecutionOutput {
+                        result: BlockExecutionResult {
+                            receipts: block_receipts,
+                            requests: Default::default(),
+                            gas_used: 0,
+                            blob_gas_used: 0,
+                        },
+                        state: BundleState::default(),
+                    };
+
+                    ExecutedBlock {
+                        recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                            block.clone(),
+                            senders,
+                        )),
+                        execution_output: execution_outcome.into(),
+                        ..Default::default()
+                    }
+                })
+                .collect(),
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        // Get canonical, safe, and finalized blocks
+        let blocks = database_blocks.iter().chain(in_memory_blocks.iter()).collect::<Vec<_>>();
+        let block_count = blocks.len();
+        let canonical_block = blocks.get(block_count - 1).unwrap();
+        let safe_block = blocks.get(block_count - 2).unwrap();
+        let finalized_block = blocks.get(block_count - 3).unwrap();
+
+        // Set the canonical head, safe, and finalized blocks
+        provider.set_canonical_head(canonical_block.clone_sealed_header());
+        provider.set_safe(safe_block.clone_sealed_header());
+        provider.set_finalized(finalized_block.clone_sealed_header());
+
+        Ok((provider, database_blocks.clone(), in_memory_blocks.clone(), receipts))
+    }
+
+    #[expect(clippy::type_complexity)]
+    fn provider_with_random_blocks(
+        rng: &mut impl Rng,
+        database_blocks: usize,
+        in_memory_blocks: usize,
+        block_range_params: BlockRangeParams,
+    ) -> eyre::Result<(
+        BlockchainProvider<MockNodeTypesWithDB>,
+        Vec<SealedBlock<Block>>,
+        Vec<SealedBlock<Block>>,
+        Vec<Vec<Receipt>>,
+    )> {
+        provider_with_chain_spec_and_random_blocks(
+            rng,
+            MAINNET.clone(),
+            database_blocks,
+            in_memory_blocks,
+            block_range_params,
+        )
+    }
+
+    /// This will persist the last block in-memory and delete it from
+    /// `canonical_in_memory_state` right after a database read transaction is created.
+    ///
+    /// This simulates a RPC method having a different view than when its database transaction was
+    /// created.
+    fn persist_block_after_db_tx_creation(
+        provider: BlockchainProvider<MockNodeTypesWithDB>,
+        block_number: BlockNumber,
+    ) {
+        let hook_provider = provider.clone();
+        provider.database.db_ref().set_post_transaction_hook(Box::new(move || {
+            if let Some(state) = hook_provider.canonical_in_memory_state.head_state() &&
+                state.anchor().number + 1 == block_number
+            {
+                let mut lowest_memory_block =
+                    state.parent_state_chain().last().expect("qed").block();
+                let num_hash = lowest_memory_block.recovered_block().num_hash();
+
+                let execution_output = (*lowest_memory_block.execution_output).clone();
+                lowest_memory_block.execution_output = Arc::new(execution_output);
+
+                // Push to disk
+                let provider_rw = hook_provider.database_provider_rw().unwrap();
+                provider_rw.save_blocks(vec![lowest_memory_block], SaveBlocksMode::Full).unwrap();
+                provider_rw.commit().unwrap();
+
+                // Remove from memory
+                hook_provider.canonical_in_memory_state.remove_persisted_blocks(num_hash);
+            }
+        }));
+    }
+
+    #[test]
+    fn test_block_reader_find_block_by_hash() -> eyre::Result<()> {
+        // Initialize random number generator and provider factory
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+
+        // Generate 10 random blocks and split into database and in-memory blocks
+        let blocks = random_block_range(
+            &mut rng,
+            0..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        let (database_blocks, in_memory_blocks) = blocks.split_at(5);
+
+        // Insert first 5 blocks into the database
+        let provider_rw = factory.provider_rw()?;
+        for block in database_blocks {
+            provider_rw.insert_block(
+                &block.clone().try_recover().expect("failed to seal block with senders"),
+            )?;
+        }
+
+        provider_rw.commit()?;
+
+        // Create a new provider
+        let provider = BlockchainProvider::new(factory)?;
+
+        // Useful blocks
+        let first_db_block = database_blocks.first().unwrap();
+        let first_in_mem_block = in_memory_blocks.first().unwrap();
+        let last_in_mem_block = in_memory_blocks.last().unwrap();
+
+        // No block in memory before setting in memory state
+        assert_eq!(provider.find_block_by_hash(first_in_mem_block.hash(), BlockSource::Any)?, None);
+        assert_eq!(
+            provider.find_block_by_hash(first_in_mem_block.hash(), BlockSource::Canonical)?,
+            None
+        );
+        // No pending block in memory
+        assert_eq!(
+            provider.find_block_by_hash(first_in_mem_block.hash(), BlockSource::Pending)?,
+            None
+        );
+
+        // Insert first block into the in-memory state
+        let in_memory_block_senders =
+            first_in_mem_block.senders().expect("failed to recover senders");
+        let chain = NewCanonicalChain::Commit {
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                    first_in_mem_block.clone(),
+                    in_memory_block_senders,
+                )),
+                ..Default::default()
+            }],
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        // Now the block should be found in memory
+        assert_eq!(
+            provider.find_block_by_hash(first_in_mem_block.hash(), BlockSource::Any)?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+        assert_eq!(
+            provider.find_block_by_hash(first_in_mem_block.hash(), BlockSource::Canonical)?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+
+        // Find the first block in database by hash
+        assert_eq!(
+            provider.find_block_by_hash(first_db_block.hash(), BlockSource::Any)?,
+            Some(first_db_block.clone().into_block())
+        );
+        assert_eq!(
+            provider.find_block_by_hash(first_db_block.hash(), BlockSource::Canonical)?,
+            Some(first_db_block.clone().into_block())
+        );
+
+        // No pending block in database
+        assert_eq!(provider.find_block_by_hash(first_db_block.hash(), BlockSource::Pending)?, None);
+
+        // Insert the last block into the pending state
+        provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {
+            recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                last_in_mem_block.clone(),
+                Default::default(),
+            )),
+            ..Default::default()
+        });
+
+        // Now the last block should be found in memory
+        assert_eq!(
+            provider.find_block_by_hash(last_in_mem_block.hash(), BlockSource::Pending)?,
+            Some(last_in_mem_block.clone().into_block())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_reader_block() -> eyre::Result<()> {
+        // Initialize random number generator and provider factory
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+
+        // Generate 10 random blocks and split into database and in-memory blocks
+        let blocks = random_block_range(
+            &mut rng,
+            0..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        let (database_blocks, in_memory_blocks) = blocks.split_at(5);
+
+        // Insert first 5 blocks into the database
+        let provider_rw = factory.provider_rw()?;
+        for block in database_blocks {
+            provider_rw.insert_block(
+                &block.clone().try_recover().expect("failed to seal block with senders"),
+            )?;
+        }
+        provider_rw.commit()?;
+
+        // Create a new provider
+        let provider = BlockchainProvider::new(factory)?;
+
+        // First in memory block
+        let first_in_mem_block = in_memory_blocks.first().unwrap();
+        // First database block
+        let first_db_block = database_blocks.first().unwrap();
+
+        // First in memory block should not be found yet as not integrated to the in-memory state
+        assert_eq!(provider.block(BlockHashOrNumber::Hash(first_in_mem_block.hash()))?, None);
+        assert_eq!(provider.block(BlockHashOrNumber::Number(first_in_mem_block.number))?, None);
+
+        // Insert first block into the in-memory state
+        let in_memory_block_senders =
+            first_in_mem_block.senders().expect("failed to recover senders");
+        let chain = NewCanonicalChain::Commit {
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                    first_in_mem_block.clone(),
+                    in_memory_block_senders,
+                )),
+                ..Default::default()
+            }],
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        // First in memory block should be found
+        assert_eq!(
+            provider.block(BlockHashOrNumber::Hash(first_in_mem_block.hash()))?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+        assert_eq!(
+            provider.block(BlockHashOrNumber::Number(first_in_mem_block.number))?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+
+        // First database block should be found
+        assert_eq!(
+            provider.block(BlockHashOrNumber::Hash(first_db_block.hash()))?,
+            Some(first_db_block.clone().into_block())
+        );
+        assert_eq!(
+            provider.block(BlockHashOrNumber::Number(first_db_block.number))?,
+            Some(first_db_block.clone().into_block())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_reader_pending_block() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, _, _, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        // Generate a random block
+        let mut rng = generators::rng();
+        let block = random_block(
+            &mut rng,
+            0,
+            BlockParams { parent: Some(B256::ZERO), ..Default::default() },
+        );
+
+        // Set the block as pending
+        provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {
+            recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                block.clone(),
+                block.senders().unwrap(),
+            )),
+            ..Default::default()
+        });
+
+        // Assertions related to the pending block
+
+        assert_eq!(
+            provider.pending_block()?,
+            Some(RecoveredBlock::new_sealed(block.clone(), block.senders().unwrap()))
+        );
+
+        assert_eq!(
+            provider.pending_block_and_receipts()?,
+            Some((RecoveredBlock::new_sealed(block.clone(), block.senders().unwrap()), vec![]))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_body_indices() -> eyre::Result<()> {
+        // Create a new provider
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams {
+                tx_count: TEST_TRANSACTIONS_COUNT..TEST_TRANSACTIONS_COUNT,
+                ..Default::default()
+            },
+        )?;
+
+        let first_in_mem_block = in_memory_blocks.first().unwrap();
+
+        // Insert the first block into the in-memory state
+        let in_memory_block_senders =
+            first_in_mem_block.senders().expect("failed to recover senders");
+        let chain = NewCanonicalChain::Commit {
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                    first_in_mem_block.clone(),
+                    in_memory_block_senders,
+                )),
+                ..Default::default()
+            }],
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        let first_db_block = database_blocks.first().unwrap().clone();
+        let first_in_mem_block = in_memory_blocks.first().unwrap().clone();
+
+        // First database block body indices should be found
+        assert_eq!(
+            provider.block_body_indices(first_db_block.number)?.unwrap(),
+            StoredBlockBodyIndices { first_tx_num: 0, tx_count: 4 }
+        );
+
+        // First in-memory block body indices should be found with the first tx after the database
+        // blocks
+        assert_eq!(
+            provider.block_body_indices(first_in_mem_block.number)?.unwrap(),
+            StoredBlockBodyIndices { first_tx_num: 20, tx_count: 4 }
+        );
+
+        // A random block number should return None as the block is not found
+        let mut rng = rand::rng();
+        let random_block_number: u64 = rng.random();
+        assert_eq!(provider.block_body_indices(random_block_number)?, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_hash_reader() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        let database_block = database_blocks.first().unwrap().clone();
+        let in_memory_block = in_memory_blocks.last().unwrap().clone();
+
+        assert_eq!(provider.block_hash(database_block.number)?, Some(database_block.hash()));
+        assert_eq!(provider.block_hash(in_memory_block.number)?, Some(in_memory_block.hash()));
+
+        assert_eq!(
+            provider.canonical_hashes_range(0, 10)?,
+            [database_blocks, in_memory_blocks]
+                .concat()
+                .iter()
+                .map(|block| block.hash())
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_header_provider() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        // make sure that the finalized block is on db
+        let finalized_block = database_blocks.get(database_blocks.len() - 3).unwrap();
+        provider.set_finalized(finalized_block.clone_sealed_header());
+
+        let blocks = [database_blocks, in_memory_blocks].concat();
+
+        assert_eq!(
+            provider.sealed_headers_while(0..=10, |header| header.number <= 8)?,
+            blocks
+                .iter()
+                .take_while(|header| header.number <= 8)
+                .map(|b| b.clone_sealed_header())
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_canon_state_subscriptions() -> eyre::Result<()> {
+        let factory = create_test_provider_factory();
+
+        // Generate a random block to initialize the blockchain provider.
+        let mut test_block_builder = TestBlockBuilder::eth();
+        let block_1 = test_block_builder.generate_random_block(0, B256::ZERO).try_recover()?;
+        let block_hash_1 = block_1.hash();
+
+        // Insert and commit the block.
+        let provider_rw = factory.provider_rw()?;
+        provider_rw.insert_block(&block_1)?;
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+
+        // Subscribe twice for canonical state updates.
+        let in_memory_state = provider.canonical_in_memory_state();
+        let mut rx_1 = provider.subscribe_to_canonical_state();
+        let mut rx_2 = provider.subscribe_to_canonical_state();
+
+        // Send and receive commit notifications.
+        let block_2 = test_block_builder.generate_random_block(1, block_hash_1).try_recover()?;
+        let chain = Chain::new(vec![block_2], ExecutionOutcome::default(), BTreeMap::new());
+        let commit = CanonStateNotification::Commit { new: Arc::new(chain.clone()) };
+        in_memory_state.notify_canon_state(commit.clone());
+        let (notification_1, notification_2) = tokio::join!(rx_1.recv(), rx_2.recv());
+        assert_eq!(notification_1, Ok(commit.clone()));
+        assert_eq!(notification_2, Ok(commit.clone()));
+
+        // Send and receive re-org notifications.
+        let block_3 = test_block_builder.generate_random_block(1, block_hash_1).try_recover()?;
+        let block_4 = test_block_builder.generate_random_block(2, block_3.hash()).try_recover()?;
+        let new_chain =
+            Chain::new(vec![block_3, block_4], ExecutionOutcome::default(), BTreeMap::new());
+        let re_org =
+            CanonStateNotification::Reorg { old: Arc::new(chain), new: Arc::new(new_chain) };
+        in_memory_state.notify_canon_state(re_org.clone());
+        let (notification_1, notification_2) = tokio::join!(rx_1.recv(), rx_2.recv());
+        assert_eq!(notification_1, Ok(re_org.clone()));
+        assert_eq!(notification_2, Ok(re_org.clone()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_num_reader() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        assert_eq!(provider.best_block_number()?, in_memory_blocks.last().unwrap().number);
+        assert_eq!(provider.last_block_number()?, database_blocks.last().unwrap().number);
+
+        let database_block = database_blocks.first().unwrap().clone();
+        let in_memory_block = in_memory_blocks.first().unwrap().clone();
+        assert_eq!(provider.block_number(database_block.hash())?, Some(database_block.number));
+        assert_eq!(provider.block_number(in_memory_block.hash())?, Some(in_memory_block.number));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_reader_id_ext_block_by_id() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        let database_block = database_blocks.first().unwrap().clone();
+        let in_memory_block = in_memory_blocks.last().unwrap().clone();
+
+        let block_number = database_block.number;
+        let block_hash = database_block.hash();
+
+        assert_eq!(
+            provider.block_by_id(block_number.into()).unwrap(),
+            Some(database_block.clone().into_block())
+        );
+        assert_eq!(
+            provider.block_by_id(block_hash.into()).unwrap(),
+            Some(database_block.into_block())
+        );
+
+        let block_number = in_memory_block.number;
+        let block_hash = in_memory_block.hash();
+        assert_eq!(
+            provider.block_by_id(block_number.into()).unwrap(),
+            Some(in_memory_block.clone().into_block())
+        );
+        assert_eq!(
+            provider.block_by_id(block_hash.into()).unwrap(),
+            Some(in_memory_block.into_block())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_reader_id_ext_header_by_number_or_tag() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        let database_block = database_blocks.first().unwrap().clone();
+
+        let in_memory_block_count = in_memory_blocks.len();
+        let canonical_block = in_memory_blocks.get(in_memory_block_count - 1).unwrap().clone();
+        let safe_block = in_memory_blocks.get(in_memory_block_count - 2).unwrap().clone();
+        let finalized_block = in_memory_blocks.get(in_memory_block_count - 3).unwrap().clone();
+
+        let block_number = database_block.number;
+        assert_eq!(
+            provider.header_by_number_or_tag(block_number.into()).unwrap(),
+            Some(database_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_number_or_tag(block_number.into())?,
+            Some(database_block.clone_sealed_header())
+        );
+
+        assert_eq!(
+            provider.header_by_number_or_tag(BlockNumberOrTag::Latest).unwrap(),
+            Some(canonical_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Latest).unwrap(),
+            Some(canonical_block.clone_sealed_header())
+        );
+
+        assert_eq!(
+            provider.header_by_number_or_tag(BlockNumberOrTag::Safe).unwrap(),
+            Some(safe_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Safe).unwrap(),
+            Some(safe_block.clone_sealed_header())
+        );
+
+        assert_eq!(
+            provider.header_by_number_or_tag(BlockNumberOrTag::Finalized).unwrap(),
+            Some(finalized_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Finalized).unwrap(),
+            Some(finalized_block.clone_sealed_header())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_reader_id_ext_header_by_id() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        let database_block = database_blocks.first().unwrap().clone();
+        let in_memory_block = in_memory_blocks.last().unwrap().clone();
+
+        let block_number = database_block.number;
+        let block_hash = database_block.hash();
+
+        assert_eq!(
+            provider.header_by_id(block_number.into()).unwrap(),
+            Some(database_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_id(block_number.into()).unwrap(),
+            Some(database_block.clone_sealed_header())
+        );
+
+        assert_eq!(
+            provider.header_by_id(block_hash.into()).unwrap(),
+            Some(database_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_id(block_hash.into()).unwrap(),
+            Some(database_block.clone_sealed_header())
+        );
+
+        let block_number = in_memory_block.number;
+        let block_hash = in_memory_block.hash();
+
+        assert_eq!(
+            provider.header_by_id(block_number.into()).unwrap(),
+            Some(in_memory_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_id(block_number.into()).unwrap(),
+            Some(in_memory_block.clone_sealed_header())
+        );
+
+        assert_eq!(
+            provider.header_by_id(block_hash.into()).unwrap(),
+            Some(in_memory_block.header().clone())
+        );
+        assert_eq!(
+            provider.sealed_header_by_id(block_hash.into()).unwrap(),
+            Some(in_memory_block.clone_sealed_header())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_receipt_provider_id_ext_receipts_by_block_id() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, receipts) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams { tx_count: 1..3, ..Default::default() },
+        )?;
+
+        let database_block = database_blocks.first().unwrap().clone();
+        let in_memory_block = in_memory_blocks.last().unwrap().clone();
+
+        let block_number = database_block.number;
+        let block_hash = database_block.hash();
+
+        assert!(!receipts.get(database_block.number as usize).unwrap().is_empty());
+        assert!(!provider
+            .receipts_by_number_or_tag(database_block.number.into())?
+            .unwrap()
+            .is_empty());
+
+        assert_eq!(
+            provider.receipts_by_block_id(block_number.into())?.unwrap(),
+            receipts.get(block_number as usize).unwrap().clone()
+        );
+        assert_eq!(
+            provider.receipts_by_block_id(block_hash.into())?.unwrap(),
+            receipts.get(block_number as usize).unwrap().clone()
+        );
+
+        let block_number = in_memory_block.number;
+        let block_hash = in_memory_block.hash();
+
+        assert_eq!(
+            provider.receipts_by_block_id(block_number.into())?.unwrap(),
+            receipts.get(block_number as usize).unwrap().clone()
+        );
+        assert_eq!(
+            provider.receipts_by_block_id(block_hash.into())?.unwrap(),
+            receipts.get(block_number as usize).unwrap().clone()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_receipt_provider_id_ext_receipts_by_block_number_or_tag() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, receipts) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams { tx_count: 1..3, ..Default::default() },
+        )?;
+
+        let database_block = database_blocks.first().unwrap().clone();
+
+        let in_memory_block_count = in_memory_blocks.len();
+        let canonical_block = in_memory_blocks.get(in_memory_block_count - 1).unwrap().clone();
+        let safe_block = in_memory_blocks.get(in_memory_block_count - 2).unwrap().clone();
+        let finalized_block = in_memory_blocks.get(in_memory_block_count - 3).unwrap().clone();
+
+        assert!(!receipts.get(database_block.number as usize).unwrap().is_empty());
+        assert!(!provider
+            .receipts_by_number_or_tag(database_block.number.into())?
+            .unwrap()
+            .is_empty());
+
+        assert_eq!(
+            provider.receipts_by_number_or_tag(database_block.number.into())?.unwrap(),
+            receipts.get(database_block.number as usize).unwrap().clone()
+        );
+        assert_eq!(
+            provider.receipts_by_number_or_tag(BlockNumberOrTag::Latest)?.unwrap(),
+            receipts.get(canonical_block.number as usize).unwrap().clone()
+        );
+        assert_eq!(
+            provider.receipts_by_number_or_tag(BlockNumberOrTag::Safe)?.unwrap(),
+            receipts.get(safe_block.number as usize).unwrap().clone()
+        );
+        assert_eq!(
+            provider.receipts_by_number_or_tag(BlockNumberOrTag::Finalized)?.unwrap(),
+            receipts.get(finalized_block.number as usize).unwrap().clone()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_changeset_reader() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+
+        let (database_blocks, in_memory_blocks) =
+            random_blocks(&mut rng, TEST_BLOCKS_COUNT, 1, None, None, 0..1);
+
+        let first_database_block = database_blocks.first().map(|block| block.number).unwrap();
+        let last_database_block = database_blocks.last().map(|block| block.number).unwrap();
+        let first_in_memory_block = in_memory_blocks.first().map(|block| block.number).unwrap();
+
+        let accounts = random_eoa_accounts(&mut rng, 2);
+
+        let (database_changesets, database_state) = random_changeset_range(
+            &mut rng,
+            &database_blocks,
+            accounts.into_iter().map(|(address, account)| (address, (account, Vec::new()))),
+            0..0,
+            0..0,
+        );
+        let (in_memory_changesets, in_memory_state) = random_changeset_range(
+            &mut rng,
+            &in_memory_blocks,
+            database_state
+                .iter()
+                .map(|(address, (account, storage))| (*address, (*account, storage.clone()))),
+            0..0,
+            0..0,
+        );
+
+        let factory = create_test_provider_factory();
+
+        let provider_rw = factory.provider_rw()?;
+        provider_rw.append_blocks_with_state(
+            database_blocks
+                .into_iter()
+                .map(|b| b.try_recover().expect("failed to seal block with senders"))
+                .collect(),
+            &ExecutionOutcome {
+                bundle: BundleState::new(
+                    database_state.into_iter().map(|(address, (account, _))| {
+                        (address, None, Some(account.into()), Default::default())
+                    }),
+                    database_changesets.iter().map(|block_changesets| {
+                        block_changesets.iter().map(|(address, account, _)| {
+                            (*address, Some(Some((*account).into())), [])
+                        })
+                    }),
+                    Vec::new(),
+                ),
+                first_block: first_database_block,
+                ..Default::default()
+            },
+            Default::default(),
+        )?;
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+
+        let in_memory_changesets = in_memory_changesets.into_iter().next().unwrap();
+        let chain = NewCanonicalChain::Commit {
+            new: vec![in_memory_blocks
+                .first()
+                .map(|block| {
+                    let senders = block.senders().expect("failed to recover senders");
+                    ExecutedBlock {
+                        recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                            block.clone(),
+                            senders,
+                        )),
+                        execution_output: Arc::new(BlockExecutionOutput {
+                            state: BundleState::new(
+                                in_memory_state.into_iter().map(|(address, (account, _))| {
+                                    (address, None, Some(account.into()), Default::default())
+                                }),
+                                [in_memory_changesets.iter().map(|(address, account, _)| {
+                                    (*address, Some(Some((*account).into())), Vec::new())
+                                })],
+                                [],
+                            ),
+                            result: BlockExecutionResult {
+                                receipts: Default::default(),
+                                requests: Default::default(),
+                                gas_used: 0,
+                                blob_gas_used: 0,
+                            },
+                        }),
+                        ..Default::default()
+                    }
+                })
+                .unwrap()],
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        assert_eq!(
+            provider.account_block_changeset(last_database_block).unwrap(),
+            database_changesets
+                .into_iter()
+                .next_back()
+                .unwrap()
+                .into_iter()
+                .sorted_by_key(|(address, _, _)| *address)
+                .map(|(address, account, _)| AccountBeforeTx { address, info: Some(account) })
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            provider.account_block_changeset(first_in_memory_block).unwrap(),
+            in_memory_changesets
+                .into_iter()
+                .sorted_by_key(|(address, _, _)| *address)
+                .map(|(address, account, _)| AccountBeforeTx { address, info: Some(account) })
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_state_provider_factory() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+
+        // test in-memory state use-cases
+        let (in_memory_provider, _, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        // test database state use-cases
+        let (only_database_provider, database_blocks, _, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            0,
+            BlockRangeParams::default(),
+        )?;
+
+        let blocks = [database_blocks.clone(), in_memory_blocks.clone()].concat();
+        let first_in_memory_block = in_memory_blocks.first().unwrap();
+        let first_db_block = database_blocks.first().unwrap();
+
+        // test latest state
+        assert_eq!(
+            first_in_memory_block.hash(),
+            in_memory_provider.latest().unwrap().block_hash(first_in_memory_block.number)?.unwrap()
+        );
+        // test latest falls back to database state when there's no in-memory block
+        assert_eq!(
+            first_db_block.hash(),
+            only_database_provider.latest().unwrap().block_hash(first_db_block.number)?.unwrap()
+        );
+
+        // test history by block number
+        assert_eq!(
+            first_in_memory_block.hash(),
+            in_memory_provider
+                .history_by_block_number(first_in_memory_block.number)?
+                .block_hash(first_in_memory_block.number)?
+                .unwrap()
+        );
+        assert_eq!(
+            first_db_block.hash(),
+            only_database_provider
+                .history_by_block_number(first_db_block.number)?
+                .block_hash(first_db_block.number)?
+                .unwrap()
+        );
+        assert_eq!(
+            first_in_memory_block.hash(),
+            in_memory_provider
+                .history_by_block_hash(first_in_memory_block.hash())?
+                .block_hash(first_in_memory_block.number)?
+                .unwrap()
+        );
+        assert!(only_database_provider.history_by_block_hash(B256::random()).is_err());
+
+        // test state by block hash
+        assert_eq!(
+            first_in_memory_block.hash(),
+            in_memory_provider
+                .state_by_block_hash(first_in_memory_block.hash())?
+                .block_hash(first_in_memory_block.number)?
+                .unwrap()
+        );
+        assert_eq!(
+            first_db_block.hash(),
+            only_database_provider
+                .state_by_block_hash(first_db_block.hash())?
+                .block_hash(first_db_block.number)?
+                .unwrap()
+        );
+        assert!(only_database_provider.state_by_block_hash(B256::random()).is_err());
+
+        // test pending without pending state- falls back to latest
+        assert_eq!(
+            first_in_memory_block.hash(),
+            in_memory_provider
+                .pending()
+                .unwrap()
+                .block_hash(first_in_memory_block.number)
+                .unwrap()
+                .unwrap()
+        );
+
+        // adding a pending block to state can test pending() and  pending_state_by_hash() function
+        let pending_block = database_blocks[database_blocks.len() - 1].clone();
+        only_database_provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {
+            recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                pending_block.clone(),
+                Default::default(),
+            )),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            pending_block.hash(),
+            only_database_provider
+                .pending()
+                .unwrap()
+                .block_hash(pending_block.number)
+                .unwrap()
+                .unwrap()
+        );
+
+        assert_eq!(
+            pending_block.hash(),
+            only_database_provider
+                .pending_state_by_hash(pending_block.hash())?
+                .unwrap()
+                .block_hash(pending_block.number)?
+                .unwrap()
+        );
+
+        // test state by block number or tag
+        assert_eq!(
+            first_in_memory_block.hash(),
+            in_memory_provider
+                .state_by_block_number_or_tag(BlockNumberOrTag::Number(
+                    first_in_memory_block.number
+                ))?
+                .block_hash(first_in_memory_block.number)?
+                .unwrap()
+        );
+        assert_eq!(
+            first_in_memory_block.hash(),
+            in_memory_provider
+                .state_by_block_number_or_tag(BlockNumberOrTag::Latest)?
+                .block_hash(first_in_memory_block.number)?
+                .unwrap()
+        );
+        // test state by block tag for safe block
+        let safe_block = in_memory_blocks[in_memory_blocks.len() - 2].clone();
+        in_memory_provider.canonical_in_memory_state.set_safe(safe_block.clone_sealed_header());
+        assert_eq!(
+            safe_block.hash(),
+            in_memory_provider
+                .state_by_block_number_or_tag(BlockNumberOrTag::Safe)?
+                .block_hash(safe_block.number)?
+                .unwrap()
+        );
+        // test state by block tag for finalized block
+        let finalized_block = in_memory_blocks[in_memory_blocks.len() - 3].clone();
+        in_memory_provider
+            .canonical_in_memory_state
+            .set_finalized(finalized_block.clone_sealed_header());
+        assert_eq!(
+            finalized_block.hash(),
+            in_memory_provider
+                .state_by_block_number_or_tag(BlockNumberOrTag::Finalized)?
+                .block_hash(finalized_block.number)?
+                .unwrap()
+        );
+        // test state by block tag for earliest block
+        let earliest_block = blocks.first().unwrap().clone();
+        assert_eq!(
+            earliest_block.hash(),
+            only_database_provider
+                .state_by_block_number_or_tag(BlockNumberOrTag::Earliest)?
+                .block_hash(earliest_block.number)?
+                .unwrap()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_id_reader() -> eyre::Result<()> {
+        // Create a new provider
+        let mut rng = generators::rng();
+        let (provider, _, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams::default(),
+        )?;
+
+        // Set the pending block in memory
+        let pending_block = in_memory_blocks.last().unwrap();
+        provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {
+            recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                pending_block.clone(),
+                Default::default(),
+            )),
+            ..Default::default()
+        });
+
+        // Set the safe block in memory
+        let safe_block = in_memory_blocks[in_memory_blocks.len() - 2].clone();
+        provider.canonical_in_memory_state.set_safe(safe_block.clone_sealed_header());
+
+        // Set the finalized block in memory
+        let finalized_block = in_memory_blocks[in_memory_blocks.len() - 3].clone();
+        provider.canonical_in_memory_state.set_finalized(finalized_block.clone_sealed_header());
+
+        // Verify the pending block number and hash
+        assert_eq!(
+            provider.pending_block_num_hash()?,
+            Some(BlockNumHash { number: pending_block.number, hash: pending_block.hash() })
+        );
+
+        // Verify the safe block number and hash
+        assert_eq!(
+            provider.safe_block_num_hash()?,
+            Some(BlockNumHash { number: safe_block.number, hash: safe_block.hash() })
+        );
+
+        // Verify the finalized block number and hash
+        assert_eq!(
+            provider.finalized_block_num_hash()?,
+            Some(BlockNumHash { number: finalized_block.number, hash: finalized_block.hash() })
+        );
+
+        Ok(())
+    }
+
+    macro_rules! test_by_tx_range {
+        ([$(($method:ident, $data_extractor:expr)),* $(,)?]) => {{
+
+            // Get the number methods being tested.
+            // Since each method tested will move a block from memory to storage, this ensures we have enough.
+            let extra_blocks = [$(stringify!($method)),*].len();
+
+            let mut rng = generators::rng();
+            let (provider, mut database_blocks, mut in_memory_blocks, receipts) = provider_with_random_blocks(
+                &mut rng,
+                TEST_BLOCKS_COUNT,
+                TEST_BLOCKS_COUNT + extra_blocks,
+                BlockRangeParams {
+                    tx_count: TEST_TRANSACTIONS_COUNT..TEST_TRANSACTIONS_COUNT,
+                    ..Default::default()
+                },
+            )?;
+
+            $(
+                // Since data moves for each tried method, need to recalculate everything
+                let db_tx_count =
+                    database_blocks.iter().map(|b| b.transaction_count()).sum::<usize>() as u64;
+                let in_mem_tx_count =
+                    in_memory_blocks.iter().map(|b| b.transaction_count()).sum::<usize>() as u64;
+
+                let db_range = 0..=(db_tx_count - 1);
+                let in_mem_range = db_tx_count..=(in_mem_tx_count + db_range.end());
+
+                // Retrieve the expected database data
+                let database_data =
+                    database_blocks.iter().flat_map(|b| $data_extractor(b, &receipts)).collect::<Vec<_>>();
+                assert_eq!(provider.$method(db_range.clone())?, database_data, "full db data");
+
+                // Retrieve the expected in-memory data
+                let in_memory_data =
+                    in_memory_blocks.iter().flat_map(|b| $data_extractor(b, &receipts)).collect::<Vec<_>>();
+                assert_eq!(provider.$method(in_mem_range.clone())?, in_memory_data, "full mem data");
+
+                // Test partial in-memory range
+                assert_eq!(
+                    &provider.$method(in_mem_range.start() + 1..=in_mem_range.end() - 1)?,
+                    &in_memory_data[1..in_memory_data.len() - 1],
+                    "partial mem data"
+                );
+
+                // Test range in memory to unbounded end
+                assert_eq!(provider.$method(in_mem_range.start() + 1..)?, &in_memory_data[1..], "unbounded mem data");
+
+                // Test last element in-memory
+                assert_eq!(provider.$method(in_mem_range.end()..)?, &in_memory_data[in_memory_data.len() -1 ..], "last mem data");
+
+                // Test range that spans database and in-memory with unbounded end
+                assert_eq!(
+                    provider.$method(in_mem_range.start() - 2..)?,
+                    database_data[database_data.len() - 2..]
+                        .iter()
+                        .chain(&in_memory_data[..])
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    "unbounded span data"
+                );
+
+                // Test range that spans database and in-memory
+                {
+                    // This block will be persisted to disk and removed from memory AFTER the first database query. This ensures that we query the in-memory state before the database avoiding any race condition.
+                    persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+
+                    assert_eq!(
+                        provider.$method(in_mem_range.start() - 2..=in_mem_range.end() - 1)?,
+                        database_data[database_data.len() - 2..]
+                            .iter()
+                            .chain(&in_memory_data[..in_memory_data.len() - 1])
+                            .cloned()
+                            .collect::<Vec<_>>(),
+                        "span data"
+                    );
+
+                    // Adjust our blocks accordingly
+                    database_blocks.push(in_memory_blocks.remove(0));
+                }
+
+                // Test invalid range
+                let start_tx_num = u64::MAX;
+                let end_tx_num = u64::MAX;
+                let result = provider.$method(start_tx_num..end_tx_num)?;
+                assert!(result.is_empty(), "No data should be found for an invalid transaction range");
+
+                // Test empty range
+                let result = provider.$method(in_mem_range.end()+10..in_mem_range.end()+20)?;
+                assert!(result.is_empty(), "No data should be found for an empty transaction range");
+            )*
+        }};
+    }
+
+    #[test]
+    fn test_methods_by_tx_range() -> eyre::Result<()> {
+        test_by_tx_range!([
+            (senders_by_tx_range, |block: &SealedBlock<Block>, _: &Vec<Vec<Receipt>>| block
+                .senders()
+                .unwrap()),
+            (transactions_by_tx_range, |block: &SealedBlock<Block>, _: &Vec<Vec<Receipt>>| block
+                .body()
+                .transactions
+                .clone()),
+            (receipts_by_tx_range, |block: &SealedBlock<Block>, receipts: &Vec<Vec<Receipt>>| {
+                receipts[block.number as usize].clone()
+            })
+        ]);
+
+        Ok(())
+    }
+
+    macro_rules! test_by_block_range {
+        ([$(($method:ident, $data_extractor:expr)),* $(,)?]) => {{
+            // Get the number methods being tested.
+            // Since each method tested will move a block from memory to storage, this ensures we have enough.
+            let extra_blocks = [$(stringify!($method)),*].len();
+
+            let mut rng = generators::rng();
+            let (provider, mut database_blocks, mut in_memory_blocks, _) = provider_with_random_blocks(
+                &mut rng,
+                TEST_BLOCKS_COUNT,
+                TEST_BLOCKS_COUNT + extra_blocks,
+                BlockRangeParams {
+                    tx_count: TEST_TRANSACTIONS_COUNT..TEST_TRANSACTIONS_COUNT,
+                    ..Default::default()
+                },
+            )?;
+
+            $(
+                // Since data moves for each tried method, need to recalculate everything
+                let db_block_count = database_blocks.len() as u64;
+                let in_mem_block_count = in_memory_blocks.len() as u64;
+
+                let db_range = 0..=db_block_count - 1;
+                let in_mem_range = db_block_count..=(in_mem_block_count + db_range.end());
+
+                // Retrieve the expected database data
+                let database_data =
+                    database_blocks.iter().map(|b| $data_extractor(b)).collect::<Vec<_>>();
+                assert_eq!(provider.$method(db_range.clone())?, database_data);
+
+                // Retrieve the expected in-memory data
+                let in_memory_data =
+                    in_memory_blocks.iter().map(|b| $data_extractor(b)).collect::<Vec<_>>();
+                assert_eq!(provider.$method(in_mem_range.clone())?, in_memory_data);
+
+                // Test partial in-memory range
+                assert_eq!(
+                    &provider.$method(in_mem_range.start() + 1..=in_mem_range.end() - 1)?,
+                    &in_memory_data[1..in_memory_data.len() - 1]
+                );
+
+                // Test range that spans database and in-memory
+                {
+
+                    // This block will be persisted to disk and removed from memory AFTER the first database query. This ensures that we query the in-memory state before the database avoiding any race condition.
+                    persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+
+                    assert_eq!(
+                        provider.$method(in_mem_range.start() - 2..=in_mem_range.end() - 1)?,
+                        database_data[database_data.len() - 2..]
+                            .iter()
+                            .chain(&in_memory_data[..in_memory_data.len() - 1])
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    );
+
+                    // Adjust our blocks accordingly
+                    database_blocks.push(in_memory_blocks.remove(0));
+                }
+
+                // Test invalid range
+                let start_block_num = u64::MAX;
+                let end_block_num = u64::MAX;
+                let result = provider.$method(start_block_num..=end_block_num-1)?;
+                assert!(result.is_empty(), "No data should be found for an invalid block range");
+
+                // Test valid range with empty results
+                let result = provider.$method(in_mem_range.end() + 10..=in_mem_range.end() + 20)?;
+                assert!(result.is_empty(), "No data should be found for an empty block range");
+            )*
+        }};
+    }
+
+    #[test]
+    fn test_methods_by_block_range() -> eyre::Result<()> {
+        // todo(joshie) add canonical_hashes_range below after changing its interface into range
+        // instead start end
+        test_by_block_range!([
+            (headers_range, |block: &SealedBlock<Block>| block.header().clone()),
+            (sealed_headers_range, |block: &SealedBlock<Block>| block.clone_sealed_header()),
+            (block_range, |block: &SealedBlock<Block>| block.clone().into_block()),
+            (block_with_senders_range, |block: &SealedBlock<Block>| block
+                .clone()
+                .try_recover()
+                .unwrap()),
+            (recovered_block_range, |block: &SealedBlock<Block>| block
+                .clone()
+                .try_recover()
+                .unwrap()),
+            (transactions_by_block_range, |block: &SealedBlock<Block>| block
+                .body()
+                .transactions
+                .clone()),
+        ]);
+
+        Ok(())
+    }
+
+    /// Helper macro to call a provider method based on argument count and check its result
+    macro_rules! call_method {
+        ($provider:expr, $method:ident, ($($args:expr),*), $expected_item:expr) => {{
+            let result = $provider.$method($($args),*)?;
+            assert_eq!(
+                result,
+                $expected_item,
+                "{}: item does not match the expected item for arguments {:?}",
+                stringify!($method),
+                ($($args),*)
+            );
+        }};
+
+        // Handle valid or invalid arguments for one argument
+        (ONE, $provider:expr, $method:ident, $item_extractor:expr, $txnum:expr, $txhash:expr, $block:expr, $receipts:expr) => {{
+            let (arg, expected_item) = $item_extractor($block, $txnum($block), $txhash($block), $receipts);
+            call_method!($provider, $method, (arg), expected_item);
+        }};
+
+        // Handle valid or invalid arguments for two arguments
+        (TWO, $provider:expr, $method:ident, $item_extractor:expr, $txnum:expr, $txhash:expr, $block:expr, $receipts:expr) => {{
+            let ((arg1, arg2), expected_item) = $item_extractor($block, $txnum($block), $txhash($block), $receipts);
+            call_method!($provider, $method, (arg1, arg2), expected_item);
+        }};
+    }
+
+    /// Macro to test non-range methods.
+    ///
+    /// ( `NUMBER_ARGUMENTS`, METHOD, FN -> ((`METHOD_ARGUMENT(s)`,...), `EXPECTED_RESULT`),
+    /// `INVALID_ARGUMENTS`)
+    macro_rules! test_non_range {
+    ([$(($arg_count:ident, $method:ident, $item_extractor:expr, $invalid_args:expr)),* $(,)?]) => {{
+
+        // Get the number methods being tested.
+        // Since each method tested will move a block from memory to storage, this ensures we have enough.
+        let extra_blocks = [$(stringify!($arg_count)),*].len();
+
+        let mut rng = generators::rng();
+        let (provider, mut database_blocks, in_memory_blocks, receipts) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT + extra_blocks,
+            BlockRangeParams {
+                tx_count: TEST_TRANSACTIONS_COUNT..TEST_TRANSACTIONS_COUNT,
+                ..Default::default()
+            },
+        )?;
+
+        let mut in_memory_blocks: std::collections::VecDeque<_> = in_memory_blocks.into();
+
+        $(
+            let tx_hash = |block: &SealedBlock<Block>| *block.body().transactions[0].tx_hash();
+            let tx_num = |block: &SealedBlock<Block>| {
+                database_blocks
+                    .iter()
+                    .chain(in_memory_blocks.iter())
+                    .take_while(|b| b.number < block.number)
+                    .map(|b| b.transaction_count())
+                    .sum::<usize>() as u64
+            };
+
+            // Ensure that the first generated in-memory block exists
+            {
+                // This block will be persisted to disk and removed from memory AFTER the first database query. This ensures that we query the in-memory state before the database avoiding any race condition.
+                persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+
+                call_method!($arg_count, provider, $method, $item_extractor, tx_num, tx_hash, &in_memory_blocks[0], &receipts);
+
+                // Move the block as well in our own structures
+                database_blocks.push(in_memory_blocks.pop_front().unwrap());
+            }
+
+            // database_blocks is changed above
+            let tx_num = |block: &SealedBlock<Block>| {
+                database_blocks
+                    .iter()
+                    .chain(in_memory_blocks.iter())
+                    .take_while(|b| b.number < block.number)
+                    .map(|b| b.transaction_count())
+                    .sum::<usize>() as u64
+            };
+
+            // Invalid/Non-existent argument should return `None`
+            {
+                call_method!($arg_count, provider, $method, |_,_,_,_|  ($invalid_args, None), tx_num, tx_hash, &in_memory_blocks[0], &receipts);
+            }
+
+            // Check that the item is only in memory and not in database
+            {
+                let last_mem_block = &in_memory_blocks[in_memory_blocks.len() - 1];
+
+                let (args, expected_item) = $item_extractor(last_mem_block, tx_num(last_mem_block), tx_hash(last_mem_block), &receipts);
+                call_method!($arg_count, provider, $method, |_,_,_,_| (args.clone(), expected_item), tx_num, tx_hash, last_mem_block, &receipts);
+
+                // Ensure the item is not in storage
+                call_method!($arg_count, provider.database, $method, |_,_,_,_|  (args, None), tx_num, tx_hash, last_mem_block, &receipts);
+            }
+        )*
+    }};
+}
+
+    #[test]
+    fn test_non_range_methods() -> eyre::Result<()> {
+        let test_tx_index = 0;
+
+        test_non_range!([
+            (
+                ONE,
+                header,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    block.hash(),
+                    Some(block.header().clone())
+                ),
+                B256::random()
+            ),
+            (
+                ONE,
+                header_by_number,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    block.number,
+                    Some(block.header().clone())
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                sealed_header,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    block.number,
+                    Some(block.clone_sealed_header())
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                block_hash,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    block.number,
+                    Some(block.hash())
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                block_number,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    block.hash(),
+                    Some(block.number)
+                ),
+                B256::random()
+            ),
+            (
+                ONE,
+                block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    BlockHashOrNumber::Hash(block.hash()),
+                    Some(block.clone().into_block())
+                ),
+                BlockHashOrNumber::Hash(B256::random())
+            ),
+            (
+                ONE,
+                block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    BlockHashOrNumber::Number(block.number),
+                    Some(block.clone().into_block())
+                ),
+                BlockHashOrNumber::Number(u64::MAX)
+            ),
+            (
+                ONE,
+                block_body_indices,
+                |block: &SealedBlock<Block>, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    block.number,
+                    Some(StoredBlockBodyIndices {
+                        first_tx_num: tx_num,
+                        tx_count: block.transaction_count() as u64
+                    })
+                ),
+                u64::MAX
+            ),
+            (
+                TWO,
+                recovered_block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    (BlockHashOrNumber::Number(block.number), TransactionVariant::WithHash),
+                    block.clone().try_recover().ok()
+                ),
+                (BlockHashOrNumber::Number(u64::MAX), TransactionVariant::WithHash)
+            ),
+            (
+                TWO,
+                recovered_block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    (BlockHashOrNumber::Hash(block.hash()), TransactionVariant::WithHash),
+                    block.clone().try_recover().ok()
+                ),
+                (BlockHashOrNumber::Hash(B256::random()), TransactionVariant::WithHash)
+            ),
+            (
+                TWO,
+                sealed_block_with_senders,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    (BlockHashOrNumber::Number(block.number), TransactionVariant::WithHash),
+                    block.clone().try_recover().ok()
+                ),
+                (BlockHashOrNumber::Number(u64::MAX), TransactionVariant::WithHash)
+            ),
+            (
+                TWO,
+                sealed_block_with_senders,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    (BlockHashOrNumber::Hash(block.hash()), TransactionVariant::WithHash),
+                    block.clone().try_recover().ok()
+                ),
+                (BlockHashOrNumber::Hash(B256::random()), TransactionVariant::WithHash)
+            ),
+            (
+                ONE,
+                transaction_id,
+                |_: &SealedBlock<Block>, tx_num: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
+                    tx_hash,
+                    Some(tx_num)
+                ),
+                B256::random()
+            ),
+            (
+                ONE,
+                transaction_by_id,
+                |block: &SealedBlock<Block>, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    tx_num,
+                    Some(block.body().transactions[test_tx_index].clone())
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                transaction_by_id_unhashed,
+                |block: &SealedBlock<Block>, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    tx_num,
+                    Some(block.body().transactions[test_tx_index].clone())
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                transaction_by_hash,
+                |block: &SealedBlock<Block>, _: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
+                    tx_hash,
+                    Some(block.body().transactions[test_tx_index].clone())
+                ),
+                B256::random()
+            ),
+            (
+                ONE,
+                block_by_transaction_id,
+                |block: &SealedBlock<Block>, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    tx_num,
+                    Some(block.number)
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                transactions_by_block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    BlockHashOrNumber::Number(block.number),
+                    Some(block.body().transactions.clone())
+                ),
+                BlockHashOrNumber::Number(u64::MAX)
+            ),
+            (
+                ONE,
+                transactions_by_block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    BlockHashOrNumber::Hash(block.hash()),
+                    Some(block.body().transactions.clone())
+                ),
+                BlockHashOrNumber::Number(u64::MAX)
+            ),
+            (
+                ONE,
+                transaction_sender,
+                |block: &SealedBlock<Block>, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                    tx_num,
+                    block.body().transactions[test_tx_index].recover_signer().ok()
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                receipt,
+                |block: &SealedBlock<Block>,
+                 tx_num: TxNumber,
+                 _: B256,
+                 receipts: &Vec<Vec<Receipt>>| (
+                    tx_num,
+                    Some(receipts[block.number as usize][test_tx_index].clone())
+                ),
+                u64::MAX
+            ),
+            (
+                ONE,
+                receipt_by_hash,
+                |block: &SealedBlock<Block>,
+                 _: TxNumber,
+                 tx_hash: B256,
+                 receipts: &Vec<Vec<Receipt>>| (
+                    tx_hash,
+                    Some(receipts[block.number as usize][test_tx_index].clone())
+                ),
+                B256::random()
+            ),
+            (
+                ONE,
+                receipts_by_block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, receipts: &Vec<Vec<Receipt>>| (
+                    BlockHashOrNumber::Number(block.number),
+                    Some(receipts[block.number as usize].clone())
+                ),
+                BlockHashOrNumber::Number(u64::MAX)
+            ),
+            (
+                ONE,
+                receipts_by_block,
+                |block: &SealedBlock<Block>, _: TxNumber, _: B256, receipts: &Vec<Vec<Receipt>>| (
+                    BlockHashOrNumber::Hash(block.hash()),
+                    Some(receipts[block.number as usize].clone())
+                ),
+                BlockHashOrNumber::Hash(B256::random())
+            ),
+            // TODO: withdrawals, requests, ommers
+        ]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_race() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, _, in_memory_blocks, _) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT - 1,
+            TEST_BLOCKS_COUNT + 1,
+            BlockRangeParams {
+                tx_count: TEST_TRANSACTIONS_COUNT..TEST_TRANSACTIONS_COUNT,
+                ..Default::default()
+            },
+        )?;
+
+        // Old implementation was querying the database first. This is problematic, if there are
+        // changes AFTER the database transaction is created.
+        let old_transaction_hash_fn =
+            |hash: B256,
+             canonical_in_memory_state: CanonicalInMemoryState,
+             factory: ProviderFactory<MockNodeTypesWithDB>| {
+                assert!(factory.transaction_by_hash(hash)?.is_none(), "should not be in database");
+                Ok::<_, ProviderError>(canonical_in_memory_state.transaction_by_hash(hash))
+            };
+
+        // Correct implementation queries in-memory first
+        let correct_transaction_hash_fn =
+            |hash: B256,
+             canonical_in_memory_state: CanonicalInMemoryState,
+             _factory: ProviderFactory<MockNodeTypesWithDB>| {
+                if let Some(tx) = canonical_in_memory_state.transaction_by_hash(hash) {
+                    return Ok::<_, ProviderError>(Some(tx));
+                }
+                panic!("should not be in database");
+                // _factory.transaction_by_hash(hash)
+            };
+
+        // OLD BEHAVIOUR
+        {
+            // This will persist block 1 AFTER a database is created. Moving it from memory to
+            // storage.
+            persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+            let to_be_persisted_tx = in_memory_blocks[0].body().transactions[0].clone();
+
+            // Even though the block exists, given the order of provider queries done in the method
+            // above, we do not see it.
+            assert!(matches!(
+                old_transaction_hash_fn(
+                    *to_be_persisted_tx.tx_hash(),
+                    provider.canonical_in_memory_state(),
+                    provider.database.clone()
+                ),
+                Ok(None)
+            ));
+        }
+
+        // CORRECT BEHAVIOUR
+        {
+            // This will persist block 1 AFTER a database is created. Moving it from memory to
+            // storage.
+            persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[1].number);
+            let to_be_persisted_tx = in_memory_blocks[1].body().transactions[0].clone();
+
+            assert_eq!(
+                correct_transaction_hash_fn(
+                    *to_be_persisted_tx.tx_hash(),
+                    provider.canonical_in_memory_state(),
+                    provider.database
+                )
+                .unwrap(),
+                Some(to_be_persisted_tx)
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/patches/reth-provider/src/providers/consistent.rs
+++ b/patches/reth-provider/src/providers/consistent.rs
@@ -1,0 +1,2141 @@
+use super::{DatabaseProviderRO, ProviderFactory, ProviderNodeTypes};
+use crate::{
+    providers::{StaticFileProvider, StaticFileProviderRWRefMut},
+    to_range, AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
+    BlockReaderIdExt, BlockSource, ChainSpecProvider, ChangeSetReader, HeaderProvider,
+    ProviderError, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
+    StageCheckpointReader, StateReader, StaticFileProviderFactory, TransactionVariant,
+    TransactionsProvider,
+};
+use alloy_consensus::{transaction::TransactionMeta, BlockHeader};
+use alloy_eips::{
+    eip2718::Encodable2718, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
+    HashOrNumber,
+};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStateProviderRef};
+use reth_chainspec::ChainInfo;
+use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
+use reth_execution_types::ExecutionOutcome;
+use reth_node_types::{BlockTy, HeaderTy, ReceiptTy, TxTy};
+use reth_primitives_traits::{Account, BlockBody, RecoveredBlock, SealedHeader, StorageEntry};
+use reth_prune_types::{PruneCheckpoint, PruneSegment};
+use reth_stages_types::{StageCheckpoint, StageId};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{
+    BlockBodyIndicesProvider, DatabaseProviderFactory, NodePrimitivesProvider, StateProvider,
+    StateProviderBox, StorageChangeSetReader, TryIntoHistoricalStateProvider,
+};
+use reth_storage_errors::provider::ProviderResult;
+use revm_database::states::PlainStorageRevert;
+use std::{
+    ops::{Add, Bound, RangeBounds, RangeInclusive, Sub},
+    sync::Arc,
+};
+use tracing::trace;
+
+/// Type that interacts with a snapshot view of the blockchain (storage and in-memory) at time of
+/// instantiation, EXCEPT for pending, safe and finalized block which might change while holding
+/// this provider.
+///
+/// CAUTION: Avoid holding this provider for too long or the inner database transaction will
+/// time-out.
+#[derive(Debug)]
+#[doc(hidden)] // triggers ICE for `cargo docs`
+pub struct ConsistentProvider<N: ProviderNodeTypes> {
+    /// Storage provider.
+    storage_provider: <ProviderFactory<N> as DatabaseProviderFactory>::Provider,
+    /// Head block at time of [`Self`] creation
+    head_block: Option<Arc<BlockState<N::Primitives>>>,
+    /// In-memory canonical state. This is not a snapshot, and can change! Use with caution.
+    canonical_in_memory_state: CanonicalInMemoryState<N::Primitives>,
+}
+
+impl<N: ProviderNodeTypes> ConsistentProvider<N> {
+    /// Create a new provider using [`ProviderFactory`] and [`CanonicalInMemoryState`],
+    ///
+    /// Underneath it will take a snapshot by fetching [`CanonicalInMemoryState::head_state`] and
+    /// [`ProviderFactory::database_provider_ro`] effectively maintaining one single snapshotted
+    /// view of memory and database.
+    pub fn new(
+        storage_provider_factory: ProviderFactory<N>,
+        state: CanonicalInMemoryState<N::Primitives>,
+    ) -> ProviderResult<Self> {
+        // Each one provides a snapshot at the time of instantiation, but its order matters.
+        //
+        // If we acquire first the database provider, it's possible that before the in-memory chain
+        // snapshot is instantiated, it will flush blocks to disk. This would
+        // mean that our database provider would not have access to the flushed blocks (since it's
+        // working under an older view), while the in-memory state may have deleted them
+        // entirely. Resulting in gaps on the range.
+        let head_block = state.head_state();
+        let storage_provider = storage_provider_factory.database_provider_ro()?;
+        Ok(Self { storage_provider, head_block, canonical_in_memory_state: state })
+    }
+
+    // Helper function to convert range bounds
+    fn convert_range_bounds<T>(
+        &self,
+        range: impl RangeBounds<T>,
+        end_unbounded: impl FnOnce() -> T,
+    ) -> (T, T)
+    where
+        T: Copy + Add<Output = T> + Sub<Output = T> + From<u8>,
+    {
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n + T::from(1u8),
+            Bound::Unbounded => T::from(0u8),
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n - T::from(1u8),
+            Bound::Unbounded => end_unbounded(),
+        };
+
+        (start, end)
+    }
+
+    /// Storage provider for latest block
+    fn latest_ref<'a>(&'a self) -> ProviderResult<Box<dyn StateProvider + 'a>> {
+        trace!(target: "providers::blockchain", "Getting latest block state provider");
+
+        // use latest state provider if the head state exists
+        if let Some(state) = &self.head_block {
+            trace!(target: "providers::blockchain", "Using head state for latest state provider");
+            Ok(self.block_state_provider_ref(state)?.boxed())
+        } else {
+            trace!(target: "providers::blockchain", "Using database state for latest state provider");
+            Ok(self.storage_provider.latest())
+        }
+    }
+
+    fn history_by_block_hash_ref<'a>(
+        &'a self,
+        block_hash: BlockHash,
+    ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
+        trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
+
+        self.get_in_memory_or_storage_by_block(
+            block_hash.into(),
+            |_| self.storage_provider.history_by_block_hash(block_hash),
+            |block_state| {
+                let state_provider = self.block_state_provider_ref(block_state)?;
+                Ok(Box::new(state_provider))
+            },
+        )
+    }
+
+    /// Fetches a range of data from both in-memory state and persistent storage while a predicate
+    /// is met.
+    ///
+    /// Creates a snapshot of the in-memory chain state and database provider to prevent
+    /// inconsistencies. Splits the range into in-memory and storage sections, prioritizing
+    /// recent in-memory blocks in case of overlaps.
+    ///
+    /// * `fetch_db_range` function (`F`) provides access to the database provider, allowing the
+    ///   user to retrieve the required items from the database using [`RangeInclusive`].
+    /// * `map_block_state_item` function (`G`) provides each block of the range in the in-memory
+    ///   state, allowing for selection or filtering for the desired data.
+    fn get_in_memory_or_storage_by_block_range_while<T, F, G, P>(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        fetch_db_range: F,
+        map_block_state_item: G,
+        mut predicate: P,
+    ) -> ProviderResult<Vec<T>>
+    where
+        F: FnOnce(
+            &DatabaseProviderRO<N::DB, N>,
+            RangeInclusive<BlockNumber>,
+            &mut P,
+        ) -> ProviderResult<Vec<T>>,
+        G: Fn(&BlockState<N::Primitives>, &mut P) -> Option<T>,
+        P: FnMut(&T) -> bool,
+    {
+        // Each one provides a snapshot at the time of instantiation, but its order matters.
+        //
+        // If we acquire first the database provider, it's possible that before the in-memory chain
+        // snapshot is instantiated, it will flush blocks to disk. This would
+        // mean that our database provider would not have access to the flushed blocks (since it's
+        // working under an older view), while the in-memory state may have deleted them
+        // entirely. Resulting in gaps on the range.
+        let mut in_memory_chain =
+            self.head_block.as_ref().map(|b| b.chain().collect::<Vec<_>>()).unwrap_or_default();
+        let db_provider = &self.storage_provider;
+
+        let (start, end) = self.convert_range_bounds(range, || {
+            // the first block is the highest one.
+            in_memory_chain
+                .first()
+                .map(|b| b.number())
+                .unwrap_or_else(|| db_provider.last_block_number().unwrap_or_default())
+        });
+
+        if start > end {
+            return Ok(vec![])
+        }
+
+        // Split range into storage_range and in-memory range. If the in-memory range is not
+        // necessary drop it early.
+        //
+        // The last block of `in_memory_chain` is the lowest block number.
+        let (in_memory, storage_range) = match in_memory_chain.last().as_ref().map(|b| b.number()) {
+            Some(lowest_memory_block) if lowest_memory_block <= end => {
+                let highest_memory_block =
+                    in_memory_chain.first().as_ref().map(|b| b.number()).expect("qed");
+
+                // Database will for a time overlap with in-memory-chain blocks. In
+                // case of a re-org, it can mean that the database blocks are of a forked chain, and
+                // so, we should prioritize the in-memory overlapped blocks.
+                let in_memory_range =
+                    lowest_memory_block.max(start)..=end.min(highest_memory_block);
+
+                // If requested range is in the middle of the in-memory range, remove the necessary
+                // lowest blocks
+                in_memory_chain.truncate(
+                    in_memory_chain
+                        .len()
+                        .saturating_sub(start.saturating_sub(lowest_memory_block) as usize),
+                );
+
+                let storage_range =
+                    (lowest_memory_block > start).then(|| start..=lowest_memory_block - 1);
+
+                (Some((in_memory_chain, in_memory_range)), storage_range)
+            }
+            _ => {
+                // Drop the in-memory chain so we don't hold blocks in memory.
+                drop(in_memory_chain);
+
+                (None, Some(start..=end))
+            }
+        };
+
+        let mut items = Vec::with_capacity((end - start + 1) as usize);
+
+        if let Some(storage_range) = storage_range {
+            let mut db_items = fetch_db_range(db_provider, storage_range.clone(), &mut predicate)?;
+            items.append(&mut db_items);
+
+            // The predicate was not met, if the number of items differs from the expected. So, we
+            // return what we have.
+            if items.len() as u64 != storage_range.end() - storage_range.start() + 1 {
+                return Ok(items)
+            }
+        }
+
+        if let Some((in_memory_chain, in_memory_range)) = in_memory {
+            for (num, block) in in_memory_range.zip(in_memory_chain.into_iter().rev()) {
+                debug_assert!(num == block.number());
+                if let Some(item) = map_block_state_item(block, &mut predicate) {
+                    items.push(item);
+                } else {
+                    break
+                }
+            }
+        }
+
+        Ok(items)
+    }
+
+    /// This uses a given [`BlockState`] to initialize a state provider for that block.
+    fn block_state_provider_ref(
+        &self,
+        state: &BlockState<N::Primitives>,
+    ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
+        let anchor_hash = state.anchor().hash;
+        let latest_historical = self.history_by_block_hash_ref(anchor_hash)?;
+        let in_memory = state.chain().map(|block_state| block_state.block()).collect();
+        Ok(MemoryOverlayStateProviderRef::new(latest_historical, in_memory))
+    }
+
+    /// Fetches data from either in-memory state or persistent storage for a range of transactions.
+    ///
+    /// * `fetch_from_db`: has a `DatabaseProviderRO` and the storage specific range.
+    /// * `fetch_from_block_state`: has a [`RangeInclusive`] of elements that should be fetched from
+    ///   [`BlockState`]. [`RangeInclusive`] is necessary to handle partial look-ups of a block.
+    fn get_in_memory_or_storage_by_tx_range<S, M, R>(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        fetch_from_db: S,
+        fetch_from_block_state: M,
+    ) -> ProviderResult<Vec<R>>
+    where
+        S: FnOnce(
+            &DatabaseProviderRO<N::DB, N>,
+            RangeInclusive<TxNumber>,
+        ) -> ProviderResult<Vec<R>>,
+        M: Fn(RangeInclusive<usize>, &BlockState<N::Primitives>) -> ProviderResult<Vec<R>>,
+    {
+        let in_mem_chain = self.head_block.iter().flat_map(|b| b.chain()).collect::<Vec<_>>();
+        let provider = &self.storage_provider;
+
+        // Get the last block number stored in the storage which does NOT overlap with in-memory
+        // chain.
+        let last_database_block_number = in_mem_chain
+            .last()
+            .map(|b| Ok(b.anchor().number))
+            .unwrap_or_else(|| provider.last_block_number())?;
+
+        // Get the next tx number for the last block stored in the storage, which marks the start of
+        // the in-memory state.
+        let last_block_body_index = provider
+            .block_body_indices(last_database_block_number)?
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(last_database_block_number))?;
+        let mut in_memory_tx_num = last_block_body_index.next_tx_num();
+
+        let (start, end) = self.convert_range_bounds(range, || {
+            in_mem_chain
+                .iter()
+                .map(|b| b.block_ref().recovered_block().body().transactions().len() as u64)
+                .sum::<u64>() +
+                last_block_body_index.last_tx_num()
+        });
+
+        if start > end {
+            return Ok(vec![])
+        }
+
+        let mut tx_range = start..=end;
+
+        // If the range is entirely before the first in-memory transaction number, fetch from
+        // storage
+        if *tx_range.end() < in_memory_tx_num {
+            return fetch_from_db(provider, tx_range);
+        }
+
+        let mut items = Vec::with_capacity((tx_range.end() - tx_range.start() + 1) as usize);
+
+        // If the range spans storage and memory, get elements from storage first.
+        if *tx_range.start() < in_memory_tx_num {
+            // Determine the range that needs to be fetched from storage.
+            let db_range = *tx_range.start()..=in_memory_tx_num.saturating_sub(1);
+
+            // Set the remaining transaction range for in-memory
+            tx_range = in_memory_tx_num..=*tx_range.end();
+
+            items.extend(fetch_from_db(provider, db_range)?);
+        }
+
+        // Iterate from the lowest block to the highest in-memory chain
+        for block_state in in_mem_chain.iter().rev() {
+            let block_tx_count =
+                block_state.block_ref().recovered_block().body().transactions().len();
+            let remaining = (tx_range.end() - tx_range.start() + 1) as usize;
+
+            // If the transaction range start is equal or higher than the next block first
+            // transaction, advance
+            if *tx_range.start() >= in_memory_tx_num + block_tx_count as u64 {
+                in_memory_tx_num += block_tx_count as u64;
+                continue
+            }
+
+            // This should only be more than 0 once, in case of a partial range inside a block.
+            let skip = (tx_range.start() - in_memory_tx_num) as usize;
+
+            items.extend(fetch_from_block_state(
+                skip..=skip + (remaining.min(block_tx_count - skip) - 1),
+                block_state,
+            )?);
+
+            in_memory_tx_num += block_tx_count as u64;
+
+            // Break if the range has been fully processed
+            if in_memory_tx_num > *tx_range.end() {
+                break
+            }
+
+            // Set updated range
+            tx_range = in_memory_tx_num..=*tx_range.end();
+        }
+
+        Ok(items)
+    }
+
+    /// Fetches data from either in-memory state or persistent storage by transaction
+    /// [`HashOrNumber`].
+    fn get_in_memory_or_storage_by_tx<S, M, R>(
+        &self,
+        id: HashOrNumber,
+        fetch_from_db: S,
+        fetch_from_block_state: M,
+    ) -> ProviderResult<Option<R>>
+    where
+        S: FnOnce(&DatabaseProviderRO<N::DB, N>) -> ProviderResult<Option<R>>,
+        M: Fn(usize, TxNumber, &BlockState<N::Primitives>) -> ProviderResult<Option<R>>,
+    {
+        let in_mem_chain = self.head_block.iter().flat_map(|b| b.chain()).collect::<Vec<_>>();
+        let provider = &self.storage_provider;
+
+        // Get the last block number stored in the database which does NOT overlap with in-memory
+        // chain.
+        let last_database_block_number = in_mem_chain
+            .last()
+            .map(|b| Ok(b.anchor().number))
+            .unwrap_or_else(|| provider.last_block_number())?;
+
+        // Get the next tx number for the last block stored in the database and consider it the
+        // first tx number of the in-memory state
+        let last_block_body_index = provider
+            .block_body_indices(last_database_block_number)?
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(last_database_block_number))?;
+        let mut in_memory_tx_num = last_block_body_index.next_tx_num();
+
+        // If the transaction number is less than the first in-memory transaction number, make a
+        // database lookup
+        if let HashOrNumber::Number(id) = id &&
+            id < in_memory_tx_num
+        {
+            return fetch_from_db(provider)
+        }
+
+        // Iterate from the lowest block to the highest
+        for block_state in in_mem_chain.iter().rev() {
+            let executed_block = block_state.block_ref();
+            let block = executed_block.recovered_block();
+
+            for tx_index in 0..block.body().transactions().len() {
+                match id {
+                    HashOrNumber::Hash(tx_hash) => {
+                        if tx_hash == block.body().transactions()[tx_index].trie_hash() {
+                            return fetch_from_block_state(tx_index, in_memory_tx_num, block_state)
+                        }
+                    }
+                    HashOrNumber::Number(id) => {
+                        if id == in_memory_tx_num {
+                            return fetch_from_block_state(tx_index, in_memory_tx_num, block_state)
+                        }
+                    }
+                }
+
+                in_memory_tx_num += 1;
+            }
+        }
+
+        // Not found in-memory, so check database.
+        if let HashOrNumber::Hash(_) = id {
+            return fetch_from_db(provider)
+        }
+
+        Ok(None)
+    }
+
+    /// Fetches data from either in-memory state or persistent storage by [`BlockHashOrNumber`].
+    pub(crate) fn get_in_memory_or_storage_by_block<S, M, R>(
+        &self,
+        id: BlockHashOrNumber,
+        fetch_from_db: S,
+        fetch_from_block_state: M,
+    ) -> ProviderResult<R>
+    where
+        S: FnOnce(&DatabaseProviderRO<N::DB, N>) -> ProviderResult<R>,
+        M: Fn(&BlockState<N::Primitives>) -> ProviderResult<R>,
+    {
+        if let Some(Some(block_state)) = self.head_block.as_ref().map(|b| b.block_on_chain(id)) {
+            return fetch_from_block_state(block_state)
+        }
+        fetch_from_db(&self.storage_provider)
+    }
+
+    /// Consumes the provider and returns a state provider for the specific block hash.
+    pub(crate) fn into_state_provider_at_block_hash(
+        self,
+        block_hash: BlockHash,
+    ) -> ProviderResult<StateProviderBox> {
+        // Resolve block number and verify it's canonical before destructuring self
+        let block_number =
+            self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        self.ensure_canonical_block(block_number)?;
+
+        let Self { storage_provider, head_block, .. } = self;
+        if let Some(Some(block_state)) =
+            head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
+        {
+            let anchor_hash = block_state.anchor().hash;
+            let block_number = storage_provider
+                .block_number(anchor_hash)?
+                .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
+            let latest_historical = storage_provider.try_into_history_at_block(block_number)?;
+            return Ok(Box::new(block_state.state_provider(latest_historical)));
+        }
+        storage_provider.try_into_history_at_block(block_number)
+    }
+}
+
+impl<N: ProviderNodeTypes> ConsistentProvider<N> {
+    /// Ensures that the given block number is canonical (synced)
+    ///
+    /// This is a helper for guarding the `HistoricalStateProvider` against block numbers that are
+    /// out of range and would lead to invalid results, mainly during initial sync.
+    ///
+    /// Verifying the `block_number` would be expensive since we need to lookup sync table
+    /// Instead, we ensure that the `block_number` is within the range of the
+    /// [`Self::best_block_number`] which is updated when a block is synced.
+    #[inline]
+    pub(crate) fn ensure_canonical_block(&self, block_number: BlockNumber) -> ProviderResult<()> {
+        let latest = self.best_block_number()?;
+        if block_number > latest {
+            Err(ProviderError::HeaderNotFound(block_number.into()))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<N: ProviderNodeTypes> NodePrimitivesProvider for ConsistentProvider<N> {
+    type Primitives = N::Primitives;
+}
+
+impl<N: ProviderNodeTypes> StaticFileProviderFactory for ConsistentProvider<N> {
+    fn static_file_provider(&self) -> StaticFileProvider<N::Primitives> {
+        self.storage_provider.static_file_provider()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        self.storage_provider.get_static_file_writer(block, segment)
+    }
+}
+
+impl<N: ProviderNodeTypes> HeaderProvider for ConsistentProvider<N> {
+    type Header = HeaderTy<N>;
+
+    fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        self.get_in_memory_or_storage_by_block(
+            block_hash.into(),
+            |db_provider| db_provider.header(block_hash),
+            |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_header())),
+        )
+    }
+
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+        self.get_in_memory_or_storage_by_block(
+            num.into(),
+            |db_provider| db_provider.header_by_number(num),
+            |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_header())),
+        )
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, _| db_provider.headers_range(range),
+            |block_state, _| Some(block_state.block_ref().recovered_block().header().clone()),
+            |_| true,
+        )
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        self.get_in_memory_or_storage_by_block(
+            number.into(),
+            |db_provider| db_provider.sealed_header(number),
+            |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_sealed_header())),
+        )
+    }
+
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, _| db_provider.sealed_headers_range(range),
+            |block_state, _| Some(block_state.block_ref().recovered_block().clone_sealed_header()),
+            |_| true,
+        )
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, predicate| db_provider.sealed_headers_while(range, predicate),
+            |block_state, predicate| {
+                let header = block_state.block_ref().recovered_block().sealed_header();
+                predicate(header).then(|| header.clone())
+            },
+            predicate,
+        )
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockHashReader for ConsistentProvider<N> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.get_in_memory_or_storage_by_block(
+            number.into(),
+            |db_provider| db_provider.block_hash(number),
+            |block_state| Ok(Some(block_state.hash())),
+        )
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            start..end,
+            |db_provider, inclusive_range, _| {
+                db_provider
+                    .canonical_hashes_range(*inclusive_range.start(), *inclusive_range.end() + 1)
+            },
+            |block_state, _| Some(block_state.hash()),
+            |_| true,
+        )
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockNumReader for ConsistentProvider<N> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        let best_number = self.best_block_number()?;
+        Ok(ChainInfo { best_hash: self.block_hash(best_number)?.unwrap_or_default(), best_number })
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.head_block.as_ref().map(|b| Ok(b.number())).unwrap_or_else(|| self.last_block_number())
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.storage_provider.last_block_number()
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        self.get_in_memory_or_storage_by_block(
+            hash.into(),
+            |db_provider| db_provider.block_number(hash),
+            |block_state| Ok(Some(block_state.number())),
+        )
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockIdReader for ConsistentProvider<N> {
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        Ok(self.canonical_in_memory_state.pending_block_num_hash())
+    }
+
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        Ok(self.canonical_in_memory_state.get_safe_num_hash())
+    }
+
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        Ok(self.canonical_in_memory_state.get_finalized_num_hash())
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
+    type Block = BlockTy<N>;
+
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        source: BlockSource,
+    ) -> ProviderResult<Option<Self::Block>> {
+        if matches!(source, BlockSource::Canonical | BlockSource::Any) &&
+            let Some(block) = self.get_in_memory_or_storage_by_block(
+                hash.into(),
+                |db_provider| db_provider.find_block_by_hash(hash, BlockSource::Canonical),
+                |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_block())),
+            )?
+        {
+            return Ok(Some(block))
+        }
+
+        if matches!(source, BlockSource::Pending | BlockSource::Any) {
+            return Ok(self
+                .canonical_in_memory_state
+                .pending_block()
+                .filter(|b| b.hash() == hash)
+                .map(|b| b.into_block()))
+        }
+
+        Ok(None)
+    }
+
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+        self.get_in_memory_or_storage_by_block(
+            id,
+            |db_provider| db_provider.block(id),
+            |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_block())),
+        )
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(self.canonical_in_memory_state.pending_recovered_block())
+    }
+
+    fn pending_block_and_receipts(
+        &self,
+    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<Self::Receipt>)>> {
+        Ok(self.canonical_in_memory_state.pending_block_and_receipts())
+    }
+
+    /// Returns the block with senders with matching number or hash from database.
+    ///
+    /// **NOTE: If [`TransactionVariant::NoHash`] is provided then the transactions have invalid
+    /// hashes, since they would need to be calculated on the spot, and we want fast querying.**
+    ///
+    /// Returns `None` if block is not found.
+    fn recovered_block(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.get_in_memory_or_storage_by_block(
+            id,
+            |db_provider| db_provider.recovered_block(id, transaction_kind),
+            |block_state| Ok(Some(block_state.block().recovered_block().clone())),
+        )
+    }
+
+    fn sealed_block_with_senders(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.get_in_memory_or_storage_by_block(
+            id,
+            |db_provider| db_provider.sealed_block_with_senders(id, transaction_kind),
+            |block_state| Ok(Some(block_state.block().recovered_block().clone())),
+        )
+    }
+
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, _| db_provider.block_range(range),
+            |block_state, _| Some(block_state.block_ref().recovered_block().clone_block()),
+            |_| true,
+        )
+    }
+
+    fn block_with_senders_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, _| db_provider.block_with_senders_range(range),
+            |block_state, _| Some(block_state.block().recovered_block().clone()),
+            |_| true,
+        )
+    }
+
+    fn recovered_block_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, _| db_provider.recovered_block_range(range),
+            |block_state, _| Some(block_state.block().recovered_block().clone()),
+            |_| true,
+        )
+    }
+
+    fn block_by_transaction_id(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        self.get_in_memory_or_storage_by_tx(
+            id.into(),
+            |db_provider| db_provider.block_by_transaction_id(id),
+            |_, _, block_state| Ok(Some(block_state.number())),
+        )
+    }
+}
+
+impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
+    type Transaction = TxTy<N>;
+
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        self.get_in_memory_or_storage_by_tx(
+            tx_hash.into(),
+            |db_provider| db_provider.transaction_id(tx_hash),
+            |_, tx_number, _| Ok(Some(tx_number)),
+        )
+    }
+
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        self.get_in_memory_or_storage_by_tx(
+            id.into(),
+            |provider| provider.transaction_by_id(id),
+            |tx_index, _, block_state| {
+                Ok(block_state
+                    .block_ref()
+                    .recovered_block()
+                    .body()
+                    .transactions()
+                    .get(tx_index)
+                    .cloned())
+            },
+        )
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        id: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        self.get_in_memory_or_storage_by_tx(
+            id.into(),
+            |provider| provider.transaction_by_id_unhashed(id),
+            |tx_index, _, block_state| {
+                Ok(block_state
+                    .block_ref()
+                    .recovered_block()
+                    .body()
+                    .transactions()
+                    .get(tx_index)
+                    .cloned())
+            },
+        )
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        if let Some(tx) = self.head_block.as_ref().and_then(|b| b.transaction_on_chain(hash)) {
+            return Ok(Some(tx))
+        }
+
+        self.storage_provider.transaction_by_hash(hash)
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        if let Some((tx, meta)) =
+            self.head_block.as_ref().and_then(|b| b.transaction_meta_on_chain(tx_hash))
+        {
+            return Ok(Some((tx, meta)))
+        }
+
+        self.storage_provider.transaction_by_hash_with_meta(tx_hash)
+    }
+
+    fn transactions_by_block(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        self.get_in_memory_or_storage_by_block(
+            id,
+            |provider| provider.transactions_by_block(id),
+            |block_state| {
+                Ok(Some(block_state.block_ref().recovered_block().body().transactions().to_vec()))
+            },
+        )
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, _| db_provider.transactions_by_block_range(range),
+            |block_state, _| {
+                Some(block_state.block_ref().recovered_block().body().transactions().to_vec())
+            },
+            |_| true,
+        )
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        self.get_in_memory_or_storage_by_tx_range(
+            range,
+            |db_provider, db_range| db_provider.transactions_by_tx_range(db_range),
+            |index_range, block_state| {
+                Ok(block_state.block_ref().recovered_block().body().transactions()[index_range]
+                    .to_vec())
+            },
+        )
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        self.get_in_memory_or_storage_by_tx_range(
+            range,
+            |db_provider, db_range| db_provider.senders_by_tx_range(db_range),
+            |index_range, block_state| {
+                Ok(block_state.block_ref().recovered_block.senders()[index_range].to_vec())
+            },
+        )
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        self.get_in_memory_or_storage_by_tx(
+            id.into(),
+            |provider| provider.transaction_sender(id),
+            |tx_index, _, block_state| {
+                Ok(block_state.block_ref().recovered_block.senders().get(tx_index).copied())
+            },
+        )
+    }
+}
+
+impl<N: ProviderNodeTypes> ReceiptProvider for ConsistentProvider<N> {
+    type Receipt = ReceiptTy<N>;
+
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+        self.get_in_memory_or_storage_by_tx(
+            id.into(),
+            |provider| provider.receipt(id),
+            |tx_index, _, block_state| {
+                Ok(block_state.executed_block_receipts_ref().get(tx_index).cloned())
+            },
+        )
+    }
+
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+        for block_state in self.head_block.iter().flat_map(|b| b.chain()) {
+            let executed_block = block_state.block_ref();
+            let block = executed_block.recovered_block();
+            let receipts = block_state.executed_block_receipts_ref();
+
+            // assuming 1:1 correspondence between transactions and receipts
+            debug_assert_eq!(
+                block.body().transactions().len(),
+                receipts.len(),
+                "Mismatch between transaction and receipt count"
+            );
+
+            if let Some(tx_index) =
+                block.body().transactions_iter().position(|tx| tx.trie_hash() == hash)
+            {
+                // safe to use tx_index for receipts due to 1:1 correspondence
+                return Ok(receipts.get(tx_index).cloned());
+            }
+        }
+
+        self.storage_provider.receipt_by_hash(hash)
+    }
+
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        self.get_in_memory_or_storage_by_block(
+            block,
+            |db_provider| db_provider.receipts_by_block(block),
+            |block_state| Ok(Some(block_state.executed_block_receipts())),
+        )
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Receipt>> {
+        self.get_in_memory_or_storage_by_tx_range(
+            range,
+            |db_provider, db_range| db_provider.receipts_by_tx_range(db_range),
+            |index_range, block_state| {
+                Ok(block_state.executed_block_receipts_ref()[index_range].to_vec())
+            },
+        )
+    }
+
+    fn receipts_by_block_range(
+        &self,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+        self.storage_provider.receipts_by_block_range(block_range)
+    }
+}
+
+impl<N: ProviderNodeTypes> ReceiptProviderIdExt for ConsistentProvider<N> {
+    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        match block {
+            BlockId::Hash(rpc_block_hash) => {
+                let mut receipts = self.receipts_by_block(rpc_block_hash.block_hash.into())?;
+                if receipts.is_none() &&
+                    !rpc_block_hash.require_canonical.unwrap_or(false) &&
+                    let Some(state) = self
+                        .head_block
+                        .as_ref()
+                        .and_then(|b| b.block_on_chain(rpc_block_hash.block_hash.into()))
+                {
+                    receipts = Some(state.executed_block_receipts());
+                }
+                Ok(receipts)
+            }
+            BlockId::Number(num_tag) => match num_tag {
+                BlockNumberOrTag::Pending => Ok(self
+                    .canonical_in_memory_state
+                    .pending_state()
+                    .map(|block_state| block_state.executed_block_receipts())),
+                _ => {
+                    if let Some(num) = self.convert_block_number(num_tag)? {
+                        self.receipts_by_block(num.into())
+                    } else {
+                        Ok(None)
+                    }
+                }
+            },
+        }
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ConsistentProvider<N> {
+    fn block_body_indices(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        self.get_in_memory_or_storage_by_block(
+            number.into(),
+            |db_provider| db_provider.block_body_indices(number),
+            |block_state| {
+                // Find the last block indices on database
+                let last_storage_block_number = block_state.anchor().number;
+                let mut stored_indices = self
+                    .storage_provider
+                    .block_body_indices(last_storage_block_number)?
+                    .ok_or(ProviderError::BlockBodyIndicesNotFound(last_storage_block_number))?;
+
+                // Prepare our block indices
+                stored_indices.first_tx_num = stored_indices.next_tx_num();
+                stored_indices.tx_count = 0;
+
+                // Iterate from the lowest block in memory until our target block
+                for state in block_state.chain().collect::<Vec<_>>().into_iter().rev() {
+                    let block_tx_count =
+                        state.block_ref().recovered_block().body().transactions().len() as u64;
+                    if state.block_ref().recovered_block().number() == number {
+                        stored_indices.tx_count = block_tx_count;
+                    } else {
+                        stored_indices.first_tx_num += block_tx_count;
+                    }
+                }
+
+                Ok(Some(stored_indices))
+            },
+        )
+    }
+
+    fn block_body_indices_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        range.map_while(|b| self.block_body_indices(b).transpose()).collect()
+    }
+}
+
+impl<N: ProviderNodeTypes> StageCheckpointReader for ConsistentProvider<N> {
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
+        self.storage_provider.get_stage_checkpoint(id)
+    }
+
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>> {
+        self.storage_provider.get_stage_checkpoint_progress(id)
+    }
+
+    fn get_all_checkpoints(&self) -> ProviderResult<Vec<(String, StageCheckpoint)>> {
+        self.storage_provider.get_all_checkpoints()
+    }
+}
+
+impl<N: ProviderNodeTypes> PruneCheckpointReader for ConsistentProvider<N> {
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
+        self.storage_provider.get_prune_checkpoint(segment)
+    }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        self.storage_provider.get_prune_checkpoints()
+    }
+}
+
+impl<N: ProviderNodeTypes> ChainSpecProvider for ConsistentProvider<N> {
+    type ChainSpec = N::ChainSpec;
+
+    fn chain_spec(&self) -> Arc<N::ChainSpec> {
+        ChainSpecProvider::chain_spec(&self.storage_provider)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockReaderIdExt for ConsistentProvider<N> {
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Block>> {
+        match id {
+            BlockId::Number(num) => self.block_by_number_or_tag(num),
+            BlockId::Hash(hash) => {
+                // TODO: should we only apply this for the RPCs that are listed in EIP-1898?
+                // so not at the provider level?
+                // if we decide to do this at a higher level, then we can make this an automatic
+                // trait impl
+                if Some(true) == hash.require_canonical {
+                    // check the database, canonical blocks are only stored in the database
+                    self.find_block_by_hash(hash.block_hash, BlockSource::Canonical)
+                } else {
+                    self.block_by_hash(hash.block_hash)
+                }
+            }
+        }
+    }
+
+    fn header_by_number_or_tag(&self, id: BlockNumberOrTag) -> ProviderResult<Option<HeaderTy<N>>> {
+        Ok(match id {
+            BlockNumberOrTag::Latest => {
+                Some(self.canonical_in_memory_state.get_canonical_head().unseal())
+            }
+            BlockNumberOrTag::Finalized => {
+                self.canonical_in_memory_state.get_finalized_header().map(|h| h.unseal())
+            }
+            BlockNumberOrTag::Safe => {
+                self.canonical_in_memory_state.get_safe_header().map(|h| h.unseal())
+            }
+            BlockNumberOrTag::Earliest => self.header_by_number(self.earliest_block_number()?)?,
+            BlockNumberOrTag::Pending => self.canonical_in_memory_state.pending_header(),
+
+            BlockNumberOrTag::Number(num) => self.header_by_number(num)?,
+        })
+    }
+
+    fn sealed_header_by_number_or_tag(
+        &self,
+        id: BlockNumberOrTag,
+    ) -> ProviderResult<Option<SealedHeader<HeaderTy<N>>>> {
+        match id {
+            BlockNumberOrTag::Latest => {
+                Ok(Some(self.canonical_in_memory_state.get_canonical_head()))
+            }
+            BlockNumberOrTag::Finalized => {
+                Ok(self.canonical_in_memory_state.get_finalized_header())
+            }
+            BlockNumberOrTag::Safe => Ok(self.canonical_in_memory_state.get_safe_header()),
+            BlockNumberOrTag::Earliest => self
+                .header_by_number(self.earliest_block_number()?)?
+                .map_or_else(|| Ok(None), |h| Ok(Some(SealedHeader::seal_slow(h)))),
+            BlockNumberOrTag::Pending => Ok(self.canonical_in_memory_state.pending_sealed_header()),
+            BlockNumberOrTag::Number(num) => self
+                .header_by_number(num)?
+                .map_or_else(|| Ok(None), |h| Ok(Some(SealedHeader::seal_slow(h)))),
+        }
+    }
+
+    fn sealed_header_by_id(
+        &self,
+        id: BlockId,
+    ) -> ProviderResult<Option<SealedHeader<HeaderTy<N>>>> {
+        Ok(match id {
+            BlockId::Number(num) => self.sealed_header_by_number_or_tag(num)?,
+            BlockId::Hash(hash) => self
+                .header(hash.block_hash)?
+                .map(|header| SealedHeader::new(header, hash.block_hash)),
+        })
+    }
+
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<HeaderTy<N>>> {
+        Ok(match id {
+            BlockId::Number(num) => self.header_by_number_or_tag(num)?,
+            BlockId::Hash(hash) => self.header(hash.block_hash)?,
+        })
+    }
+}
+
+impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
+    fn storage_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        if let Some(state) =
+            self.head_block.as_ref().and_then(|b| b.block_on_chain(block_number.into()))
+        {
+            let changesets = state
+                .block()
+                .execution_output
+                .state
+                .reverts
+                .to_plain_state_reverts()
+                .storage
+                .into_iter()
+                .flatten()
+                .flat_map(|revert: PlainStorageRevert| {
+                    revert.storage_revert.into_iter().map(move |(key, value)| {
+                        let plain_key = B256::from(key.to_be_bytes());
+                        (
+                            BlockNumberAddress((block_number, revert.address)),
+                            StorageEntry { key: plain_key, value: value.to_previous_value() },
+                        )
+                    })
+                })
+                .collect();
+            Ok(changesets)
+        } else {
+            // Perform checks on whether or not changesets exist for the block.
+
+            // No prune checkpoint means history should exist and we should `unwrap_or(true)`
+            let storage_history_exists = self
+                .storage_provider
+                .get_prune_checkpoint(PruneSegment::StorageHistory)?
+                .and_then(|checkpoint| {
+                    // return true if the block number is ahead of the prune checkpoint.
+                    //
+                    // The checkpoint stores the highest pruned block number, so we should make
+                    // sure the block_number is strictly greater.
+                    checkpoint.block_number.map(|checkpoint| block_number > checkpoint)
+                })
+                .unwrap_or(true);
+
+            if !storage_history_exists {
+                return Err(ProviderError::StateAtBlockPruned(block_number))
+            }
+
+            self.storage_provider.storage_changeset(block_number)
+        }
+    }
+
+    fn get_storage_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+        storage_key: B256,
+    ) -> ProviderResult<Option<StorageEntry>> {
+        if let Some(state) =
+            self.head_block.as_ref().and_then(|b| b.block_on_chain(block_number.into()))
+        {
+            let changeset = state
+                .block_ref()
+                .execution_output
+                .state
+                .reverts
+                .to_plain_state_reverts()
+                .storage
+                .into_iter()
+                .flatten()
+                .find_map(|revert: PlainStorageRevert| {
+                    if revert.address != address {
+                        return None
+                    }
+                    revert.storage_revert.into_iter().find_map(|(key, value)| {
+                        let plain_key = B256::from(key.to_be_bytes());
+                        (plain_key == storage_key).then(|| StorageEntry {
+                            key: plain_key,
+                            value: value.to_previous_value(),
+                        })
+                    })
+                });
+            Ok(changeset)
+        } else {
+            let storage_history_exists = self
+                .storage_provider
+                .get_prune_checkpoint(PruneSegment::StorageHistory)?
+                .and_then(|checkpoint| {
+                    checkpoint.block_number.map(|checkpoint| block_number > checkpoint)
+                })
+                .unwrap_or(true);
+
+            if !storage_history_exists {
+                return Err(ProviderError::StateAtBlockPruned(block_number))
+            }
+
+            self.storage_provider.get_storage_before_block(block_number, address, storage_key)
+        }
+    }
+
+    fn storage_changesets_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        let range = to_range(range);
+        let mut changesets = Vec::new();
+        let database_start = range.start;
+        let mut database_end = range.end;
+
+        if let Some(head_block) = &self.head_block {
+            database_end = head_block.anchor().number;
+
+            for state in head_block.chain() {
+                let block_changesets = state
+                    .block_ref()
+                    .execution_output
+                    .state
+                    .reverts
+                    .to_plain_state_reverts()
+                    .storage
+                    .into_iter()
+                    .flatten()
+                    .flat_map(|revert: PlainStorageRevert| {
+                        revert.storage_revert.into_iter().map(move |(key, value)| {
+                            let plain_key = B256::from(key.to_be_bytes());
+                            (
+                                BlockNumberAddress((state.number(), revert.address)),
+                                StorageEntry { key: plain_key, value: value.to_previous_value() },
+                            )
+                        })
+                    });
+
+                changesets.extend(block_changesets);
+            }
+        }
+
+        if database_start < database_end {
+            let storage_history_exists = self
+                .storage_provider
+                .get_prune_checkpoint(PruneSegment::StorageHistory)?
+                .and_then(|checkpoint| {
+                    checkpoint.block_number.map(|checkpoint| database_start > checkpoint)
+                })
+                .unwrap_or(true);
+
+            if !storage_history_exists {
+                return Err(ProviderError::StateAtBlockPruned(database_start))
+            }
+
+            let db_changesets = self
+                .storage_provider
+                .storage_changesets_range(database_start..=database_end - 1)?;
+            changesets.extend(db_changesets);
+        }
+
+        changesets.sort_by_key(|(block_address, _)| block_address.block_number());
+
+        Ok(changesets)
+    }
+}
+
+impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
+    fn account_block_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
+        if let Some(state) =
+            self.head_block.as_ref().and_then(|b| b.block_on_chain(block_number.into()))
+        {
+            let changesets = state
+                .block_ref()
+                .execution_output
+                .state
+                .reverts
+                .to_plain_state_reverts()
+                .accounts
+                .into_iter()
+                .flatten()
+                .map(|(address, info)| AccountBeforeTx { address, info: info.map(Into::into) })
+                .collect();
+            Ok(changesets)
+        } else {
+            // Perform checks on whether or not changesets exist for the block.
+
+            // No prune checkpoint means history should exist and we should `unwrap_or(true)`
+            let account_history_exists = self
+                .storage_provider
+                .get_prune_checkpoint(PruneSegment::AccountHistory)?
+                .and_then(|checkpoint| {
+                    // return true if the block number is ahead of the prune checkpoint.
+                    //
+                    // The checkpoint stores the highest pruned block number, so we should make
+                    // sure the block_number is strictly greater.
+                    checkpoint.block_number.map(|checkpoint| block_number > checkpoint)
+                })
+                .unwrap_or(true);
+
+            if !account_history_exists {
+                return Err(ProviderError::StateAtBlockPruned(block_number))
+            }
+
+            self.storage_provider.account_block_changeset(block_number)
+        }
+    }
+
+    fn get_account_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+    ) -> ProviderResult<Option<AccountBeforeTx>> {
+        if let Some(state) =
+            self.head_block.as_ref().and_then(|b| b.block_on_chain(block_number.into()))
+        {
+            // Search in-memory state for the account changeset
+            let changeset = state
+                .block_ref()
+                .execution_output
+                .state
+                .reverts
+                .to_plain_state_reverts()
+                .accounts
+                .into_iter()
+                .flatten()
+                .find(|(addr, _)| addr == &address)
+                .map(|(address, info)| AccountBeforeTx { address, info: info.map(Into::into) });
+            Ok(changeset)
+        } else {
+            // Perform checks on whether or not changesets exist for the block.
+            // No prune checkpoint means history should exist and we should `unwrap_or(true)`
+            let account_history_exists = self
+                .storage_provider
+                .get_prune_checkpoint(PruneSegment::AccountHistory)?
+                .and_then(|checkpoint| {
+                    // return true if the block number is ahead of the prune checkpoint.
+                    //
+                    // The checkpoint stores the highest pruned block number, so we should make
+                    // sure the block_number is strictly greater.
+                    checkpoint.block_number.map(|checkpoint| block_number > checkpoint)
+                })
+                .unwrap_or(true);
+
+            if !account_history_exists {
+                return Err(ProviderError::StateAtBlockPruned(block_number))
+            }
+
+            // Delegate to the storage provider for database lookups
+            self.storage_provider.get_account_before_block(block_number, address)
+        }
+    }
+
+    fn account_changesets_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
+        let range = to_range(range);
+        let mut changesets = Vec::new();
+        let database_start = range.start;
+        let mut database_end = range.end;
+
+        // Check which blocks in the range are in memory
+        if let Some(head_block) = &self.head_block {
+            // the anchor is the end of the db range
+            database_end = head_block.anchor().number;
+
+            for state in head_block.chain() {
+                // found block in memory, collect its changesets
+                let block_changesets = state
+                    .block_ref()
+                    .execution_output
+                    .state
+                    .reverts
+                    .to_plain_state_reverts()
+                    .accounts
+                    .into_iter()
+                    .flatten()
+                    .map(|(address, info)| AccountBeforeTx { address, info: info.map(Into::into) });
+
+                for changeset in block_changesets {
+                    changesets.push((state.number(), changeset));
+                }
+            }
+        }
+
+        // get changesets from database for remaining blocks
+        if database_start < database_end {
+            // check if account history is pruned for these blocks
+            let account_history_exists = self
+                .storage_provider
+                .get_prune_checkpoint(PruneSegment::AccountHistory)?
+                .and_then(|checkpoint| {
+                    checkpoint.block_number.map(|checkpoint| database_start > checkpoint)
+                })
+                .unwrap_or(true);
+
+            if !account_history_exists {
+                return Err(ProviderError::StateAtBlockPruned(database_start))
+            }
+
+            let db_changesets =
+                self.storage_provider.account_changesets_range(database_start..database_end)?;
+            changesets.extend(db_changesets);
+        }
+
+        changesets.sort_by_key(|(block_num, _)| *block_num);
+
+        Ok(changesets)
+    }
+}
+
+impl<N: ProviderNodeTypes> AccountReader for ConsistentProvider<N> {
+    /// Get basic account information.
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        // use latest state provider
+        let state_provider = self.latest_ref()?;
+        state_provider.basic_account(address)
+    }
+}
+
+impl<N: ProviderNodeTypes> StateReader for ConsistentProvider<N> {
+    type Receipt = ReceiptTy<N>;
+
+    /// Re-constructs the [`ExecutionOutcome`] from in-memory and database state, if necessary.
+    ///
+    /// If data for the block does not exist, this will return [`None`].
+    ///
+    /// NOTE: This cannot be called safely in a loop outside of the blockchain tree thread. This is
+    /// because the [`CanonicalInMemoryState`] could change during a reorg, causing results to be
+    /// inconsistent. Currently this can safely be called within the blockchain tree thread,
+    /// because the tree thread is responsible for modifying the [`CanonicalInMemoryState`] in the
+    /// first place.
+    fn get_state(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+        if let Some(state) = self.head_block.as_ref().and_then(|b| b.block_on_chain(block.into())) {
+            let state = state.block_ref().execution_outcome().clone();
+            Ok(Some(ExecutionOutcome::from((state, block))))
+        } else {
+            self.storage_provider.get_state(block)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        providers::blockchain_provider::BlockchainProvider,
+        test_utils::create_test_provider_factory, BlockWriter,
+    };
+    use alloy_eips::BlockHashOrNumber;
+    use alloy_primitives::B256;
+    use itertools::Itertools;
+    use rand::Rng;
+    use reth_chain_state::{ExecutedBlock, NewCanonicalChain};
+    use reth_db_api::models::AccountBeforeTx;
+    use reth_ethereum_primitives::Block;
+    use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult, ExecutionOutcome};
+    use reth_primitives_traits::{RecoveredBlock, SealedBlock};
+    use reth_storage_api::{BlockReader, BlockSource, ChangeSetReader, StateReader};
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_eoa_accounts, BlockRangeParams,
+    };
+    use revm_database::BundleState;
+    use std::{
+        ops::{Bound, Range, RangeBounds},
+        sync::Arc,
+    };
+
+    const TEST_BLOCKS_COUNT: usize = 5;
+
+    fn random_blocks(
+        rng: &mut impl Rng,
+        database_blocks: usize,
+        in_memory_blocks: usize,
+        requests_count: Option<Range<u8>>,
+        withdrawals_count: Option<Range<u8>>,
+        tx_count: impl RangeBounds<u8>,
+    ) -> (Vec<SealedBlock<Block>>, Vec<SealedBlock<Block>>) {
+        let block_range = (database_blocks + in_memory_blocks - 1) as u64;
+
+        let tx_start = match tx_count.start_bound() {
+            Bound::Included(&n) | Bound::Excluded(&n) => n,
+            Bound::Unbounded => u8::MIN,
+        };
+        let tx_end = match tx_count.end_bound() {
+            Bound::Included(&n) | Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => u8::MAX,
+        };
+
+        let blocks = random_block_range(
+            rng,
+            0..=block_range,
+            BlockRangeParams {
+                parent: Some(B256::ZERO),
+                tx_count: tx_start..tx_end,
+                requests_count,
+                withdrawals_count,
+            },
+        );
+        let (database_blocks, in_memory_blocks) = blocks.split_at(database_blocks);
+        (database_blocks.to_vec(), in_memory_blocks.to_vec())
+    }
+
+    #[test]
+    fn test_block_reader_find_block_by_hash() -> eyre::Result<()> {
+        // Initialize random number generator and provider factory
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+
+        // Generate 10 random blocks and split into database and in-memory blocks
+        let blocks = random_block_range(
+            &mut rng,
+            0..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        let (database_blocks, in_memory_blocks) = blocks.split_at(5);
+
+        // Insert first 5 blocks into the database
+        let provider_rw = factory.provider_rw()?;
+        for block in database_blocks {
+            provider_rw.insert_block(
+                &block.clone().try_recover().expect("failed to seal block with senders"),
+            )?;
+        }
+        provider_rw.commit()?;
+
+        // Create a new provider
+        let provider = BlockchainProvider::new(factory)?;
+        let consistent_provider = provider.consistent_provider()?;
+
+        // Useful blocks
+        let first_db_block = database_blocks.first().unwrap();
+        let first_in_mem_block = in_memory_blocks.first().unwrap();
+        let last_in_mem_block = in_memory_blocks.last().unwrap();
+
+        // No block in memory before setting in memory state
+        assert_eq!(
+            consistent_provider.find_block_by_hash(first_in_mem_block.hash(), BlockSource::Any)?,
+            None
+        );
+        assert_eq!(
+            consistent_provider
+                .find_block_by_hash(first_in_mem_block.hash(), BlockSource::Canonical)?,
+            None
+        );
+        // No pending block in memory
+        assert_eq!(
+            consistent_provider
+                .find_block_by_hash(first_in_mem_block.hash(), BlockSource::Pending)?,
+            None
+        );
+
+        // Insert first block into the in-memory state
+        let in_memory_block_senders =
+            first_in_mem_block.senders().expect("failed to recover senders");
+        let chain = NewCanonicalChain::Commit {
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                    first_in_mem_block.clone(),
+                    in_memory_block_senders,
+                )),
+                ..Default::default()
+            }],
+        };
+        consistent_provider.canonical_in_memory_state.update_chain(chain);
+        let consistent_provider = provider.consistent_provider()?;
+
+        // Now the block should be found in memory
+        assert_eq!(
+            consistent_provider.find_block_by_hash(first_in_mem_block.hash(), BlockSource::Any)?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+        assert_eq!(
+            consistent_provider
+                .find_block_by_hash(first_in_mem_block.hash(), BlockSource::Canonical)?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+
+        // Find the first block in database by hash
+        assert_eq!(
+            consistent_provider.find_block_by_hash(first_db_block.hash(), BlockSource::Any)?,
+            Some(first_db_block.clone().into_block())
+        );
+        assert_eq!(
+            consistent_provider
+                .find_block_by_hash(first_db_block.hash(), BlockSource::Canonical)?,
+            Some(first_db_block.clone().into_block())
+        );
+
+        // No pending block in database
+        assert_eq!(
+            consistent_provider.find_block_by_hash(first_db_block.hash(), BlockSource::Pending)?,
+            None
+        );
+
+        // Insert the last block into the pending state
+        provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {
+            recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                last_in_mem_block.clone(),
+                Default::default(),
+            )),
+            ..Default::default()
+        });
+
+        // Now the last block should be found in memory
+        assert_eq!(
+            consistent_provider
+                .find_block_by_hash(last_in_mem_block.hash(), BlockSource::Pending)?,
+            Some(last_in_mem_block.clone_block())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_reader_block() -> eyre::Result<()> {
+        // Initialize random number generator and provider factory
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+
+        // Generate 10 random blocks and split into database and in-memory blocks
+        let blocks = random_block_range(
+            &mut rng,
+            0..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        let (database_blocks, in_memory_blocks) = blocks.split_at(5);
+
+        // Insert first 5 blocks into the database
+        let provider_rw = factory.provider_rw()?;
+        for block in database_blocks {
+            provider_rw.insert_block(
+                &block.clone().try_recover().expect("failed to seal block with senders"),
+            )?;
+        }
+        provider_rw.commit()?;
+
+        // Create a new provider
+        let provider = BlockchainProvider::new(factory)?;
+        let consistent_provider = provider.consistent_provider()?;
+
+        // First in memory block
+        let first_in_mem_block = in_memory_blocks.first().unwrap();
+        // First database block
+        let first_db_block = database_blocks.first().unwrap();
+
+        // First in memory block should not be found yet as not integrated to the in-memory state
+        assert_eq!(
+            consistent_provider.block(BlockHashOrNumber::Hash(first_in_mem_block.hash()))?,
+            None
+        );
+        assert_eq!(
+            consistent_provider.block(BlockHashOrNumber::Number(first_in_mem_block.number))?,
+            None
+        );
+
+        // Insert first block into the in-memory state
+        let in_memory_block_senders =
+            first_in_mem_block.senders().expect("failed to recover senders");
+        let chain = NewCanonicalChain::Commit {
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                    first_in_mem_block.clone(),
+                    in_memory_block_senders,
+                )),
+                ..Default::default()
+            }],
+        };
+        consistent_provider.canonical_in_memory_state.update_chain(chain);
+
+        let consistent_provider = provider.consistent_provider()?;
+
+        // First in memory block should be found
+        assert_eq!(
+            consistent_provider.block(BlockHashOrNumber::Hash(first_in_mem_block.hash()))?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+        assert_eq!(
+            consistent_provider.block(BlockHashOrNumber::Number(first_in_mem_block.number))?,
+            Some(first_in_mem_block.clone().into_block())
+        );
+
+        // First database block should be found
+        assert_eq!(
+            consistent_provider.block(BlockHashOrNumber::Hash(first_db_block.hash()))?,
+            Some(first_db_block.clone().into_block())
+        );
+        assert_eq!(
+            consistent_provider.block(BlockHashOrNumber::Number(first_db_block.number))?,
+            Some(first_db_block.clone().into_block())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_changeset_reader() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+
+        let (database_blocks, in_memory_blocks) =
+            random_blocks(&mut rng, TEST_BLOCKS_COUNT, 1, None, None, 0..1);
+
+        let first_database_block = database_blocks.first().map(|block| block.number).unwrap();
+        let last_database_block = database_blocks.last().map(|block| block.number).unwrap();
+        let first_in_memory_block = in_memory_blocks.first().map(|block| block.number).unwrap();
+
+        let accounts = random_eoa_accounts(&mut rng, 2);
+
+        let (database_changesets, database_state) = random_changeset_range(
+            &mut rng,
+            &database_blocks,
+            accounts.into_iter().map(|(address, account)| (address, (account, Vec::new()))),
+            0..0,
+            0..0,
+        );
+        let (in_memory_changesets, in_memory_state) = random_changeset_range(
+            &mut rng,
+            &in_memory_blocks,
+            database_state
+                .iter()
+                .map(|(address, (account, storage))| (*address, (*account, storage.clone()))),
+            0..0,
+            0..0,
+        );
+
+        let factory = create_test_provider_factory();
+
+        let provider_rw = factory.provider_rw()?;
+        provider_rw.append_blocks_with_state(
+            database_blocks
+                .into_iter()
+                .map(|b| b.try_recover().expect("failed to seal block with senders"))
+                .collect(),
+            &ExecutionOutcome {
+                bundle: BundleState::new(
+                    database_state.into_iter().map(|(address, (account, _))| {
+                        (address, None, Some(account.into()), Default::default())
+                    }),
+                    database_changesets.iter().map(|block_changesets| {
+                        block_changesets.iter().map(|(address, account, _)| {
+                            (*address, Some(Some((*account).into())), [])
+                        })
+                    }),
+                    Vec::new(),
+                ),
+                first_block: first_database_block,
+                ..Default::default()
+            },
+            Default::default(),
+        )?;
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+
+        let in_memory_changesets = in_memory_changesets.into_iter().next().unwrap();
+        let chain = NewCanonicalChain::Commit {
+            new: vec![in_memory_blocks
+                .first()
+                .map(|block| {
+                    let senders = block.senders().expect("failed to recover senders");
+                    ExecutedBlock {
+                        recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                            block.clone(),
+                            senders,
+                        )),
+                        execution_output: Arc::new(BlockExecutionOutput {
+                            state: BundleState::new(
+                                in_memory_state.into_iter().map(|(address, (account, _))| {
+                                    (address, None, Some(account.into()), Default::default())
+                                }),
+                                [in_memory_changesets.iter().map(|(address, account, _)| {
+                                    (*address, Some(Some((*account).into())), Vec::new())
+                                })],
+                                [],
+                            ),
+                            result: BlockExecutionResult {
+                                receipts: Default::default(),
+                                requests: Default::default(),
+                                gas_used: 0,
+                                blob_gas_used: 0,
+                            },
+                        }),
+                        ..Default::default()
+                    }
+                })
+                .unwrap()],
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        let consistent_provider = provider.consistent_provider()?;
+
+        assert_eq!(
+            consistent_provider.account_block_changeset(last_database_block).unwrap(),
+            database_changesets
+                .into_iter()
+                .next_back()
+                .unwrap()
+                .into_iter()
+                .sorted_by_key(|(address, _, _)| *address)
+                .map(|(address, account, _)| AccountBeforeTx { address, info: Some(account) })
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            consistent_provider.account_block_changeset(first_in_memory_block).unwrap(),
+            in_memory_changesets
+                .into_iter()
+                .sorted_by_key(|(address, _, _)| *address)
+                .map(|(address, account, _)| AccountBeforeTx { address, info: Some(account) })
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    }
+    #[test]
+    fn test_get_state_storage_value_plain_state() -> eyre::Result<()> {
+        use alloy_primitives::U256;
+        use reth_db_api::{models::StorageSettings, tables, transaction::DbTxMut};
+        use reth_primitives_traits::StorageEntry;
+        use reth_storage_api::StorageSettingsCache;
+        use std::collections::HashMap;
+
+        let address = alloy_primitives::Address::with_last_byte(1);
+        let account = reth_primitives_traits::Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: None,
+        };
+        let slot = U256::from(0x42);
+        let slot_b256 = B256::from(slot);
+
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v1());
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=1,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+
+        let provider_rw = factory.provider_rw()?;
+        provider_rw.append_blocks_with_state(
+            blocks
+                .into_iter()
+                .map(|b| b.try_recover().expect("failed to seal block with senders"))
+                .collect(),
+            &ExecutionOutcome {
+                bundle: BundleState::new(
+                    [(address, None, Some(account.into()), {
+                        let mut s = HashMap::default();
+                        s.insert(slot, (U256::ZERO, U256::from(100)));
+                        s
+                    })],
+                    [
+                        Vec::new(),
+                        vec![(address, Some(Some(account.into())), vec![(slot, U256::ZERO)])],
+                    ],
+                    [],
+                ),
+                first_block: 0,
+                ..Default::default()
+            },
+            Default::default(),
+        )?;
+
+        provider_rw.tx_ref().put::<tables::PlainStorageState>(
+            address,
+            StorageEntry { key: slot_b256, value: U256::from(100) },
+        )?;
+        provider_rw.tx_ref().put::<tables::PlainAccountState>(address, account)?;
+
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+        let consistent_provider = provider.consistent_provider()?;
+
+        let outcome = consistent_provider.get_state(1)?.expect("should return execution outcome");
+
+        let state = &outcome.bundle.state;
+        let account_state = state.get(&address).expect("should have account in bundle state");
+        let storage = &account_state.storage;
+
+        let storage_slot = storage.get(&slot).expect("should have the slot in storage");
+
+        assert_eq!(
+            storage_slot.present_value,
+            U256::from(100),
+            "present_value should be 100 (the actual value in PlainStorageState)"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_storage_changeset_consistent_keys_plain_state() -> eyre::Result<()> {
+        use alloy_primitives::U256;
+        use reth_db_api::models::StorageSettings;
+        use reth_storage_api::{StorageChangeSetReader, StorageSettingsCache};
+        use std::collections::HashMap;
+
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v1());
+
+        let (database_blocks, in_memory_blocks) = random_blocks(&mut rng, 1, 1, None, None, 0..1);
+
+        let address = alloy_primitives::Address::with_last_byte(1);
+        let account = reth_primitives_traits::Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: None,
+        };
+        let slot = U256::from(0x42);
+
+        let provider_rw = factory.provider_rw()?;
+        provider_rw.append_blocks_with_state(
+            database_blocks
+                .into_iter()
+                .map(|b| b.try_recover().expect("failed to seal block with senders"))
+                .collect(),
+            &ExecutionOutcome {
+                bundle: BundleState::new(
+                    [(address, None, Some(account.into()), {
+                        let mut s = HashMap::default();
+                        s.insert(slot, (U256::ZERO, U256::from(100)));
+                        s
+                    })],
+                    [[(address, Some(Some(account.into())), vec![(slot, U256::ZERO)])]],
+                    [],
+                ),
+                first_block: 0,
+                ..Default::default()
+            },
+            Default::default(),
+        )?;
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+
+        let in_mem_block = in_memory_blocks.first().unwrap();
+        let senders = in_mem_block.senders().expect("failed to recover senders");
+        let chain = NewCanonicalChain::Commit {
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                    in_mem_block.clone(),
+                    senders,
+                )),
+                execution_output: Arc::new(BlockExecutionOutput {
+                    state: BundleState::new(
+                        [(address, None, Some(account.into()), {
+                            let mut s = HashMap::default();
+                            s.insert(slot, (U256::from(100), U256::from(200)));
+                            s
+                        })],
+                        [[(address, Some(Some(account.into())), vec![(slot, U256::from(100))])]],
+                        [],
+                    ),
+                    result: BlockExecutionResult {
+                        receipts: Default::default(),
+                        requests: Default::default(),
+                        gas_used: 0,
+                        blob_gas_used: 0,
+                    },
+                }),
+                ..Default::default()
+            }],
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        let consistent_provider = provider.consistent_provider()?;
+
+        let db_changeset = consistent_provider.storage_changeset(0)?;
+        let mem_changeset = consistent_provider.storage_changeset(1)?;
+
+        let slot_b256 = B256::from(slot);
+
+        assert_eq!(db_changeset.len(), 1);
+        assert_eq!(mem_changeset.len(), 1);
+
+        let db_key = db_changeset[0].1.key;
+        let mem_key = mem_changeset[0].1.key;
+
+        assert_eq!(db_key, slot_b256, "DB changeset should use plain (unhashed) key");
+        assert_eq!(mem_key, slot_b256, "In-memory changeset should use plain (unhashed) key");
+        assert_eq!(
+            db_key, mem_key,
+            "DB and in-memory changesets should return the same key format (plain) for the same logical slot"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_storage_changesets_range_consistent_keys_plain_state() -> eyre::Result<()> {
+        use alloy_primitives::U256;
+        use reth_db_api::models::StorageSettings;
+        use reth_storage_api::{StorageChangeSetReader, StorageSettingsCache};
+        use std::collections::HashMap;
+
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v1());
+
+        let (database_blocks, in_memory_blocks) = random_blocks(&mut rng, 2, 1, None, None, 0..1);
+
+        let address = alloy_primitives::Address::with_last_byte(1);
+        let account = reth_primitives_traits::Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: None,
+        };
+        let slot = U256::from(0x42);
+
+        let provider_rw = factory.provider_rw()?;
+        provider_rw.append_blocks_with_state(
+            database_blocks
+                .into_iter()
+                .map(|b| b.try_recover().expect("failed to seal block with senders"))
+                .collect(),
+            &ExecutionOutcome {
+                bundle: BundleState::new(
+                    [(address, None, Some(account.into()), {
+                        let mut s = HashMap::default();
+                        s.insert(slot, (U256::ZERO, U256::from(100)));
+                        s
+                    })],
+                    vec![
+                        vec![(address, Some(Some(account.into())), vec![(slot, U256::ZERO)])],
+                        vec![],
+                    ],
+                    [],
+                ),
+                first_block: 0,
+                ..Default::default()
+            },
+            Default::default(),
+        )?;
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+
+        let in_mem_block = in_memory_blocks.first().unwrap();
+        let senders = in_mem_block.senders().expect("failed to recover senders");
+        let chain = NewCanonicalChain::Commit {
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                    in_mem_block.clone(),
+                    senders,
+                )),
+                execution_output: Arc::new(BlockExecutionOutput {
+                    state: BundleState::new(
+                        [(address, None, Some(account.into()), {
+                            let mut s = HashMap::default();
+                            s.insert(slot, (U256::from(100), U256::from(200)));
+                            s
+                        })],
+                        [[(address, Some(Some(account.into())), vec![(slot, U256::from(100))])]],
+                        [],
+                    ),
+                    result: BlockExecutionResult {
+                        receipts: Default::default(),
+                        requests: Default::default(),
+                        gas_used: 0,
+                        blob_gas_used: 0,
+                    },
+                }),
+                ..Default::default()
+            }],
+        };
+        provider.canonical_in_memory_state.update_chain(chain);
+
+        let consistent_provider = provider.consistent_provider()?;
+
+        let all_changesets = consistent_provider.storage_changesets_range(0..=2)?;
+
+        assert_eq!(all_changesets.len(), 2, "should have one changeset entry per block");
+
+        let slot_b256 = B256::from(slot);
+        let keys: Vec<B256> = all_changesets.iter().map(|(_, entry)| entry.key).collect();
+
+        assert_eq!(
+            keys[0], keys[1],
+            "same logical slot should produce identical keys whether from DB or memory"
+        );
+        assert_eq!(
+            keys[0], slot_b256,
+            "keys should be plain/unhashed when use_hashed_state is false"
+        );
+
+        Ok(())
+    }
+}

--- a/patches/reth-provider/src/providers/consistent_view.rs
+++ b/patches/reth-provider/src/providers/consistent_view.rs
@@ -1,0 +1,222 @@
+use crate::{BlockNumReader, DatabaseProviderFactory, HeaderProvider};
+use alloy_primitives::B256;
+pub use reth_storage_errors::provider::ConsistentViewError;
+use reth_storage_errors::provider::ProviderResult;
+
+/// A consistent view over state in the database.
+///
+/// View gets initialized with the latest or provided tip.
+/// Upon every attempt to create a database provider, the view will
+/// perform a consistency check of current tip against the initial one.
+///
+/// ## Usage
+///
+/// The view should only be used outside of staged-sync.
+/// Otherwise, any attempt to create a provider will result in [`ConsistentViewError::Syncing`].
+///
+/// When using the view, the consumer should either
+/// 1) have a failover for when the state changes and handle [`ConsistentViewError::Inconsistent`]
+///    appropriately.
+/// 2) be sure that the state does not change.
+#[derive(Clone, Debug)]
+pub struct ConsistentDbView<Factory> {
+    factory: Factory,
+    tip: Option<(B256, u64)>,
+}
+
+impl<Factory> ConsistentDbView<Factory>
+where
+    Factory: DatabaseProviderFactory<Provider: BlockNumReader + HeaderProvider>,
+{
+    /// Creates new consistent database view.
+    pub const fn new(factory: Factory, tip: Option<(B256, u64)>) -> Self {
+        Self { factory, tip }
+    }
+
+    /// Creates new consistent database view with latest tip.
+    pub fn new_with_latest_tip(provider: Factory) -> ProviderResult<Self> {
+        let provider_ro = provider.database_provider_ro()?;
+        let last_num = provider_ro.last_block_number()?;
+        let tip = provider_ro.sealed_header(last_num)?.map(|h| (h.hash(), last_num));
+        Ok(Self::new(provider, tip))
+    }
+
+    /// Creates new read-only provider and performs consistency checks on the current tip.
+    pub fn provider_ro(&self) -> ProviderResult<Factory::Provider> {
+        // Create a new provider.
+        let provider_ro = self.factory.database_provider_ro()?;
+
+        // Check that the currently stored tip is included on-disk.
+        // This means that the database may have moved, but the view was not reorged.
+        //
+        // NOTE: We must use `sealed_header` with the block number here, because if we are using
+        // the consistent view provider while we're persisting blocks, we may enter a race
+        // condition. Recall that we always commit to static files first, then the database, and
+        // that block hash to block number indexes are contained in the database. If we were to
+        // fetch the block by hash while we're persisting, the following situation may occur:
+        //
+        // 1. Persistence appends the latest block to static files.
+        // 2. We initialize the consistent view provider, which fetches based on `last_block_number`
+        //    and `sealed_header`, which both check static files, setting the tip to the newly
+        //    committed block.
+        // 3. We attempt to fetch a header by hash, using for example the `header` method. This
+        //    checks the database first, to fetch the number corresponding to the hash. Because the
+        //    database has not been committed yet, this fails, and we return
+        //    `ConsistentViewError::Reorged`.
+        // 4. Some time later, the database commits.
+        //
+        // To ensure this doesn't happen, we just have to make sure that we fetch from the same
+        // data source that we used during initialization. In this case, that is static files
+        if let Some((hash, number)) = self.tip &&
+            provider_ro.sealed_header(number)?.is_none_or(|header| header.hash() != hash)
+        {
+            return Err(ConsistentViewError::Reorged { block: hash }.into())
+        }
+
+        Ok(provider_ro)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reth_errors::ProviderError;
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::{test_utils::create_test_provider_factory, BlockWriter};
+    use alloy_primitives::Bytes;
+    use assert_matches::assert_matches;
+    use reth_chainspec::{ChainSpecProvider, EthChainSpec};
+    use reth_ethereum_primitives::{Block, BlockBody};
+    use reth_primitives_traits::{block::TestBlock, RecoveredBlock, SealedBlock};
+
+    #[test]
+    fn test_consistent_view_extend() {
+        let provider_factory = create_test_provider_factory();
+
+        let genesis_block = SealedBlock::<Block>::seal_parts(
+            provider_factory.chain_spec().genesis_header().clone(),
+            BlockBody::default(),
+        );
+        let genesis_hash: B256 = genesis_block.hash();
+        let genesis_block = RecoveredBlock::new_sealed(genesis_block, vec![]);
+
+        // insert the block
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.insert_block(&genesis_block).unwrap();
+        provider_rw.commit().unwrap();
+
+        // create a consistent view provider and check that a ro provider can be made
+        let view = ConsistentDbView::new_with_latest_tip(provider_factory.clone()).unwrap();
+
+        // ensure successful creation of a read-only provider.
+        assert_matches!(view.provider_ro(), Ok(_));
+
+        // generate a block that extends the genesis
+        let mut block = Block::default();
+        block.header_mut().parent_hash = genesis_hash;
+        block.header_mut().number = 1;
+        let sealed_block = SealedBlock::seal_slow(block);
+        let recovered_block = RecoveredBlock::new_sealed(sealed_block, vec![]);
+
+        // insert the block
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.insert_block(&recovered_block).unwrap();
+        provider_rw.commit().unwrap();
+
+        // ensure successful creation of a read-only provider, based on this new db state.
+        assert_matches!(view.provider_ro(), Ok(_));
+
+        // generate a block that extends that block
+        let mut block = Block::default();
+        block.header_mut().parent_hash = genesis_hash;
+        block.header_mut().number = 2;
+        let sealed_block = SealedBlock::seal_slow(block);
+        let recovered_block = RecoveredBlock::new_sealed(sealed_block, vec![]);
+
+        // insert the block
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.insert_block(&recovered_block).unwrap();
+        provider_rw.commit().unwrap();
+
+        // check that creation of a read-only provider still works
+        assert_matches!(view.provider_ro(), Ok(_));
+    }
+
+    #[test]
+    fn test_consistent_view_remove() {
+        let provider_factory = create_test_provider_factory();
+
+        let genesis_block = SealedBlock::<Block>::seal_parts(
+            provider_factory.chain_spec().genesis_header().clone(),
+            BlockBody::default(),
+        );
+        let genesis_hash: B256 = genesis_block.hash();
+        let genesis_block = RecoveredBlock::new_sealed(genesis_block, vec![]);
+
+        // insert the block
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.insert_block(&genesis_block).unwrap();
+        provider_rw.commit().unwrap();
+
+        // create a consistent view provider and check that a ro provider can be made
+        let view = ConsistentDbView::new_with_latest_tip(provider_factory.clone()).unwrap();
+
+        // ensure successful creation of a read-only provider.
+        assert_matches!(view.provider_ro(), Ok(_));
+
+        // generate a block that extends the genesis
+        let mut block = Block::default();
+        block.header_mut().parent_hash = genesis_hash;
+        block.header_mut().number = 1;
+        let sealed_block = SealedBlock::seal_slow(block);
+        let recovered_block = RecoveredBlock::new_sealed(sealed_block.clone(), vec![]);
+
+        // insert the block
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.insert_block(&recovered_block).unwrap();
+        provider_rw.commit().unwrap();
+
+        // create a second consistent view provider and check that a ro provider can be made
+        let view = ConsistentDbView::new_with_latest_tip(provider_factory.clone()).unwrap();
+        let initial_tip_hash = sealed_block.hash();
+
+        // ensure successful creation of a read-only provider, based on this new db state.
+        assert_matches!(view.provider_ro(), Ok(_));
+
+        // remove the block above the genesis block
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.remove_blocks_above(0).unwrap();
+        provider_rw.commit().unwrap();
+
+        // ensure unsuccessful creation of a read-only provider, based on this new db state.
+        let Err(ProviderError::ConsistentView(boxed_consistent_view_err)) = view.provider_ro()
+        else {
+            panic!("expected reorged consistent view error, got success");
+        };
+        let unboxed = *boxed_consistent_view_err;
+        assert_eq!(unboxed, ConsistentViewError::Reorged { block: initial_tip_hash });
+
+        // generate a block that extends the genesis with a different hash
+        let mut block = Block::default();
+        block.header_mut().parent_hash = genesis_hash;
+        block.header_mut().number = 1;
+        block.header_mut().extra_data =
+            Bytes::from_str("6a6f75726e657920746f20697468616361").unwrap();
+        let sealed_block = SealedBlock::seal_slow(block);
+        let recovered_block = RecoveredBlock::new_sealed(sealed_block, vec![]);
+
+        // reinsert the block at the same height, but with a different hash
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.insert_block(&recovered_block).unwrap();
+        provider_rw.commit().unwrap();
+
+        // ensure unsuccessful creation of a read-only provider, based on this new db state.
+        let Err(ProviderError::ConsistentView(boxed_consistent_view_err)) = view.provider_ro()
+        else {
+            panic!("expected reorged consistent view error, got success");
+        };
+        let unboxed = *boxed_consistent_view_err;
+        assert_eq!(unboxed, ConsistentViewError::Reorged { block: initial_tip_hash });
+    }
+}

--- a/patches/reth-provider/src/providers/database/builder.rs
+++ b/patches/reth-provider/src/providers/database/builder.rs
@@ -1,0 +1,251 @@
+//! Helper builder entrypoint to instantiate a [`ProviderFactory`].
+
+use crate::{
+    providers::{NodeTypesForProvider, RocksDBProvider, StaticFileProvider},
+    ProviderFactory,
+};
+use reth_db::{
+    mdbx::{DatabaseArguments, MaxReadTransactionDuration},
+    open_db_read_only, DatabaseEnv,
+};
+use reth_node_types::NodeTypesWithDBAdapter;
+use std::{
+    marker::PhantomData,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+/// Helper type to create a [`ProviderFactory`].
+///
+/// See [`ProviderFactoryBuilder::open_read_only`] for usage examples.
+#[derive(Debug)]
+pub struct ProviderFactoryBuilder<N> {
+    _types: PhantomData<N>,
+}
+
+impl<N> ProviderFactoryBuilder<N> {
+    /// Maps the [`reth_node_types::NodeTypes`] of this builder.
+    pub fn types<T>(self) -> ProviderFactoryBuilder<T> {
+        ProviderFactoryBuilder::default()
+    }
+
+    /// Opens the database with the given chainspec and [`ReadOnlyConfig`].
+    ///
+    /// # Open a monitored instance
+    ///
+    /// This is recommended when the new read-only instance is used with an active node.
+    ///
+    /// ```no_run
+    /// use reth_chainspec::MAINNET;
+    /// use reth_provider::providers::{NodeTypesForProvider, ProviderFactoryBuilder};
+    ///
+    /// fn demo<N: NodeTypesForProvider<ChainSpec = reth_chainspec::ChainSpec>>(
+    ///     runtime: reth_tasks::Runtime,
+    /// ) {
+    ///     let provider_factory = ProviderFactoryBuilder::<N>::default()
+    ///         .open_read_only(MAINNET.clone(), "datadir", runtime)
+    ///         .unwrap();
+    /// }
+    /// ```
+    ///
+    /// # Open an unmonitored instance
+    ///
+    /// This is recommended when no changes to the database are expected (e.g. no active node)
+    ///
+    /// ```no_run
+    /// use reth_chainspec::MAINNET;
+    /// use reth_provider::providers::{NodeTypesForProvider, ProviderFactoryBuilder, ReadOnlyConfig};
+    ///
+    /// fn demo<N: NodeTypesForProvider<ChainSpec = reth_chainspec::ChainSpec>>(
+    ///     runtime: reth_tasks::Runtime,
+    /// ) {
+    ///     let provider_factory = ProviderFactoryBuilder::<N>::default()
+    ///         .open_read_only(
+    ///             MAINNET.clone(),
+    ///             ReadOnlyConfig::from_datadir("datadir").no_watch(),
+    ///             runtime,
+    ///         )
+    ///         .unwrap();
+    /// }
+    /// ```
+    ///
+    /// # Open an instance with disabled read-transaction timeout
+    ///
+    /// By default, read transactions are automatically terminated after a timeout to prevent
+    /// database free list growth. However, if the database is static (no writes occurring), this
+    /// safety mechanism can be disabled using
+    /// [`ReadOnlyConfig::disable_long_read_transaction_safety`].
+    ///
+    /// ```no_run
+    /// use reth_chainspec::MAINNET;
+    /// use reth_provider::providers::{NodeTypesForProvider, ProviderFactoryBuilder, ReadOnlyConfig};
+    ///
+    /// fn demo<N: NodeTypesForProvider<ChainSpec = reth_chainspec::ChainSpec>>(
+    ///     runtime: reth_tasks::Runtime,
+    /// ) {
+    ///     let provider_factory = ProviderFactoryBuilder::<N>::default()
+    ///         .open_read_only(
+    ///             MAINNET.clone(),
+    ///             ReadOnlyConfig::from_datadir("datadir").disable_long_read_transaction_safety(),
+    ///             runtime,
+    ///         )
+    ///         .unwrap();
+    /// }
+    /// ```
+    pub fn open_read_only(
+        self,
+        chainspec: Arc<N::ChainSpec>,
+        config: impl Into<ReadOnlyConfig>,
+        runtime: reth_tasks::Runtime,
+    ) -> eyre::Result<ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>>>
+    where
+        N: NodeTypesForProvider,
+    {
+        let ReadOnlyConfig { db_dir, db_args, static_files_dir, rocksdb_dir, watch } =
+            config.into();
+        let db = open_db_read_only(db_dir, db_args)?;
+        let static_file_provider = StaticFileProvider::read_only(static_files_dir)?;
+        let rocksdb_provider = RocksDBProvider::builder(&rocksdb_dir)
+            .with_default_tables()
+            .with_read_only(true)
+            .build()?;
+        let factory =
+            ProviderFactory::new(db, chainspec, static_file_provider, rocksdb_provider, runtime)?
+                .with_read_only_sync(watch);
+        Ok(factory)
+    }
+}
+
+impl<N> Default for ProviderFactoryBuilder<N> {
+    fn default() -> Self {
+        Self { _types: Default::default() }
+    }
+}
+
+/// Settings for how to open the database, static files, and `RocksDB`.
+///
+/// The default derivation from a path assumes the path is the datadir:
+/// [`ReadOnlyConfig::from_datadir`]
+#[derive(Debug, Clone)]
+pub struct ReadOnlyConfig {
+    /// The path to the database directory.
+    pub db_dir: PathBuf,
+    /// How to open the database
+    pub db_args: DatabaseArguments,
+    /// The path to the static file dir
+    pub static_files_dir: PathBuf,
+    /// The path to the `RocksDB` directory
+    pub rocksdb_dir: PathBuf,
+    /// Whether to watch the MDBX directory for changes and eagerly sync providers.
+    pub watch: bool,
+}
+
+impl ReadOnlyConfig {
+    /// Derives the [`ReadOnlyConfig`] from the datadir.
+    ///
+    /// By default this assumes the following datadir layout:
+    ///
+    /// ```text
+    ///  -`datadir`
+    ///    |__db
+    ///    |__rocksdb
+    ///    |__static_files
+    /// ```
+    ///
+    /// By default this watches the static files directory for changes, see also
+    /// [`ProviderFactory::with_read_only_sync`]
+    pub fn from_datadir(datadir: impl AsRef<Path>) -> Self {
+        let datadir = datadir.as_ref();
+        Self {
+            db_dir: datadir.join("db"),
+            db_args: Default::default(),
+            static_files_dir: datadir.join("static_files"),
+            rocksdb_dir: datadir.join("rocksdb"),
+            watch: true,
+        }
+    }
+
+    /// Disables long-lived read transaction safety guarantees.
+    ///
+    /// Caution: Keeping database transaction open indefinitely can cause the free list to grow if
+    /// changes to the database are made.
+    pub const fn disable_long_read_transaction_safety(mut self) -> Self {
+        self.db_args.max_read_transaction_duration(Some(MaxReadTransactionDuration::Unbounded));
+        self
+    }
+
+    /// Derives the [`ReadOnlyConfig`] from the database dir.
+    ///
+    /// By default this assumes the following datadir layout:
+    ///
+    /// ```text
+    ///    - db
+    ///    - rocksdb
+    ///    - static_files
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// If the path does not exist
+    pub fn from_db_dir(db_dir: impl AsRef<Path>) -> Self {
+        let db_dir = db_dir.as_ref();
+        let datadir = std::fs::canonicalize(db_dir).unwrap().parent().unwrap().to_path_buf();
+        let static_files_dir = datadir.join("static_files");
+        let rocksdb_dir = datadir.join("rocksdb");
+        Self::from_dirs(db_dir, static_files_dir, rocksdb_dir)
+    }
+
+    /// Creates the config for the given paths.
+    ///
+    /// By default this watches the static files directory for changes, see also
+    /// [`ProviderFactory::with_read_only_sync`]
+    pub fn from_dirs(
+        db_dir: impl AsRef<Path>,
+        static_files_dir: impl AsRef<Path>,
+        rocksdb_dir: impl AsRef<Path>,
+    ) -> Self {
+        Self {
+            db_dir: db_dir.as_ref().into(),
+            db_args: Default::default(),
+            static_files_dir: static_files_dir.as_ref().into(),
+            rocksdb_dir: rocksdb_dir.as_ref().into(),
+            watch: true,
+        }
+    }
+
+    /// Configures the db arguments used when opening the database.
+    pub fn with_db_args(mut self, db_args: impl Into<DatabaseArguments>) -> Self {
+        self.db_args = db_args.into();
+        self
+    }
+
+    /// Configures the db directory.
+    pub fn with_db_dir(mut self, db_dir: impl Into<PathBuf>) -> Self {
+        self.db_dir = db_dir.into();
+        self
+    }
+
+    /// Configures the static file directory.
+    pub fn with_static_file_dir(mut self, static_file_dir: impl Into<PathBuf>) -> Self {
+        self.static_files_dir = static_file_dir.into();
+        self
+    }
+
+    /// Don't watch the static files directory for changes.
+    ///
+    /// This is only recommended if this is used without a running node instance that modifies
+    /// the database.
+    pub const fn no_watch(mut self) -> Self {
+        self.watch = false;
+        self
+    }
+}
+
+impl<T> From<T> for ReadOnlyConfig
+where
+    T: AsRef<Path>,
+{
+    fn from(value: T) -> Self {
+        Self::from_datadir(value.as_ref())
+    }
+}

--- a/patches/reth-provider/src/providers/database/chain.rs
+++ b/patches/reth-provider/src/providers/database/chain.rs
@@ -1,0 +1,77 @@
+use crate::{providers::NodeTypesForProvider, DatabaseProvider};
+use reth_db_api::transaction::{DbTx, DbTxMut};
+use reth_node_types::NodePrimitives;
+
+use reth_primitives_traits::{FullBlockHeader, FullSignedTx};
+use reth_storage_api::{ChainStorageReader, ChainStorageWriter, EmptyBodyStorage, EthStorage};
+
+/// Trait that provides access to implementations of [`ChainStorage`]
+pub trait ChainStorage<Primitives: NodePrimitives>: Send + Sync {
+    /// Provides access to the chain reader.
+    fn reader<TX, Types>(&self) -> impl ChainStorageReader<DatabaseProvider<TX, Types>, Primitives>
+    where
+        TX: DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = Primitives>;
+
+    /// Provides access to the chain writer.
+    fn writer<TX, Types>(&self) -> impl ChainStorageWriter<DatabaseProvider<TX, Types>, Primitives>
+    where
+        TX: DbTxMut + DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = Primitives>;
+}
+
+impl<N, T, H> ChainStorage<N> for EthStorage<T, H>
+where
+    T: FullSignedTx,
+    H: FullBlockHeader,
+    N: NodePrimitives<
+        Block = alloy_consensus::Block<T, H>,
+        BlockHeader = H,
+        BlockBody = alloy_consensus::BlockBody<T, H>,
+        SignedTx = T,
+    >,
+{
+    fn reader<TX, Types>(&self) -> impl ChainStorageReader<DatabaseProvider<TX, Types>, N>
+    where
+        TX: DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = N>,
+    {
+        self
+    }
+
+    fn writer<TX, Types>(&self) -> impl ChainStorageWriter<DatabaseProvider<TX, Types>, N>
+    where
+        TX: DbTxMut + DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = N>,
+    {
+        self
+    }
+}
+
+impl<N, T, H> ChainStorage<N> for EmptyBodyStorage<T, H>
+where
+    T: FullSignedTx,
+    H: FullBlockHeader,
+    N: NodePrimitives<
+        Block = alloy_consensus::Block<T, H>,
+        BlockHeader = H,
+        BlockBody = alloy_consensus::BlockBody<T, H>,
+        SignedTx = T,
+    >,
+{
+    fn reader<TX, Types>(&self) -> impl ChainStorageReader<DatabaseProvider<TX, Types>, N>
+    where
+        TX: DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = N>,
+    {
+        self
+    }
+
+    fn writer<TX, Types>(&self) -> impl ChainStorageWriter<DatabaseProvider<TX, Types>, N>
+    where
+        TX: DbTxMut + DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = N>,
+    {
+        self
+    }
+}

--- a/patches/reth-provider/src/providers/database/metrics.rs
+++ b/patches/reth-provider/src/providers/database/metrics.rs
@@ -1,0 +1,212 @@
+use metrics::{Gauge, Histogram};
+use reth_metrics::Metrics;
+use reth_primitives_traits::FastInstant as Instant;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub(crate) struct DurationsRecorder<'a> {
+    start: Instant,
+    current_metrics: &'a DatabaseProviderMetrics,
+    pub(crate) actions: Vec<(Action, Duration)>,
+    latest: Option<Duration>,
+}
+
+impl<'a> DurationsRecorder<'a> {
+    /// Creates a new durations recorder with the given metrics instance.
+    pub(crate) fn new(metrics: &'a DatabaseProviderMetrics) -> Self {
+        Self { start: Instant::now(), actions: Vec::new(), latest: None, current_metrics: metrics }
+    }
+}
+
+impl<'a> DurationsRecorder<'a> {
+    /// Records the duration since last record, saves it for future logging and instantly reports as
+    /// a metric with `action` label.
+    pub(crate) fn record_relative(&mut self, action: Action) {
+        let elapsed = self.start.elapsed();
+        let duration = elapsed - self.latest.unwrap_or_default();
+
+        self.actions.push((action, duration));
+        self.current_metrics.record_duration(action, duration);
+        self.latest = Some(elapsed);
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum Action {
+    InsertBlock,
+    InsertState,
+    InsertHashes,
+    InsertHistoryIndices,
+    UpdatePipelineStages,
+    InsertHeaderNumbers,
+    InsertBlockBodyIndices,
+    InsertTransactionBlocks,
+    InsertTransactionSenders,
+    InsertTransactionHashNumbers,
+}
+
+/// Database provider metrics
+#[derive(Metrics)]
+#[metrics(scope = "storage.providers.database")]
+pub(crate) struct DatabaseProviderMetrics {
+    /// Duration of insert block
+    insert_block: Histogram,
+    /// Duration of insert state
+    insert_state: Histogram,
+    /// Duration of insert hashes
+    insert_hashes: Histogram,
+    /// Duration of insert history indices
+    insert_history_indices: Histogram,
+    /// Duration of update pipeline stages
+    update_pipeline_stages: Histogram,
+    /// Duration of insert header numbers
+    insert_header_numbers: Histogram,
+    /// Duration of insert block body indices
+    insert_block_body_indices: Histogram,
+    /// Duration of insert transaction blocks
+    insert_tx_blocks: Histogram,
+    /// Duration of insert transaction senders
+    insert_transaction_senders: Histogram,
+    /// Duration of insert transaction hash numbers
+    insert_transaction_hash_numbers: Histogram,
+    /// Duration of `save_blocks`
+    save_blocks_total: Histogram,
+    /// Duration of MDBX work in `save_blocks`
+    save_blocks_mdbx: Histogram,
+    /// Duration of static file work in `save_blocks`
+    save_blocks_sf: Histogram,
+    /// Duration of `RocksDB` work in `save_blocks`
+    save_blocks_rocksdb: Histogram,
+    /// Duration of `insert_block` in `save_blocks`
+    save_blocks_insert_block: Histogram,
+    /// Duration of `write_state` in `save_blocks`
+    save_blocks_write_state: Histogram,
+    /// Duration of `write_hashed_state` in `save_blocks`
+    save_blocks_write_hashed_state: Histogram,
+    /// Duration of `write_trie_updates` in `save_blocks`
+    save_blocks_write_trie_updates: Histogram,
+    /// Duration of `update_history_indices` in `save_blocks`
+    save_blocks_update_history_indices: Histogram,
+    /// Duration of `update_pipeline_stages` in `save_blocks`
+    save_blocks_update_pipeline_stages: Histogram,
+    /// Number of blocks per `save_blocks` call
+    save_blocks_batch_size: Histogram,
+    /// Duration of MDBX commit in `save_blocks`
+    save_blocks_commit_mdbx: Histogram,
+    /// Duration of static file commit in `save_blocks`
+    save_blocks_commit_sf: Histogram,
+    /// Duration of `RocksDB` commit in `save_blocks`
+    save_blocks_commit_rocksdb: Histogram,
+    /// Last duration of `save_blocks`
+    save_blocks_total_last: Gauge,
+    /// Last duration of MDBX work in `save_blocks`
+    save_blocks_mdbx_last: Gauge,
+    /// Last duration of static file work in `save_blocks`
+    save_blocks_sf_last: Gauge,
+    /// Last duration of `RocksDB` work in `save_blocks`
+    save_blocks_rocksdb_last: Gauge,
+    /// Last duration of `insert_block` in `save_blocks`
+    save_blocks_insert_block_last: Gauge,
+    /// Last duration of `write_state` in `save_blocks`
+    save_blocks_write_state_last: Gauge,
+    /// Last duration of `write_hashed_state` in `save_blocks`
+    save_blocks_write_hashed_state_last: Gauge,
+    /// Last duration of `write_trie_updates` in `save_blocks`
+    save_blocks_write_trie_updates_last: Gauge,
+    /// Last duration of `update_history_indices` in `save_blocks`
+    save_blocks_update_history_indices_last: Gauge,
+    /// Last duration of `update_pipeline_stages` in `save_blocks`
+    save_blocks_update_pipeline_stages_last: Gauge,
+    /// Last number of blocks per `save_blocks` call
+    save_blocks_batch_size_last: Gauge,
+    /// Last duration of MDBX commit in `save_blocks`
+    save_blocks_commit_mdbx_last: Gauge,
+    /// Last duration of static file commit in `save_blocks`
+    save_blocks_commit_sf_last: Gauge,
+    /// Last duration of `RocksDB` commit in `save_blocks`
+    save_blocks_commit_rocksdb_last: Gauge,
+}
+
+/// Timings collected during a `save_blocks` call.
+#[derive(Debug, Default)]
+pub(crate) struct SaveBlocksTimings {
+    pub total: Duration,
+    pub mdbx: Duration,
+    pub sf: Duration,
+    pub rocksdb: Duration,
+    pub insert_block: Duration,
+    pub write_state: Duration,
+    pub write_hashed_state: Duration,
+    pub write_trie_updates: Duration,
+    pub update_history_indices: Duration,
+    pub update_pipeline_stages: Duration,
+    pub batch_size: u64,
+}
+
+/// Timings collected during a `commit` call.
+#[derive(Debug, Default)]
+pub(crate) struct CommitTimings {
+    pub mdbx: Duration,
+    pub sf: Duration,
+    pub rocksdb: Duration,
+}
+
+impl DatabaseProviderMetrics {
+    /// Records the duration for the given action.
+    pub(crate) fn record_duration(&self, action: Action, duration: Duration) {
+        match action {
+            Action::InsertBlock => self.insert_block.record(duration),
+            Action::InsertState => self.insert_state.record(duration),
+            Action::InsertHashes => self.insert_hashes.record(duration),
+            Action::InsertHistoryIndices => self.insert_history_indices.record(duration),
+            Action::UpdatePipelineStages => self.update_pipeline_stages.record(duration),
+            Action::InsertHeaderNumbers => self.insert_header_numbers.record(duration),
+            Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
+            Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),
+            Action::InsertTransactionSenders => self.insert_transaction_senders.record(duration),
+            Action::InsertTransactionHashNumbers => {
+                self.insert_transaction_hash_numbers.record(duration)
+            }
+        }
+    }
+
+    /// Records all `save_blocks` timings.
+    pub(crate) fn record_save_blocks(&self, timings: &SaveBlocksTimings) {
+        self.save_blocks_total.record(timings.total);
+        self.save_blocks_mdbx.record(timings.mdbx);
+        self.save_blocks_sf.record(timings.sf);
+        self.save_blocks_rocksdb.record(timings.rocksdb);
+        self.save_blocks_insert_block.record(timings.insert_block);
+        self.save_blocks_write_state.record(timings.write_state);
+        self.save_blocks_write_hashed_state.record(timings.write_hashed_state);
+        self.save_blocks_write_trie_updates.record(timings.write_trie_updates);
+        self.save_blocks_update_history_indices.record(timings.update_history_indices);
+        self.save_blocks_update_pipeline_stages.record(timings.update_pipeline_stages);
+        self.save_blocks_batch_size.record(timings.batch_size as f64);
+
+        self.save_blocks_total_last.set(timings.total.as_secs_f64());
+        self.save_blocks_mdbx_last.set(timings.mdbx.as_secs_f64());
+        self.save_blocks_sf_last.set(timings.sf.as_secs_f64());
+        self.save_blocks_rocksdb_last.set(timings.rocksdb.as_secs_f64());
+        self.save_blocks_insert_block_last.set(timings.insert_block.as_secs_f64());
+        self.save_blocks_write_state_last.set(timings.write_state.as_secs_f64());
+        self.save_blocks_write_hashed_state_last.set(timings.write_hashed_state.as_secs_f64());
+        self.save_blocks_write_trie_updates_last.set(timings.write_trie_updates.as_secs_f64());
+        self.save_blocks_update_history_indices_last
+            .set(timings.update_history_indices.as_secs_f64());
+        self.save_blocks_update_pipeline_stages_last
+            .set(timings.update_pipeline_stages.as_secs_f64());
+        self.save_blocks_batch_size_last.set(timings.batch_size as f64);
+    }
+
+    /// Records all commit timings.
+    pub(crate) fn record_commit(&self, timings: &CommitTimings) {
+        self.save_blocks_commit_mdbx.record(timings.mdbx);
+        self.save_blocks_commit_sf.record(timings.sf);
+        self.save_blocks_commit_rocksdb.record(timings.rocksdb);
+
+        self.save_blocks_commit_mdbx_last.set(timings.mdbx.as_secs_f64());
+        self.save_blocks_commit_sf_last.set(timings.sf.as_secs_f64());
+        self.save_blocks_commit_rocksdb_last.set(timings.rocksdb.as_secs_f64());
+    }
+}

--- a/patches/reth-provider/src/providers/database/mod.rs
+++ b/patches/reth-provider/src/providers/database/mod.rs
@@ -1,0 +1,1178 @@
+use crate::{
+    providers::{
+        state::latest::LatestStateProvider, NodeTypesForProvider, RocksDBProvider,
+        StaticFileProvider, StaticFileProviderRWRefMut,
+    },
+    to_range,
+    traits::{BlockSource, ReceiptProvider},
+    BalProvider, BalStoreHandle, BlockHashReader, BlockNumReader, BlockReader, ChainSpecProvider,
+    DatabaseProviderFactory, EitherWriterDestination, HashedPostStateProvider, HeaderProvider,
+    HeaderSyncGapProvider, MetadataProvider, ProviderError, PruneCheckpointReader,
+    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StaticFileProviderFactory,
+    StaticFileWriter, TransactionVariant, TransactionsProvider,
+};
+use alloy_consensus::transaction::TransactionMeta;
+use alloy_eips::BlockHashOrNumber;
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use core::fmt;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use parking_lot::RwLock;
+use reth_chainspec::ChainInfo;
+use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
+use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
+use reth_errors::{RethError, RethResult};
+use reth_node_types::{
+    BlockTy, HeaderTy, NodeTypesWithDB, NodeTypesWithDBAdapter, ReceiptTy, TxTy,
+};
+use reth_primitives_traits::{RecoveredBlock, SealedHeader};
+use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment, MINIMUM_UNWIND_SAFE_DISTANCE};
+use reth_stages_types::{PipelineTarget, StageCheckpoint, StageId};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{
+    BlockBodyIndicesProvider, ChainStateBlockReader, ChainStateBlockWriter, DBProvider,
+    NodePrimitivesProvider, StorageSettings, StorageSettingsCache, TryIntoHistoricalStateProvider,
+};
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::HashedPostState;
+use reth_trie_db::ChangesetCache;
+use revm_database::BundleState;
+use std::{
+    ops::{RangeBounds, RangeInclusive},
+    path::Path,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
+use tracing::{info, instrument, trace, warn};
+
+mod provider;
+pub use provider::{
+    CommitOrder, DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, SaveBlocksMode,
+};
+
+use super::ProviderNodeTypes;
+use reth_trie::KeccakKeyHasher;
+
+mod builder;
+pub use builder::{ProviderFactoryBuilder, ReadOnlyConfig};
+
+mod metrics;
+
+mod chain;
+pub use chain::*;
+
+/// Sync state for read-only [`ProviderFactory`] instances.
+struct ReadOnlySyncState {
+    /// Last MDBX txn ID we synced `RocksDB` secondary / static file indexes to.
+    last_synced_txnid: AtomicU64,
+    /// Serializes the slow-path catch-up (`RocksDB` + static file re-init).
+    sync_lock: Mutex<()>,
+}
+
+/// A common provider that fetches data from a database or static file.
+///
+/// This provider implements most provider or provider factory traits.
+pub struct ProviderFactory<N: NodeTypesWithDB> {
+    /// Database instance
+    db: N::DB,
+    /// Chain spec
+    chain_spec: Arc<N::ChainSpec>,
+    /// Static File Provider
+    static_file_provider: StaticFileProvider<N::Primitives>,
+    /// Optional pruning configuration
+    prune_modes: PruneModes,
+    /// The node storage handler.
+    storage: Arc<N::Storage>,
+    /// Storage configuration settings for this node
+    storage_settings: Arc<RwLock<StorageSettings>>,
+    /// `RocksDB` provider
+    rocksdb_provider: RocksDBProvider,
+    /// Changeset cache for trie unwinding
+    changeset_cache: ChangesetCache,
+    /// Store for block access lists.
+    bal_store: BalStoreHandle,
+    /// Task runtime for spawning parallel I/O work.
+    runtime: reth_tasks::Runtime,
+    /// Minimum distance from tip required before pruning can occur.
+    minimum_pruning_distance: u64,
+    /// State for on-demand syncing of `RocksDB` secondary and static file indexes.
+    ///
+    /// Only set for read-only factories. Can be disabled if there is no concurrent read-write
+    /// factory writing to the database (e.g as part of a running reth node).
+    read_only_sync: Option<Arc<ReadOnlySyncState>>,
+}
+
+impl<N: NodeTypesForProvider> ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>> {
+    /// Instantiates the builder for this type
+    pub fn builder() -> ProviderFactoryBuilder<N> {
+        ProviderFactoryBuilder::default()
+    }
+}
+
+impl<N: ProviderNodeTypes> ProviderFactory<N> {
+    /// Create new database provider factory.
+    ///
+    /// The storage backends used by the produced factory MAY be inconsistent.
+    /// It is recommended to call [`Self::check_consistency`] after
+    /// creation to ensure consistency between the database and static files.
+    /// If the function returns unwind targets, the caller MUST unwind the
+    /// inner database to the minimum of the two targets to ensure consistency.
+    pub fn new(
+        db: N::DB,
+        chain_spec: Arc<N::ChainSpec>,
+        static_file_provider: StaticFileProvider<N::Primitives>,
+        rocksdb_provider: RocksDBProvider,
+        runtime: reth_tasks::Runtime,
+    ) -> ProviderResult<Self> {
+        // Load storage settings from database at init time. Creates a temporary provider
+        // to read persisted settings, falling back to legacy defaults if none exist.
+        //
+        // Both factory and all providers it creates should share these cached settings.
+        let legacy_settings = StorageSettings::v1();
+        let storage_settings = DatabaseProvider::<_, N>::new(
+            db.tx()?,
+            chain_spec.clone(),
+            static_file_provider.clone(),
+            Default::default(),
+            Default::default(),
+            Arc::new(RwLock::new(legacy_settings)),
+            rocksdb_provider.clone(),
+            ChangesetCache::new(),
+            runtime.clone(),
+            db.path(),
+        )
+        .storage_settings()?
+        .unwrap_or(legacy_settings);
+
+        Ok(Self {
+            db,
+            chain_spec,
+            static_file_provider,
+            prune_modes: PruneModes::default(),
+            storage: Default::default(),
+            storage_settings: Arc::new(RwLock::new(storage_settings)),
+            rocksdb_provider,
+            changeset_cache: ChangesetCache::new(),
+            bal_store: BalStoreHandle::default(),
+            runtime,
+            minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
+            read_only_sync: None,
+        })
+    }
+
+    /// Create new database provider factory and perform consistency checks.
+    ///
+    /// This will call [`Self::check_consistency`] internally and return
+    /// [`ProviderError::MustUnwind`] if inconsistencies are found. It may also
+    /// return any [`ProviderError`] that [`Self::new`] may return, or that are
+    /// encountered during consistency checks.
+    pub fn new_checked(
+        db: N::DB,
+        chain_spec: Arc<N::ChainSpec>,
+        static_file_provider: StaticFileProvider<N::Primitives>,
+        rocksdb_provider: RocksDBProvider,
+        runtime: reth_tasks::Runtime,
+    ) -> ProviderResult<Self> {
+        Self::new(db, chain_spec, static_file_provider, rocksdb_provider, runtime)
+            .and_then(Self::assert_consistent)
+    }
+}
+
+impl<N: NodeTypesWithDB> ProviderFactory<N> {
+    /// Sets the pruning configuration for an existing [`ProviderFactory`].
+    pub fn with_prune_modes(mut self, prune_modes: PruneModes) -> Self {
+        self.prune_modes = prune_modes;
+        self
+    }
+
+    /// Sets the changeset cache for an existing [`ProviderFactory`].
+    pub fn with_changeset_cache(mut self, changeset_cache: ChangesetCache) -> Self {
+        self.changeset_cache = changeset_cache;
+        self
+    }
+
+    /// Sets the minimum pruning distance for an existing [`ProviderFactory`].
+    ///
+    /// This controls the minimum distance from tip required before pruning can occur.
+    /// The default is [`MINIMUM_UNWIND_SAFE_DISTANCE`].
+    pub const fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
+        self.minimum_pruning_distance = distance;
+        self
+    }
+
+    /// Enables on-demand syncing of `RocksDB` secondary and static file indexes for read-only
+    /// factories. Initializes the tracker to the current MDBX txn ID.
+    ///
+    /// Should be used for read-only factories that are running concurrently to a reth node writing
+    /// new data to the database. Would effectively be a no-op if database directory is unchanged.
+    pub fn with_read_only_sync(mut self, watch: bool) -> Self
+    where
+        N::DB: Database,
+    {
+        // Initialize to 0 so the first `sync_providers_if_needed` call always
+        // triggers a RocksDB/static-file catch-up, regardless of what MDBX txnid
+        // the database was at when we opened it.
+        let state = Arc::new(ReadOnlySyncState {
+            last_synced_txnid: AtomicU64::new(0),
+            sync_lock: Mutex::new(()),
+        });
+        self.read_only_sync = Some(state);
+
+        if watch {
+            self.watch_db_directory();
+        }
+        self
+    }
+
+    /// Watches the MDBX data directory for changes and eagerly syncs `RocksDB` secondary and
+    /// static file indexes when modifications are detected.
+    fn watch_db_directory(&self)
+    where
+        N::DB: Database,
+    {
+        let factory = self.clone();
+        let db_path = self.db.path();
+        reth_tasks::spawn_os_thread("ro-sync", move || {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let mut watcher = RecommendedWatcher::new(
+                move |res| {
+                    let _ = tx.send(res);
+                },
+                notify::Config::default(),
+            )
+            .expect("failed to create watcher");
+
+            watcher
+                .watch(&db_path, RecursiveMode::NonRecursive)
+                .expect("failed to watch MDBX path");
+
+            while let Ok(res) = rx.recv() {
+                match res {
+                    Ok(event) => {
+                        if !matches!(
+                            event.kind,
+                            notify::EventKind::Modify(_) | notify::EventKind::Create(_)
+                        ) {
+                            continue;
+                        }
+
+                        if let Err(err) = factory.sync_providers_if_needed() {
+                            warn!(target: "reth::provider", %err, "background ro-sync failed");
+                        }
+                    }
+                    Err(err) => {
+                        warn!(target: "reth::provider", ?err, "MDBX directory watcher error");
+                    }
+                }
+            }
+        });
+    }
+
+    /// For read-only factories, checks whether the MDBX committed txn ID has advanced since the
+    /// last sync and, if so, catches up the `RocksDB` secondary instance and re-initializes the
+    /// static file index.
+    ///
+    /// No-op for read-write factories.
+    pub fn sync_providers_if_needed(&self) -> ProviderResult<()> {
+        let Some(sync_state) = &self.read_only_sync else { return Ok(()) };
+        let current_txnid = self.db.last_txnid().unwrap_or(0);
+
+        // Fast path: no contention when nothing changed.
+        if current_txnid == sync_state.last_synced_txnid.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        // Slow path: serialize the actual catch-up I/O.
+        let _guard = sync_state.sync_lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Double-check after acquiring the lock — another thread may have already synced.
+        if current_txnid == sync_state.last_synced_txnid.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        self.rocksdb_provider.try_catch_up_with_primary()?;
+        self.static_file_provider.initialize_index()?;
+        sync_state.last_synced_txnid.store(current_txnid, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Returns reference to the underlying database.
+    pub const fn db_ref(&self) -> &N::DB {
+        &self.db
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    /// Consumes Self and returns DB
+    pub fn into_db(self) -> N::DB {
+        self.db
+    }
+}
+
+impl<N: NodeTypesWithDB> StorageSettingsCache for ProviderFactory<N> {
+    fn cached_storage_settings(&self) -> StorageSettings {
+        *self.storage_settings.read()
+    }
+
+    fn set_storage_settings_cache(&self, settings: StorageSettings) {
+        *self.storage_settings.write() = settings;
+    }
+}
+
+impl<N: NodeTypesWithDB> RocksDBProviderFactory for ProviderFactory<N> {
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        self.rocksdb_provider.clone()
+    }
+
+    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
+        unimplemented!("ProviderFactory is a factory, not a provider - use DatabaseProvider::set_pending_rocksdb_batch instead")
+    }
+
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+        unimplemented!("ProviderFactory is a factory, not a provider - use DatabaseProvider::commit_pending_rocksdb_batches instead")
+    }
+}
+
+impl<N: ProviderNodeTypes<DB = DatabaseEnv>> ProviderFactory<N> {
+    /// Create new database provider by passing a path. [`ProviderFactory`] will own the database
+    /// instance.
+    pub fn new_with_database_path<P: AsRef<Path>>(
+        path: P,
+        chain_spec: Arc<N::ChainSpec>,
+        args: DatabaseArguments,
+        static_file_provider: StaticFileProvider<N::Primitives>,
+        rocksdb_provider: RocksDBProvider,
+        runtime: reth_tasks::Runtime,
+    ) -> RethResult<Self> {
+        Self::new(
+            init_db(path, args).map_err(RethError::msg)?,
+            chain_spec,
+            static_file_provider,
+            rocksdb_provider,
+            runtime,
+        )
+        .map_err(RethError::Provider)
+    }
+}
+
+impl<N: ProviderNodeTypes> ProviderFactory<N> {
+    /// Returns a provider with a created `DbTx` inside, which allows fetching data from the
+    /// database using different types of providers. Example: [`HeaderProvider`]
+    /// [`BlockHashReader`]. This may fail if the inner read database transaction fails to open.
+    ///
+    /// This sets the [`PruneModes`] to [`None`], because they should only be relevant for writing
+    /// data.
+    #[track_caller]
+    pub fn provider(&self) -> ProviderResult<DatabaseProviderRO<N::DB, N>> {
+        let db_tx = self.db.tx()?;
+
+        // Sync providers after opening the database transaction to make
+        // sure that no data is pruned from rocksdb or static files.
+        //
+        // Reorg logic ensures that no data is pruned from rocksdb or static files while there is an
+        // mdbx transaction open that might rely on this data.
+        self.sync_providers_if_needed()?;
+
+        Ok(DatabaseProvider::new(
+            db_tx,
+            self.chain_spec.clone(),
+            self.static_file_provider.clone(),
+            self.prune_modes.clone(),
+            self.storage.clone(),
+            self.storage_settings.clone(),
+            self.rocksdb_provider.clone(),
+            self.changeset_cache.clone(),
+            self.runtime.clone(),
+            self.db.path(),
+        )
+        .with_minimum_pruning_distance(self.minimum_pruning_distance))
+    }
+
+    /// Returns a provider with a created `DbTxMut` inside, which allows fetching and updating
+    /// data from the database using different types of providers. Example: [`HeaderProvider`]
+    /// [`BlockHashReader`].  This may fail if the inner read/write database transaction fails to
+    /// open.
+    #[track_caller]
+    pub fn provider_rw(&self) -> ProviderResult<DatabaseProviderRW<N::DB, N>> {
+        Ok(DatabaseProviderRW(
+            DatabaseProvider::new_rw(
+                self.db.tx_mut()?,
+                self.chain_spec.clone(),
+                self.static_file_provider.clone(),
+                self.prune_modes.clone(),
+                self.storage.clone(),
+                self.storage_settings.clone(),
+                self.rocksdb_provider.clone(),
+                self.changeset_cache.clone(),
+                self.runtime.clone(),
+                self.db.path(),
+            )
+            .with_reader_txn_tracker(self.db.clone())
+            .with_minimum_pruning_distance(self.minimum_pruning_distance),
+        ))
+    }
+
+    /// Returns a provider with a created `DbTxMut` inside, configured for unwind operations.
+    /// Uses unwind commit order (MDBX first, then `RocksDB`, then static files) to allow
+    /// recovery by truncating static files on restart if interrupted.
+    ///
+    /// Unwind commits may wait for pre-existing readers to drain before finishing later
+    /// cross-store steps. Drop any long-lived read providers before committing this provider.
+    #[track_caller]
+    pub fn unwind_provider_rw(
+        &self,
+    ) -> ProviderResult<DatabaseProvider<<N::DB as Database>::TXMut, N>> {
+        Ok(DatabaseProvider::new_unwind_rw(
+            self.db.tx_mut()?,
+            self.chain_spec.clone(),
+            self.static_file_provider.clone(),
+            self.prune_modes.clone(),
+            self.storage.clone(),
+            self.storage_settings.clone(),
+            self.rocksdb_provider.clone(),
+            self.changeset_cache.clone(),
+            self.runtime.clone(),
+            self.db.path(),
+        )
+        .with_reader_txn_tracker(self.db.clone())
+        .with_minimum_pruning_distance(self.minimum_pruning_distance))
+    }
+
+    /// State provider for latest block
+    #[track_caller]
+    pub fn latest(&self) -> ProviderResult<StateProviderBox> {
+        trace!(target: "providers::db", "Returning latest state provider");
+        Ok(Box::new(LatestStateProvider::new(self.database_provider_ro()?)))
+    }
+
+    /// Storage provider for state at that given block
+    pub fn history_by_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<StateProviderBox> {
+        let state_provider = self.provider()?.try_into_history_at_block(block_number)?;
+        trace!(target: "providers::db", ?block_number, "Returning historical state provider for block number");
+        Ok(state_provider)
+    }
+
+    /// Storage provider for state at that given block hash
+    pub fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox> {
+        let provider = self.provider()?;
+
+        let block_number = provider
+            .block_number(block_hash)?
+            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+
+        let state_provider = provider.try_into_history_at_block(block_number)?;
+        trace!(target: "providers::db", ?block_number, %block_hash, "Returning historical state provider for block hash");
+        Ok(state_provider)
+    }
+
+    /// Asserts that the static files and database are consistent. If not,
+    /// returns [`ProviderError::MustUnwind`] with the appropriate unwind
+    /// target. May also return any [`ProviderError`] that
+    /// [`Self::check_consistency`] may return.
+    pub fn assert_consistent(self) -> ProviderResult<Self> {
+        let (rocksdb_unwind, static_file_unwind) = self.check_consistency()?;
+
+        let source = match (rocksdb_unwind, static_file_unwind) {
+            (None, None) => return Ok(self),
+            (Some(_), Some(_)) => "RocksDB and Static Files",
+            (Some(_), None) => "RocksDB",
+            (None, Some(_)) => "Static Files",
+        };
+
+        Err(ProviderError::MustUnwind {
+            data_source: source,
+            unwind_to: rocksdb_unwind
+                .into_iter()
+                .chain(static_file_unwind)
+                .min()
+                .expect("at least one unwind target must be Some"),
+        })
+    }
+
+    /// Checks the consistency between the static files and the database. This
+    /// may result in static files being pruned or otherwise healed to ensure
+    /// consistency. I.e. this MAY result in writes to the static files.
+    #[instrument(err, skip(self))]
+    pub fn check_consistency(&self) -> ProviderResult<(Option<u64>, Option<u64>)> {
+        let provider_ro = self
+            .database_provider_ro()?
+            // Healing can run long-lived read transactions (e.g., iterating changesets
+            // over millions of blocks). Disable the default timeout so MDBX doesn't
+            // kill the transaction mid-heal, which causes a crash loop on startup.
+            .disable_long_read_transaction_safety();
+
+        // Step 1: heal file-level inconsistencies (no pruning)
+        self.static_file_provider().check_file_consistency(&provider_ro)?;
+
+        // Step 2: RocksDB consistency check (needs static files tx data)
+        let rocksdb_unwind = self.rocksdb_provider().check_consistency(&provider_ro)?;
+
+        // Step 3: Static file checkpoint consistency (may prune)
+        let static_file_unwind = self.static_file_provider().check_consistency(&provider_ro)?.map(
+            |target| match target {
+                PipelineTarget::Unwind(block) => block,
+                PipelineTarget::Sync(_) => unreachable!("check_consistency returns Unwind"),
+            },
+        );
+
+        // Step 4: Heal finalized/safe block numbers that may be ahead of the
+        // highest header on nodes coming from <=1.10.2.
+        //
+        // Unwinds already set it to the target block.
+        if rocksdb_unwind.is_none() && static_file_unwind.is_none() {
+            self.heal_chain_state_block_numbers(&provider_ro)?;
+        }
+
+        Ok((rocksdb_unwind, static_file_unwind))
+    }
+
+    /// If the stored finalized or safe block number is ahead of the highest
+    /// header, resets it to the highest header.
+    fn heal_chain_state_block_numbers(
+        &self,
+        provider_ro: &DatabaseProvider<<N::DB as Database>::TX, N>,
+    ) -> ProviderResult<()> {
+        let highest_header = self.last_block_number()?;
+
+        let finalized = provider_ro.last_finalized_block_number()?;
+        let safe = provider_ro.last_safe_block_number()?;
+
+        if finalized.is_none_or(|f| f <= highest_header) && safe.is_none_or(|s| s <= highest_header)
+        {
+            return Ok(());
+        }
+
+        let provider_rw = self.provider_rw()?;
+
+        if let Some(finalized) = finalized.filter(|&f| f > highest_header) {
+            info!(
+                target: "providers::db",
+                finalized,
+                highest_header,
+                "Healing finalized block number",
+            );
+            provider_rw.save_finalized_block_number(highest_header)?;
+        }
+
+        if let Some(safe) = safe.filter(|&s| s > highest_header) {
+            info!(
+                target: "providers::db",
+                safe,
+                highest_header,
+                "Healing safe block number",
+            );
+            provider_rw.save_safe_block_number(highest_header)?;
+        }
+
+        provider_rw.commit()?;
+
+        Ok(())
+    }
+
+    /// Returns a static file provider. For read-only instances, this will also invoke
+    /// [`Self::sync_providers_if_needed`] to make sure that the static file provider is up to date.
+    pub fn caught_up_static_file_provider(
+        &self,
+    ) -> ProviderResult<StaticFileProvider<N::Primitives>> {
+        self.sync_providers_if_needed()?;
+        Ok(self.static_file_provider.clone())
+    }
+}
+
+impl<N: NodeTypesWithDB> NodePrimitivesProvider for ProviderFactory<N> {
+    type Primitives = N::Primitives;
+}
+
+impl<N: NodeTypesWithDB> BalProvider for ProviderFactory<N> {
+    fn bal_store(&self) -> &BalStoreHandle {
+        &self.bal_store
+    }
+}
+
+impl<N: ProviderNodeTypes> DatabaseProviderFactory for ProviderFactory<N> {
+    type DB = N::DB;
+    type Provider = DatabaseProvider<<N::DB as Database>::TX, N>;
+    type ProviderRW = DatabaseProvider<<N::DB as Database>::TXMut, N>;
+
+    fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
+        self.provider()
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
+        self.provider_rw().map(|provider| provider.0)
+    }
+}
+
+impl<N: NodeTypesWithDB> StaticFileProviderFactory for ProviderFactory<N> {
+    /// Returns static file provider
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
+        self.static_file_provider.clone()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        self.static_file_provider.get_writer(block, segment)
+    }
+}
+
+impl<N: ProviderNodeTypes> HeaderSyncGapProvider for ProviderFactory<N> {
+    type Header = HeaderTy<N>;
+    fn local_tip_header(
+        &self,
+        highest_uninterrupted_block: BlockNumber,
+    ) -> ProviderResult<SealedHeader<Self::Header>> {
+        self.provider()?.local_tip_header(highest_uninterrupted_block)
+    }
+}
+
+impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
+    type Header = HeaderTy<N>;
+
+    fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        self.provider()?.header(block_hash)
+    }
+
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+        self.caught_up_static_file_provider()?.header_by_number(num)
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
+        self.caught_up_static_file_provider()?.headers_range(range)
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        self.caught_up_static_file_provider()?.sealed_header(number)
+    }
+
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.caught_up_static_file_provider()?.sealed_headers_range(range)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.caught_up_static_file_provider()?.sealed_headers_while(range, predicate)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockHashReader for ProviderFactory<N> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.caught_up_static_file_provider()?.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.caught_up_static_file_provider()?.canonical_hashes_range(start, end)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockNumReader for ProviderFactory<N> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        self.provider()?.chain_info()
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.provider()?.best_block_number()
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.caught_up_static_file_provider()?.last_block_number()
+    }
+
+    fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
+        // earliest history height tracks the lowest block number that has __not__ been expired, in
+        // other words, the first/earliest available block.
+        Ok(self.caught_up_static_file_provider()?.earliest_history_height())
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        self.provider()?.block_number(hash)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockReader for ProviderFactory<N> {
+    type Block = BlockTy<N>;
+
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        source: BlockSource,
+    ) -> ProviderResult<Option<Self::Block>> {
+        self.provider()?.find_block_by_hash(hash, source)
+    }
+
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+        self.provider()?.block(id)
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.provider()?.pending_block()
+    }
+
+    fn pending_block_and_receipts(
+        &self,
+    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<Self::Receipt>)>> {
+        self.provider()?.pending_block_and_receipts()
+    }
+
+    fn recovered_block(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.provider()?.recovered_block(id, transaction_kind)
+    }
+
+    fn sealed_block_with_senders(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.provider()?.sealed_block_with_senders(id, transaction_kind)
+    }
+
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
+        self.provider()?.block_range(range)
+    }
+
+    fn block_with_senders_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.provider()?.block_with_senders_range(range)
+    }
+
+    fn recovered_block_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.provider()?.recovered_block_range(range)
+    }
+
+    fn block_by_transaction_id(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        self.provider()?.block_by_transaction_id(id)
+    }
+}
+
+impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
+    type Transaction = TxTy<N>;
+
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        self.provider()?.transaction_id(tx_hash)
+    }
+
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        self.caught_up_static_file_provider()?.transaction_by_id(id)
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        id: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        self.caught_up_static_file_provider()?.transaction_by_id_unhashed(id)
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        self.provider()?.transaction_by_hash(hash)
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        self.provider()?.transaction_by_hash_with_meta(tx_hash)
+    }
+
+    fn transactions_by_block(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        self.provider()?.transactions_by_block(id)
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        self.provider()?.transactions_by_block_range(range)
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        self.caught_up_static_file_provider()?.transactions_by_tx_range(range)
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        if EitherWriterDestination::senders(self).is_static_file() {
+            self.caught_up_static_file_provider()?.senders_by_tx_range(range)
+        } else {
+            self.provider()?.senders_by_tx_range(range)
+        }
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        if EitherWriterDestination::senders(self).is_static_file() {
+            self.caught_up_static_file_provider()?.transaction_sender(id)
+        } else {
+            self.provider()?.transaction_sender(id)
+        }
+    }
+}
+
+impl<N: ProviderNodeTypes> ReceiptProvider for ProviderFactory<N> {
+    type Receipt = ReceiptTy<N>;
+
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+        self.caught_up_static_file_provider()?.get_with_static_file_or_database(
+            StaticFileSegment::Receipts,
+            id,
+            |static_file| static_file.receipt(id),
+            || self.provider()?.receipt(id),
+        )
+    }
+
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+        self.provider()?.receipt_by_hash(hash)
+    }
+
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        self.provider()?.receipts_by_block(block)
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Receipt>> {
+        self.caught_up_static_file_provider()?.get_range_with_static_file_or_database(
+            StaticFileSegment::Receipts,
+            to_range(range),
+            |static_file, range, _| static_file.receipts_by_tx_range(range),
+            |range, _| self.provider()?.receipts_by_tx_range(range),
+            |_| true,
+        )
+    }
+
+    fn receipts_by_block_range(
+        &self,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+        self.provider()?.receipts_by_block_range(block_range)
+    }
+}
+
+impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ProviderFactory<N> {
+    fn block_body_indices(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        self.provider()?.block_body_indices(number)
+    }
+
+    fn block_body_indices_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        self.provider()?.block_body_indices_range(range)
+    }
+}
+
+impl<N: ProviderNodeTypes> StageCheckpointReader for ProviderFactory<N> {
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
+        self.provider()?.get_stage_checkpoint(id)
+    }
+
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>> {
+        self.provider()?.get_stage_checkpoint_progress(id)
+    }
+    fn get_all_checkpoints(&self) -> ProviderResult<Vec<(String, StageCheckpoint)>> {
+        self.provider()?.get_all_checkpoints()
+    }
+}
+
+impl<N: NodeTypesWithDB> ChainSpecProvider for ProviderFactory<N> {
+    type ChainSpec = N::ChainSpec;
+
+    fn chain_spec(&self) -> Arc<N::ChainSpec> {
+        self.chain_spec.clone()
+    }
+}
+
+impl<N: ProviderNodeTypes> PruneCheckpointReader for ProviderFactory<N> {
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
+        self.provider()?.get_prune_checkpoint(segment)
+    }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        self.provider()?.get_prune_checkpoints()
+    }
+}
+
+impl<N: ProviderNodeTypes> HashedPostStateProvider for ProviderFactory<N> {
+    fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+}
+
+impl<N: ProviderNodeTypes> MetadataProvider for ProviderFactory<N> {
+    fn get_metadata(&self, key: &str) -> ProviderResult<Option<Vec<u8>>> {
+        self.provider()?.get_metadata(key)
+    }
+}
+
+impl<N> fmt::Debug for ProviderFactory<N>
+where
+    N: NodeTypesWithDB<DB: fmt::Debug, ChainSpec: fmt::Debug, Storage: fmt::Debug>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            db,
+            chain_spec,
+            static_file_provider,
+            prune_modes,
+            storage,
+            storage_settings,
+            rocksdb_provider,
+            changeset_cache,
+            bal_store,
+            runtime,
+            minimum_pruning_distance,
+            read_only_sync,
+        } = self;
+        f.debug_struct("ProviderFactory")
+            .field("db", &db)
+            .field("chain_spec", &chain_spec)
+            .field("static_file_provider", &static_file_provider)
+            .field("prune_modes", &prune_modes)
+            .field("storage", &storage)
+            .field("storage_settings", &*storage_settings.read())
+            .field("rocksdb_provider", &rocksdb_provider)
+            .field("changeset_cache", &changeset_cache)
+            .field("bal_store", &bal_store)
+            .field("runtime", &runtime)
+            .field("minimum_pruning_distance", &minimum_pruning_distance)
+            .field(
+                "read_only_sync",
+                &read_only_sync.as_ref().map(|s| s.last_synced_txnid.load(Ordering::Relaxed)),
+            )
+            .finish()
+    }
+}
+
+impl<N: NodeTypesWithDB> Clone for ProviderFactory<N> {
+    fn clone(&self) -> Self {
+        Self {
+            db: self.db.clone(),
+            chain_spec: self.chain_spec.clone(),
+            static_file_provider: self.static_file_provider.clone(),
+            prune_modes: self.prune_modes.clone(),
+            storage: self.storage.clone(),
+            storage_settings: self.storage_settings.clone(),
+            rocksdb_provider: self.rocksdb_provider.clone(),
+            changeset_cache: self.changeset_cache.clone(),
+            bal_store: self.bal_store.clone(),
+            runtime: self.runtime.clone(),
+            minimum_pruning_distance: self.minimum_pruning_distance,
+            read_only_sync: self.read_only_sync.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        providers::{StaticFileProvider, StaticFileWriter},
+        test_utils::{blocks::TEST_BLOCK, create_test_provider_factory, MockNodeTypesWithDB},
+        BlockHashReader, BlockNumReader, BlockWriter, DBProvider, HeaderSyncGapProvider,
+        TransactionsProvider,
+    };
+    use alloy_primitives::{TxNumber, B256};
+    use assert_matches::assert_matches;
+    use reth_chainspec::ChainSpecBuilder;
+    use reth_db::{
+        mdbx::DatabaseArguments,
+        test_utils::{create_test_rocksdb_dir, create_test_static_files_dir, ERROR_TEMPDIR},
+    };
+    use reth_db_api::tables;
+    use reth_primitives_traits::SignerRecoverable;
+    use reth_prune_types::{PruneMode, PruneModes};
+    use reth_storage_errors::provider::ProviderError;
+    use reth_testing_utils::generators::{self, random_block, random_header, BlockParams};
+    use std::{ops::RangeInclusive, sync::Arc};
+
+    #[test]
+    fn common_history_provider() {
+        let factory = create_test_provider_factory();
+        let _ = factory.latest();
+    }
+
+    #[test]
+    fn default_chain_info() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider().unwrap();
+
+        let chain_info = provider.chain_info().expect("should be ok");
+        assert_eq!(chain_info.best_number, 0);
+        assert_eq!(chain_info.best_hash, B256::ZERO);
+    }
+
+    #[test]
+    fn provider_flow() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider().unwrap();
+        provider.block_hash(0).unwrap();
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.block_hash(0).unwrap();
+        provider.block_hash(0).unwrap();
+    }
+
+    #[test]
+    fn provider_factory_with_database_path() {
+        let chain_spec = ChainSpecBuilder::mainnet().build();
+        let (_static_dir, static_dir_path) = create_test_static_files_dir();
+        let (_rocksdb_dir, rocksdb_path) = create_test_rocksdb_dir();
+        let _db_tempdir = tempfile::TempDir::new().expect(ERROR_TEMPDIR);
+        let factory = ProviderFactory::<MockNodeTypesWithDB<DatabaseEnv>>::new_with_database_path(
+            _db_tempdir.path(),
+            Arc::new(chain_spec),
+            DatabaseArguments::new(Default::default()),
+            StaticFileProvider::read_write(static_dir_path).unwrap(),
+            RocksDBProvider::builder(&rocksdb_path).build().unwrap(),
+            reth_tasks::Runtime::test(),
+        )
+        .unwrap();
+        let provider = factory.provider().unwrap();
+        provider.block_hash(0).unwrap();
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.block_hash(0).unwrap();
+        provider.block_hash(0).unwrap();
+    }
+
+    #[test]
+    fn insert_block_with_prune_modes() {
+        let block = TEST_BLOCK.clone();
+
+        {
+            let factory = create_test_provider_factory();
+            let provider = factory.provider_rw().unwrap();
+            assert_matches!(provider.insert_block(&block.clone().try_recover().unwrap()), Ok(_));
+            assert_matches!(
+                provider.transaction_sender(0), Ok(Some(sender))
+                if sender == block.body().transactions[0].recover_signer().unwrap()
+            );
+            assert_matches!(
+                provider.transaction_id(*block.body().transactions[0].tx_hash()),
+                Ok(Some(0))
+            );
+        }
+
+        {
+            let prune_modes = PruneModes {
+                sender_recovery: Some(PruneMode::Full),
+                transaction_lookup: Some(PruneMode::Full),
+                ..PruneModes::default()
+            };
+            // Keep factory alive until provider is dropped to prevent TempDatabase cleanup
+            let factory = create_test_provider_factory().with_prune_modes(prune_modes);
+            let provider = factory.provider_rw().unwrap();
+            assert_matches!(provider.insert_block(&block.clone().try_recover().unwrap()), Ok(_));
+            assert_matches!(provider.transaction_sender(0), Ok(None));
+            assert_matches!(
+                provider.transaction_id(*block.body().transactions[0].tx_hash()),
+                Ok(None)
+            );
+        }
+    }
+
+    #[test]
+    fn take_block_transaction_range_recover_senders() {
+        let mut rng = generators::rng();
+        let block =
+            random_block(&mut rng, 0, BlockParams { tx_count: Some(3), ..Default::default() });
+
+        let tx_ranges: Vec<RangeInclusive<TxNumber>> = vec![0..=0, 1..=1, 2..=2, 0..=1, 1..=2];
+        for range in tx_ranges {
+            let factory = create_test_provider_factory();
+            let provider = factory.provider_rw().unwrap();
+
+            assert_matches!(provider.insert_block(&block.clone().try_recover().unwrap()), Ok(_));
+
+            let senders = provider.take::<tables::TransactionSenders>(range.clone()).unwrap();
+            assert_eq!(
+                senders,
+                range
+                    .clone()
+                    .map(|tx_number| (
+                        tx_number,
+                        block.body().transactions[tx_number as usize].recover_signer().unwrap()
+                    ))
+                    .collect::<Vec<_>>()
+            );
+
+            let db_senders = provider.senders_by_tx_range(range);
+            assert!(matches!(db_senders, Ok(ref v) if v.is_empty()));
+        }
+    }
+
+    #[test]
+    fn header_sync_gap_lookup() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+
+        let mut rng = generators::rng();
+
+        // Genesis
+        let checkpoint = 0;
+        let head = random_header(&mut rng, 0, None);
+
+        // Empty database
+        assert_matches!(
+            provider.local_tip_header(checkpoint),
+            Err(ProviderError::HeaderNotFound(block_number))
+                if block_number.as_number().unwrap() == checkpoint
+        );
+
+        // Checkpoint and no gap
+        let static_file_provider = provider.static_file_provider();
+        let mut static_file_writer =
+            static_file_provider.latest_writer(StaticFileSegment::Headers).unwrap();
+        static_file_writer.append_header(head.header(), &head.hash()).unwrap();
+        static_file_writer.commit().unwrap();
+        drop(static_file_writer);
+
+        let local_head = provider.local_tip_header(checkpoint).unwrap();
+
+        assert_eq!(local_head, head);
+    }
+}

--- a/patches/reth-provider/src/providers/database/provider.rs
+++ b/patches/reth-provider/src/providers/database/provider.rs
@@ -1,0 +1,5465 @@
+use crate::{
+    changesets_utils::StorageRevertsIter,
+    providers::{
+        database::{chain::ChainStorage, metrics},
+        rocksdb::{PendingRocksDBBatches, RocksDBProvider, RocksDBWriteCtx},
+        static_file::{StaticFileWriteCtx, StaticFileWriter},
+        NodeTypesForProvider, StaticFileProvider,
+    },
+    to_range,
+    traits::{
+        AccountExtReader, BlockSource, ChangeSetReader, ReceiptProvider, StageCheckpointWriter,
+    },
+    AccountReader, BlockBodyWriter, BlockExecutionWriter, BlockHashReader, BlockNumReader,
+    BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
+    DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
+    HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
+    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
+    PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
+    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
+    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
+    TransactionsProvider, TransactionsProviderExt, TrieWriter,
+};
+use alloy_consensus::{
+    transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
+    BlockHeader, TxReceipt,
+};
+use alloy_eips::BlockHashOrNumber;
+use alloy_primitives::{
+    keccak256,
+    map::{hash_map, AddressSet, B256Map, HashMap},
+    Address, BlockHash, BlockNumber, StorageKey, StorageValue, TxHash, TxNumber, B256,
+};
+use itertools::Itertools;
+use parking_lot::RwLock;
+use rayon::slice::ParallelSliceMut;
+use reth_chain_state::{ComputedTrieData, ExecutedBlock};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec};
+use reth_db_api::{
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
+    database::{Database, ReaderTxnTracker},
+    models::{
+        sharded_key, storage_sharded_key::StorageShardedKey, AccountBeforeTx, BlockNumberAddress,
+        BlockNumberAddressRange, ShardedKey, StorageBeforeTx, StorageSettings,
+        StoredBlockBodyIndices,
+    },
+    table::Table,
+    tables,
+    transaction::{DbTx, DbTxMut},
+    BlockNumberList,
+};
+use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult, Chain, ExecutionOutcome};
+use reth_node_types::{BlockTy, BodyTy, HeaderTy, NodeTypes, ReceiptTy, TxTy};
+use reth_primitives_traits::{
+    Account, Block as _, BlockBody as _, Bytecode, FastInstant as Instant, RecoveredBlock,
+    SealedHeader, StorageEntry,
+};
+use reth_prune_types::{
+    PruneCheckpoint, PruneMode, PruneModes, PruneSegment, MINIMUM_UNWIND_SAFE_DISTANCE,
+};
+use reth_stages_types::{StageCheckpoint, StageId};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{
+    BlockBodyIndicesProvider, BlockBodyReader, MetadataProvider, MetadataWriter,
+    NodePrimitivesProvider, StateProvider, StateReader, StateWriteConfig, StorageChangeSetReader,
+    StoragePath, StorageSettingsCache, TryIntoHistoricalStateProvider, WriteStateInput,
+};
+use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
+use reth_trie::{
+    updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
+    HashedPostStateSorted,
+};
+use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor, TrieTableAdapter};
+use revm_database::states::{
+    PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
+};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+    ops::{Deref, DerefMut, Range, RangeBounds, RangeInclusive},
+    path::PathBuf,
+    sync::Arc,
+};
+use tracing::{debug, instrument, trace};
+
+/// Determines the commit order for database operations.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CommitOrder {
+    /// Normal commit order: static files first, then `RocksDB`, then MDBX.
+    #[default]
+    Normal,
+    /// Unwind commit order: MDBX first, then `RocksDB`, then static files.
+    /// Used for unwind operations to allow recovery by truncating static files on restart.
+    Unwind,
+}
+
+impl CommitOrder {
+    /// Returns true if this is unwind commit order.
+    pub const fn is_unwind(&self) -> bool {
+        matches!(self, Self::Unwind)
+    }
+}
+
+/// A [`DatabaseProvider`] that holds a read-only database transaction.
+pub type DatabaseProviderRO<DB, N> = DatabaseProvider<<DB as Database>::TX, N>;
+
+/// A [`DatabaseProvider`] that holds a read-write database transaction.
+///
+/// Ideally this would be an alias type. However, there's some weird compiler error (<https://github.com/rust-lang/rust/issues/102211>), that forces us to wrap this in a struct instead.
+/// Once that issue is solved, we can probably revert back to being an alias type.
+#[derive(Debug)]
+pub struct DatabaseProviderRW<DB: Database, N: NodeTypes>(
+    pub DatabaseProvider<<DB as Database>::TXMut, N>,
+);
+
+impl<DB: Database, N: NodeTypes> Deref for DatabaseProviderRW<DB, N> {
+    type Target = DatabaseProvider<<DB as Database>::TXMut, N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<DB: Database, N: NodeTypes> DerefMut for DatabaseProviderRW<DB, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<DB: Database, N: NodeTypes> AsRef<DatabaseProvider<<DB as Database>::TXMut, N>>
+    for DatabaseProviderRW<DB, N>
+{
+    fn as_ref(&self) -> &DatabaseProvider<<DB as Database>::TXMut, N> {
+        &self.0
+    }
+}
+
+impl<DB: Database, N: NodeTypes + 'static> DatabaseProviderRW<DB, N> {
+    /// Commit database transaction and static file if it exists.
+    pub fn commit(self) -> ProviderResult<()> {
+        self.0.commit()
+    }
+
+    /// Consume `DbTx` or `DbTxMut`.
+    pub fn into_tx(self) -> <DB as Database>::TXMut {
+        self.0.into_tx()
+    }
+
+    /// Override the minimum pruning distance for testing purposes.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub const fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
+        self.0.minimum_pruning_distance = distance;
+        self
+    }
+}
+
+impl<DB: Database, N: NodeTypes> From<DatabaseProviderRW<DB, N>>
+    for DatabaseProvider<<DB as Database>::TXMut, N>
+{
+    fn from(provider: DatabaseProviderRW<DB, N>) -> Self {
+        provider.0
+    }
+}
+
+/// Mode for [`DatabaseProvider::save_blocks`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveBlocksMode {
+    /// Full mode: write block structure + receipts + state + trie.
+    /// Used by engine/production code.
+    Full,
+    /// Blocks only: write block structure (headers, txs, senders, indices).
+    /// Receipts/state/trie are skipped - they may come later via separate calls.
+    /// Used by `insert_block`.
+    BlocksOnly,
+}
+
+impl SaveBlocksMode {
+    /// Returns `true` if this is [`SaveBlocksMode::Full`].
+    pub const fn with_state(self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
+
+/// A provider struct that fetches data from the database.
+/// Wrapper around [`DbTx`] and [`DbTxMut`]. Example: [`HeaderProvider`] [`BlockHashReader`]
+pub struct DatabaseProvider<TX, N: NodeTypes> {
+    /// Database transaction.
+    tx: TX,
+    /// Chain spec
+    chain_spec: Arc<N::ChainSpec>,
+    /// Static File provider
+    static_file_provider: StaticFileProvider<N::Primitives>,
+    /// Pruning configuration
+    prune_modes: PruneModes,
+    /// Node storage handler.
+    storage: Arc<N::Storage>,
+    /// Storage configuration settings for this node
+    storage_settings: Arc<RwLock<StorageSettings>>,
+    /// `RocksDB` provider
+    rocksdb_provider: RocksDBProvider,
+    /// Changeset cache for trie unwinding
+    changeset_cache: ChangesetCache,
+    /// Task runtime for spawning parallel I/O work.
+    runtime: reth_tasks::Runtime,
+    /// Path to the database directory.
+    db_path: PathBuf,
+    /// Pending `RocksDB` batches to be committed at provider commit time.
+    pending_rocksdb_batches: PendingRocksDBBatches,
+    /// Commit order for database operations.
+    commit_order: CommitOrder,
+    /// Minimum distance from tip required for pruning
+    minimum_pruning_distance: u64,
+    /// Database provider metrics
+    metrics: metrics::DatabaseProviderMetrics,
+    /// Database handle used to inspect active MDBX readers during unwind commits.
+    reader_txn_tracker: Option<Arc<dyn ReaderTxnTracker>>,
+}
+
+impl<TX: Debug, N: NodeTypes> Debug for DatabaseProvider<TX, N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("DatabaseProvider");
+        s.field("tx", &self.tx)
+            .field("chain_spec", &self.chain_spec)
+            .field("static_file_provider", &self.static_file_provider)
+            .field("prune_modes", &self.prune_modes)
+            .field("storage", &self.storage)
+            .field("storage_settings", &self.storage_settings)
+            .field("rocksdb_provider", &self.rocksdb_provider)
+            .field("changeset_cache", &self.changeset_cache)
+            .field("runtime", &self.runtime)
+            .field("pending_rocksdb_batches", &"<pending batches>")
+            .field("commit_order", &self.commit_order)
+            .field("minimum_pruning_distance", &self.minimum_pruning_distance)
+            .field("reader_txn_tracker", &"<reader txn tracker>")
+            .finish()
+    }
+}
+
+impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Returns reference to prune modes.
+    pub const fn prune_modes_ref(&self) -> &PruneModes {
+        &self.prune_modes
+    }
+
+    /// Sets the minimum pruning distance.
+    pub const fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
+        self.minimum_pruning_distance = distance;
+        self
+    }
+
+    /// Attaches reader tracking so unwind commits can wait on active readers.
+    pub(crate) fn with_reader_txn_tracker<T>(mut self, reader_txn_tracker: T) -> Self
+    where
+        T: ReaderTxnTracker + 'static,
+    {
+        self.reader_txn_tracker = Some(Arc::new(reader_txn_tracker));
+        self
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Commits unwind writes in MDBX -> `RocksDB` -> static-file order.
+    ///
+    /// This keeps MDBX as the first durable step so an interrupted unwind can be recovered by
+    /// truncating static files from checkpoints on the next startup.
+    ///
+    /// This waits after the MDBX commit so readers holding older MDBX-visible views cannot overlap
+    /// later cross-store unwind steps.
+    ///
+    /// Historical `storage_v2` reads ignore `RocksDB` history entries above their MDBX-visible tip,
+    /// so no additional post-`RocksDB` wait is needed before static-file commit.
+    fn commit_unwind(self) -> ProviderResult<()> {
+        let storage_v2 = self.cached_storage_settings().storage_v2;
+        let reader_txn_tracker = self.reader_txn_tracker.clone();
+        self.tx.commit()?;
+
+        if let Some(reader_txn_tracker) = reader_txn_tracker.as_ref() {
+            reader_txn_tracker.wait_for_pre_commit_readers();
+        }
+
+        if storage_v2 {
+            let batches = std::mem::take(&mut *self.pending_rocksdb_batches.lock());
+            for batch in batches {
+                self.rocksdb_provider.commit_batch(batch)?;
+            }
+        }
+
+        self.static_file_provider.commit()?;
+        Ok(())
+    }
+
+    /// State provider for latest state
+    pub fn latest<'a>(&'a self) -> Box<dyn StateProvider + 'a> {
+        trace!(target: "providers::db", "Returning latest state provider");
+        Box::new(LatestStateProviderRef::new(self))
+    }
+
+    /// Storage provider for state at that given block hash
+    pub fn history_by_block_hash<'a>(
+        &'a self,
+        block_hash: BlockHash,
+    ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
+        let block_number =
+            self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        self.history_by_block_number(block_number)
+    }
+
+    /// Storage provider for state at that given block number
+    pub fn history_by_block_number<'a>(
+        &'a self,
+        mut block_number: BlockNumber,
+    ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
+        if block_number == self.best_block_number().unwrap_or_default() &&
+            block_number == self.last_block_number().unwrap_or_default()
+        {
+            return Ok(Box::new(LatestStateProviderRef::new(self)))
+        }
+
+        // +1 as the changeset that we want is the one that was applied after this block.
+        block_number += 1;
+
+        let account_history_prune_checkpoint =
+            self.get_prune_checkpoint(PruneSegment::AccountHistory)?;
+        let storage_history_prune_checkpoint =
+            self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
+
+        let mut state_provider =
+            HistoricalStateProviderRef::new(self, block_number, self.changeset_cache.clone());
+        // If we pruned account or storage history, we can't return state on every historical block.
+        // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.
+        if let Some(prune_checkpoint_block_number) =
+            account_history_prune_checkpoint.and_then(|checkpoint| checkpoint.block_number)
+        {
+            state_provider = state_provider.with_lowest_available_account_history_block_number(
+                prune_checkpoint_block_number + 1,
+            );
+        }
+        if let Some(prune_checkpoint_block_number) =
+            storage_history_prune_checkpoint.and_then(|checkpoint| checkpoint.block_number)
+        {
+            state_provider = state_provider.with_lowest_available_storage_history_block_number(
+                prune_checkpoint_block_number + 1,
+            );
+        }
+
+        Ok(Box::new(state_provider))
+    }
+
+    #[cfg(feature = "test-utils")]
+    /// Sets the prune modes for provider.
+    pub fn set_prune_modes(&mut self, prune_modes: PruneModes) {
+        self.prune_modes = prune_modes;
+    }
+}
+
+impl<TX, N: NodeTypes> NodePrimitivesProvider for DatabaseProvider<TX, N> {
+    type Primitives = N::Primitives;
+}
+
+impl<TX, N: NodeTypes> StaticFileProviderFactory for DatabaseProvider<TX, N> {
+    /// Returns a static file provider
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
+        self.static_file_provider.clone()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<crate::providers::StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        self.static_file_provider.get_writer(block, segment)
+    }
+}
+
+impl<TX, N: NodeTypes> RocksDBProviderFactory for DatabaseProvider<TX, N> {
+    /// Returns the `RocksDB` provider.
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        self.rocksdb_provider.clone()
+    }
+
+    fn set_pending_rocksdb_batch(&self, batch: rocksdb::WriteBatchWithTransaction<true>) {
+        self.pending_rocksdb_batches.lock().push(batch);
+    }
+
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+        let batches = std::mem::take(&mut *self.pending_rocksdb_batches.lock());
+        for batch in batches {
+            self.rocksdb_provider.commit_batch(batch)?;
+        }
+        Ok(())
+    }
+}
+
+impl<TX: Debug + Send, N: NodeTypes<ChainSpec: EthChainSpec + 'static>> ChainSpecProvider
+    for DatabaseProvider<TX, N>
+{
+    type ChainSpec = N::ChainSpec;
+
+    fn chain_spec(&self) -> Arc<Self::ChainSpec> {
+        self.chain_spec.clone()
+    }
+}
+
+impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Creates a provider with an inner read-write transaction.
+    #[expect(clippy::too_many_arguments)]
+    fn new_rw_inner(
+        tx: TX,
+        chain_spec: Arc<N::ChainSpec>,
+        static_file_provider: StaticFileProvider<N::Primitives>,
+        prune_modes: PruneModes,
+        storage: Arc<N::Storage>,
+        storage_settings: Arc<RwLock<StorageSettings>>,
+        rocksdb_provider: RocksDBProvider,
+        changeset_cache: ChangesetCache,
+        runtime: reth_tasks::Runtime,
+        db_path: PathBuf,
+        commit_order: CommitOrder,
+    ) -> Self {
+        Self {
+            tx,
+            chain_spec,
+            static_file_provider,
+            prune_modes,
+            storage,
+            storage_settings,
+            rocksdb_provider,
+            changeset_cache,
+            runtime,
+            db_path,
+            pending_rocksdb_batches: Default::default(),
+            commit_order,
+            minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
+            metrics: metrics::DatabaseProviderMetrics::default(),
+            reader_txn_tracker: None,
+        }
+    }
+
+    /// Creates a provider with an inner read-write transaction using normal commit order.
+    #[expect(clippy::too_many_arguments)]
+    pub fn new_rw(
+        tx: TX,
+        chain_spec: Arc<N::ChainSpec>,
+        static_file_provider: StaticFileProvider<N::Primitives>,
+        prune_modes: PruneModes,
+        storage: Arc<N::Storage>,
+        storage_settings: Arc<RwLock<StorageSettings>>,
+        rocksdb_provider: RocksDBProvider,
+        changeset_cache: ChangesetCache,
+        runtime: reth_tasks::Runtime,
+        db_path: PathBuf,
+    ) -> Self {
+        Self::new_rw_inner(
+            tx,
+            chain_spec,
+            static_file_provider,
+            prune_modes,
+            storage,
+            storage_settings,
+            rocksdb_provider,
+            changeset_cache,
+            runtime,
+            db_path,
+            CommitOrder::Normal,
+        )
+    }
+
+    /// Creates a provider with an inner read-write transaction using unwind commit order.
+    #[expect(clippy::too_many_arguments)]
+    pub fn new_unwind_rw(
+        tx: TX,
+        chain_spec: Arc<N::ChainSpec>,
+        static_file_provider: StaticFileProvider<N::Primitives>,
+        prune_modes: PruneModes,
+        storage: Arc<N::Storage>,
+        storage_settings: Arc<RwLock<StorageSettings>>,
+        rocksdb_provider: RocksDBProvider,
+        changeset_cache: ChangesetCache,
+        runtime: reth_tasks::Runtime,
+        db_path: PathBuf,
+    ) -> Self {
+        Self::new_rw_inner(
+            tx,
+            chain_spec,
+            static_file_provider,
+            prune_modes,
+            storage,
+            storage_settings,
+            rocksdb_provider,
+            changeset_cache,
+            runtime,
+            db_path,
+            CommitOrder::Unwind,
+        )
+    }
+}
+
+impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
+    /// Executes a closure with a `RocksDB` batch, automatically registering it for commit.
+    ///
+    /// This helper encapsulates all the cfg-gated `RocksDB` batch handling.
+    pub fn with_rocksdb_batch<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        F: FnOnce(RocksBatchArg<'_>) -> ProviderResult<(R, Option<RawRocksDBBatch>)>,
+    {
+        let rocksdb = self.rocksdb_provider();
+        let rocksdb_batch = rocksdb.batch();
+
+        let (result, raw_batch) = f(rocksdb_batch)?;
+
+        if let Some(batch) = raw_batch {
+            self.set_pending_rocksdb_batch(batch);
+        }
+        let _ = raw_batch; // silence unused warning when rocksdb feature is disabled
+
+        Ok(result)
+    }
+
+    /// Creates the context for static file writes.
+    fn static_file_write_ctx(
+        &self,
+        save_mode: SaveBlocksMode,
+        first_block: BlockNumber,
+        last_block: BlockNumber,
+    ) -> ProviderResult<StaticFileWriteCtx> {
+        let tip = self.last_block_number()?.max(last_block);
+        Ok(StaticFileWriteCtx {
+            write_senders: EitherWriterDestination::senders(self).is_static_file() &&
+                self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()),
+            write_receipts: save_mode.with_state() &&
+                EitherWriter::receipts_destination(self).is_static_file(),
+            write_account_changesets: save_mode.with_state() &&
+                EitherWriterDestination::account_changesets(self).is_static_file(),
+            write_storage_changesets: save_mode.with_state() &&
+                EitherWriterDestination::storage_changesets(self).is_static_file(),
+            tip,
+            receipts_prune_mode: self.prune_modes.receipts,
+            // Receipts are prunable if no receipts exist in SF yet and within pruning distance
+            receipts_prunable: self
+                .static_file_provider
+                .get_highest_static_file_tx(StaticFileSegment::Receipts)
+                .is_none() &&
+                PruneMode::Distance(self.minimum_pruning_distance)
+                    .should_prune(first_block, tip),
+        })
+    }
+
+    /// Creates the context for `RocksDB` writes.
+    fn rocksdb_write_ctx(&self, first_block: BlockNumber) -> RocksDBWriteCtx {
+        RocksDBWriteCtx {
+            first_block_number: first_block,
+            prune_tx_lookup: self.prune_modes.transaction_lookup,
+            storage_settings: self.cached_storage_settings(),
+            pending_batches: self.pending_rocksdb_batches.clone(),
+        }
+    }
+
+    /// Writes executed blocks and state to storage.
+    ///
+    /// This method parallelizes static file (SF) writes with MDBX writes.
+    /// The SF thread writes headers, transactions, senders (if SF), and receipts (if SF, Full mode
+    /// only). The main thread writes MDBX data (indices, state, trie - Full mode only).
+    ///
+    /// Use [`SaveBlocksMode::Full`] for production (includes receipts, state, trie).
+    /// Use [`SaveBlocksMode::BlocksOnly`] for block structure only (used by `insert_block`).
+    #[instrument(level = "debug", target = "providers::db", skip_all, fields(block_count = blocks.len()))]
+    pub fn save_blocks(
+        &self,
+        blocks: Vec<ExecutedBlock<N::Primitives>>,
+        save_mode: SaveBlocksMode,
+    ) -> ProviderResult<()> {
+        if blocks.is_empty() {
+            debug!(target: "providers::db", "Attempted to write empty block range");
+            return Ok(())
+        }
+
+        let total_start = Instant::now();
+        let block_count = blocks.len() as u64;
+        let first_number = blocks.first().unwrap().recovered_block().number();
+        let last_block_number = blocks.last().unwrap().recovered_block().number();
+
+        debug!(target: "providers::db", block_count, "Writing blocks and execution data to storage");
+
+        // Compute tx_nums upfront (both threads need these)
+        let first_tx_num = self
+            .tx
+            .cursor_read::<tables::TransactionBlocks>()?
+            .last()?
+            .map(|(n, _)| n + 1)
+            .unwrap_or_default();
+
+        let tx_nums: Vec<TxNumber> = {
+            let mut nums = Vec::with_capacity(blocks.len());
+            let mut current = first_tx_num;
+            for block in &blocks {
+                nums.push(current);
+                current += block.recovered_block().body().transaction_count() as u64;
+            }
+            nums
+        };
+
+        let mut timings =
+            metrics::SaveBlocksTimings { batch_size: block_count, ..Default::default() };
+
+        // avoid capturing &self.tx in scope below.
+        let sf_provider = &self.static_file_provider;
+        let sf_ctx = self.static_file_write_ctx(save_mode, first_number, last_block_number)?;
+        let rocksdb_provider = self.rocksdb_provider.clone();
+        let rocksdb_ctx = self.rocksdb_write_ctx(first_number);
+        let rocksdb_enabled = rocksdb_ctx.storage_settings.storage_v2;
+
+        let mut sf_result = None;
+        let mut rocksdb_result = None;
+
+        // Write to all backends in parallel.
+        let runtime = &self.runtime;
+        // Propagate tracing context into rayon-spawned threads so that static file
+        // and RocksDB write spans appear as children of save_blocks in traces.
+        let span = tracing::Span::current();
+        runtime.storage_pool().in_place_scope(|s| {
+            // SF writes
+            s.spawn(|_| {
+                let _guard = span.enter();
+                let start = Instant::now();
+                sf_result = Some(
+                    sf_provider
+                        .write_blocks_data(&blocks, &tx_nums, sf_ctx, runtime)
+                        .map(|()| start.elapsed()),
+                );
+            });
+
+            // RocksDB writes
+            if rocksdb_enabled {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    let start = Instant::now();
+                    rocksdb_result = Some(
+                        rocksdb_provider
+                            .write_blocks_data(&blocks, &tx_nums, rocksdb_ctx, runtime)
+                            .map(|()| start.elapsed()),
+                    );
+                });
+            }
+
+            // MDBX writes
+            let mdbx_start = Instant::now();
+
+            // Collect all transaction hashes across all blocks, sort them, and write in batch
+            if !self.cached_storage_settings().storage_v2 &&
+                self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
+            {
+                let start = Instant::now();
+                let total_tx_count: usize =
+                    blocks.iter().map(|b| b.recovered_block().body().transaction_count()).sum();
+                let mut all_tx_hashes = Vec::with_capacity(total_tx_count);
+                for (i, block) in blocks.iter().enumerate() {
+                    let recovered_block = block.recovered_block();
+                    for (tx_num, transaction) in
+                        (tx_nums[i]..).zip(recovered_block.body().transactions_iter())
+                    {
+                        all_tx_hashes.push((*transaction.tx_hash(), tx_num));
+                    }
+                }
+
+                // Sort by hash for optimal MDBX insertion performance
+                all_tx_hashes.sort_unstable_by_key(|(hash, _)| *hash);
+
+                // Write all transaction hash numbers in a single batch
+                self.with_rocksdb_batch(|batch| {
+                    let mut tx_hash_writer =
+                        EitherWriter::new_transaction_hash_numbers(self, batch)?;
+                    tx_hash_writer.put_transaction_hash_numbers_batch(all_tx_hashes, false)?;
+                    let raw_batch = tx_hash_writer.into_raw_rocksdb_batch();
+                    Ok(((), raw_batch))
+                })?;
+                self.metrics.record_duration(
+                    metrics::Action::InsertTransactionHashNumbers,
+                    start.elapsed(),
+                );
+            }
+
+            for (i, block) in blocks.iter().enumerate() {
+                let recovered_block = block.recovered_block();
+
+                let start = Instant::now();
+                self.insert_block_mdbx_only(recovered_block, tx_nums[i])?;
+                timings.insert_block += start.elapsed();
+
+                if save_mode.with_state() {
+                    let execution_output = block.execution_outcome();
+
+                    // Write state and changesets to the database.
+                    // Must be written after blocks because of the receipt lookup.
+                    // Skip receipts/account changesets if they're being written to static files.
+                    let start = Instant::now();
+                    self.write_state(
+                        WriteStateInput::Single {
+                            outcome: execution_output,
+                            block: recovered_block.number(),
+                        },
+                        OriginalValuesKnown::No,
+                        StateWriteConfig {
+                            write_receipts: !sf_ctx.write_receipts,
+                            write_account_changesets: !sf_ctx.write_account_changesets,
+                            write_storage_changesets: !sf_ctx.write_storage_changesets,
+                        },
+                    )?;
+                    timings.write_state += start.elapsed();
+                }
+            }
+
+            // Write all hashed state and trie updates in single batches.
+            // This reduces cursor open/close overhead from N calls to 1.
+            if save_mode.with_state() {
+                // Blocks are oldest-to-newest, merge_batch expects newest-to-oldest.
+                let start = Instant::now();
+                let merged_hashed_state = HashedPostStateSorted::merge_batch(
+                    blocks.iter().rev().map(|b| b.trie_data().hashed_state),
+                );
+                if !merged_hashed_state.is_empty() {
+                    self.write_hashed_state(&merged_hashed_state)?;
+                }
+                timings.write_hashed_state += start.elapsed();
+
+                let start = Instant::now();
+                let merged_trie =
+                    TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()));
+                if !merged_trie.is_empty() {
+                    self.write_trie_updates_sorted(&merged_trie)?;
+                }
+                timings.write_trie_updates += start.elapsed();
+            }
+
+            // Full mode: update history indices
+            if save_mode.with_state() {
+                let start = Instant::now();
+                self.update_history_indices(first_number..=last_block_number)?;
+                timings.update_history_indices = start.elapsed();
+            }
+
+            // Update pipeline progress
+            let start = Instant::now();
+            self.update_pipeline_stages(last_block_number, false)?;
+            timings.update_pipeline_stages = start.elapsed();
+
+            timings.mdbx = mdbx_start.elapsed();
+
+            Ok::<_, ProviderError>(())
+        })?;
+
+        // Collect results from spawned tasks
+        timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
+
+        if rocksdb_enabled {
+            timings.rocksdb = rocksdb_result.ok_or_else(|| {
+                ProviderError::Database(reth_db_api::DatabaseError::Other(
+                    "RocksDB thread panicked".into(),
+                ))
+            })??;
+        }
+
+        timings.total = total_start.elapsed();
+
+        self.metrics.record_save_blocks(&timings);
+        debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+
+        Ok(())
+    }
+
+    /// Writes MDBX-only data for a block (indices, lookups, and senders if configured for MDBX).
+    ///
+    /// SF data (headers, transactions, senders if SF, receipts if SF) must be written separately.
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn insert_block_mdbx_only(
+        &self,
+        block: &RecoveredBlock<BlockTy<N>>,
+        first_tx_num: TxNumber,
+    ) -> ProviderResult<StoredBlockBodyIndices> {
+        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()) &&
+            EitherWriterDestination::senders(self).is_database()
+        {
+            let start = Instant::now();
+            let tx_nums_iter = std::iter::successors(Some(first_tx_num), |n| Some(n + 1));
+            let mut cursor = self.tx.cursor_write::<tables::TransactionSenders>()?;
+            for (tx_num, sender) in tx_nums_iter.zip(block.senders_iter().copied()) {
+                cursor.append(tx_num, &sender)?;
+            }
+            self.metrics
+                .record_duration(metrics::Action::InsertTransactionSenders, start.elapsed());
+        }
+
+        let block_number = block.number();
+        let tx_count = block.body().transaction_count() as u64;
+
+        let start = Instant::now();
+        self.tx.put::<tables::HeaderNumbers>(block.hash(), block_number)?;
+        self.metrics.record_duration(metrics::Action::InsertHeaderNumbers, start.elapsed());
+
+        self.write_block_body_indices(block_number, block.body(), first_tx_num, tx_count)?;
+
+        Ok(StoredBlockBodyIndices { first_tx_num, tx_count })
+    }
+
+    /// Writes MDBX block body indices (`BlockBodyIndices`, `TransactionBlocks`,
+    /// `Ommers`/`Withdrawals`).
+    fn write_block_body_indices(
+        &self,
+        block_number: BlockNumber,
+        body: &BodyTy<N>,
+        first_tx_num: TxNumber,
+        tx_count: u64,
+    ) -> ProviderResult<()> {
+        // MDBX: BlockBodyIndices
+        let start = Instant::now();
+        self.tx
+            .cursor_write::<tables::BlockBodyIndices>()?
+            .append(block_number, &StoredBlockBodyIndices { first_tx_num, tx_count })?;
+        self.metrics.record_duration(metrics::Action::InsertBlockBodyIndices, start.elapsed());
+
+        // MDBX: TransactionBlocks (last tx -> block mapping)
+        if tx_count > 0 {
+            let start = Instant::now();
+            self.tx
+                .cursor_write::<tables::TransactionBlocks>()?
+                .append(first_tx_num + tx_count - 1, &block_number)?;
+            self.metrics.record_duration(metrics::Action::InsertTransactionBlocks, start.elapsed());
+        }
+
+        // MDBX: Ommers/Withdrawals
+        self.storage.writer().write_block_bodies(self, vec![(block_number, Some(body))])?;
+
+        Ok(())
+    }
+
+    /// Unwinds trie state starting at and including the given block.
+    ///
+    /// This includes calculating the resulted state root and comparing it with the parent block
+    /// state root.
+    pub fn unwind_trie_state_from(&self, from: BlockNumber) -> ProviderResult<()> {
+        let changed_accounts = self.account_changesets_range(from..)?;
+
+        // Unwind account hashes.
+        self.unwind_account_hashing(changed_accounts.iter())?;
+
+        // Unwind account history indices.
+        self.unwind_account_history_indices(changed_accounts.iter())?;
+
+        let changed_storages = self.storage_changesets_range(from..)?;
+
+        // Unwind storage hashes.
+        self.unwind_storage_hashing(changed_storages.iter().copied())?;
+
+        // Unwind storage history indices.
+        self.unwind_storage_history_indices(changed_storages.iter().copied())?;
+
+        // Unwind accounts/storages trie tables using the revert.
+        // Get the database tip block number
+        let db_tip_block = self
+            .get_stage_checkpoint(reth_stages_types::StageId::Finish)?
+            .as_ref()
+            .map(|chk| chk.block_number)
+            .ok_or_else(|| ProviderError::InsufficientChangesets {
+                requested: from,
+                available: 0..=0,
+            })?;
+
+        let trie_revert = self.changeset_cache.get_or_compute_range(self, from..=db_tip_block)?;
+        self.write_trie_updates_sorted(&trie_revert)?;
+
+        Ok(())
+    }
+
+    /// Removes receipts from all transactions starting with provided number (inclusive).
+    fn remove_receipts_from(
+        &self,
+        from_tx: TxNumber,
+        last_block: BlockNumber,
+    ) -> ProviderResult<()> {
+        // iterate over block body and remove receipts
+        self.remove::<tables::Receipts<ReceiptTy<N>>>(from_tx..)?;
+
+        if EitherWriter::receipts_destination(self).is_static_file() {
+            let static_file_receipt_num =
+                self.static_file_provider.get_highest_static_file_tx(StaticFileSegment::Receipts);
+
+            let to_delete = static_file_receipt_num
+                .map(|static_num| (static_num + 1).saturating_sub(from_tx))
+                .unwrap_or_default();
+
+            self.static_file_provider
+                .latest_writer(StaticFileSegment::Receipts)?
+                .prune_receipts(to_delete, last_block)?;
+        }
+
+        Ok(())
+    }
+
+    /// Writes bytecodes to MDBX.
+    fn write_bytecodes(
+        &self,
+        bytecodes: impl IntoIterator<Item = (B256, Bytecode)>,
+    ) -> ProviderResult<()> {
+        let mut bytecodes_cursor = self.tx_ref().cursor_write::<tables::Bytecodes>()?;
+        for (hash, bytecode) in bytecodes {
+            bytecodes_cursor.upsert(hash, &bytecode)?;
+        }
+        Ok(())
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for DatabaseProvider<TX, N> {
+    fn try_into_history_at_block(
+        self,
+        mut block_number: BlockNumber,
+    ) -> ProviderResult<StateProviderBox> {
+        let best_block = self.best_block_number().unwrap_or_default();
+
+        // Reject requests for blocks beyond the best block
+        if block_number > best_block {
+            return Err(ProviderError::BlockNotExecuted {
+                requested: block_number,
+                executed: best_block,
+            });
+        }
+
+        // If requesting state at the best block, use the latest state provider
+        if block_number == best_block {
+            return Ok(Box::new(LatestStateProvider::new(self)));
+        }
+
+        // +1 as the changeset that we want is the one that was applied after this block.
+        block_number += 1;
+
+        let account_history_prune_checkpoint =
+            self.get_prune_checkpoint(PruneSegment::AccountHistory)?;
+        let storage_history_prune_checkpoint =
+            self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
+        let changeset_cache = self.changeset_cache.clone();
+
+        let mut state_provider = HistoricalStateProvider::new(self, block_number, changeset_cache);
+
+        // If we pruned account or storage history, we can't return state on every historical block.
+        // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.
+        if let Some(prune_checkpoint_block_number) =
+            account_history_prune_checkpoint.and_then(|checkpoint| checkpoint.block_number)
+        {
+            state_provider = state_provider.with_lowest_available_account_history_block_number(
+                prune_checkpoint_block_number + 1,
+            );
+        }
+        if let Some(prune_checkpoint_block_number) =
+            storage_history_prune_checkpoint.and_then(|checkpoint| checkpoint.block_number)
+        {
+            state_provider = state_provider.with_lowest_available_storage_history_block_number(
+                prune_checkpoint_block_number + 1,
+            );
+        }
+
+        Ok(Box::new(state_provider))
+    }
+}
+
+/// For a given key, unwind all history shards that contain block numbers at or above the given
+/// block number.
+///
+/// S - Sharded key subtype.
+/// T - Table to walk over.
+/// C - Cursor implementation.
+///
+/// This function walks the entries from the given start key and deletes all shards that belong to
+/// the key and contain block numbers at or above the given block number. Shards entirely below
+/// the block number are preserved.
+///
+/// The boundary shard (the shard that spans across the block number) is removed from the database.
+/// Any indices that are below the block number are filtered out and returned for reinsertion.
+/// The boundary shard is returned for reinsertion (if it's not empty).
+fn unwind_history_shards<S, T, C>(
+    cursor: &mut C,
+    start_key: T::Key,
+    block_number: BlockNumber,
+    mut shard_belongs_to_key: impl FnMut(&T::Key) -> bool,
+) -> ProviderResult<Vec<u64>>
+where
+    T: Table<Value = BlockNumberList>,
+    T::Key: AsRef<ShardedKey<S>>,
+    C: DbCursorRO<T> + DbCursorRW<T>,
+{
+    // Start from the given key and iterate through shards
+    let mut item = cursor.seek_exact(start_key)?;
+    while let Some((sharded_key, list)) = item {
+        // If the shard does not belong to the key, break.
+        if !shard_belongs_to_key(&sharded_key) {
+            break
+        }
+
+        // Always delete the current shard from the database first
+        // We'll decide later what (if anything) to reinsert
+        cursor.delete_current()?;
+
+        // Get the first (lowest) block number in this shard
+        // All block numbers in a shard are sorted in ascending order
+        let first = list.iter().next().expect("List can't be empty");
+
+        // Case 1: Entire shard is at or above the unwinding point
+        // Keep it deleted (don't return anything for reinsertion)
+        if first >= block_number {
+            item = cursor.prev()?;
+            continue
+        }
+        // Case 2: This is a boundary shard (spans across the unwinding point)
+        // The shard contains some blocks below and some at/above the unwinding point
+        else if block_number <= sharded_key.as_ref().highest_block_number {
+            // Return only the block numbers that are below the unwinding point
+            // These will be reinserted to preserve the historical data
+            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>())
+        }
+        // Case 3: Entire shard is below the unwinding point
+        // Return all block numbers for reinsertion (preserve entire shard)
+        return Ok(list.iter().collect::<Vec<_>>())
+    }
+
+    // No shards found or all processed
+    Ok(Vec::new())
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
+    /// Creates a provider with an inner read-only transaction.
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
+        tx: TX,
+        chain_spec: Arc<N::ChainSpec>,
+        static_file_provider: StaticFileProvider<N::Primitives>,
+        prune_modes: PruneModes,
+        storage: Arc<N::Storage>,
+        storage_settings: Arc<RwLock<StorageSettings>>,
+        rocksdb_provider: RocksDBProvider,
+        changeset_cache: ChangesetCache,
+        runtime: reth_tasks::Runtime,
+        db_path: PathBuf,
+    ) -> Self {
+        Self {
+            tx,
+            chain_spec,
+            static_file_provider,
+            prune_modes,
+            storage,
+            storage_settings,
+            rocksdb_provider,
+            changeset_cache,
+            runtime,
+            db_path,
+            pending_rocksdb_batches: Default::default(),
+            commit_order: CommitOrder::Normal,
+            minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
+            metrics: metrics::DatabaseProviderMetrics::default(),
+            reader_txn_tracker: None,
+        }
+    }
+
+    /// Consume `DbTx` or `DbTxMut`.
+    pub fn into_tx(self) -> TX {
+        self.tx
+    }
+
+    /// Pass `DbTx` or `DbTxMut` mutable reference.
+    pub const fn tx_mut(&mut self) -> &mut TX {
+        &mut self.tx
+    }
+
+    /// Pass `DbTx` or `DbTxMut` immutable reference.
+    pub const fn tx_ref(&self) -> &TX {
+        &self.tx
+    }
+
+    /// Returns a reference to the chain specification.
+    pub fn chain_spec(&self) -> &N::ChainSpec {
+        &self.chain_spec
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
+    fn recovered_block<H, HF, B, BF>(
+        &self,
+        id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+        header_by_number: HF,
+        construct_block: BF,
+    ) -> ProviderResult<Option<B>>
+    where
+        H: AsRef<HeaderTy<N>>,
+        HF: FnOnce(BlockNumber) -> ProviderResult<Option<H>>,
+        BF: FnOnce(H, BodyTy<N>, Vec<Address>) -> ProviderResult<Option<B>>,
+    {
+        let Some(block_number) = self.convert_hash_or_number(id)? else { return Ok(None) };
+        let Some(header) = header_by_number(block_number)? else { return Ok(None) };
+
+        // Get the block body
+        //
+        // If the body indices are not found, this means that the transactions either do not exist
+        // in the database yet, or they do exit but are not indexed. If they exist but are not
+        // indexed, we don't have enough information to return the block anyways, so we return
+        // `None`.
+        let Some(body) = self.block_body_indices(block_number)? else { return Ok(None) };
+
+        let tx_range = body.tx_num_range();
+
+        let transactions = if tx_range.is_empty() {
+            vec![]
+        } else {
+            self.transactions_by_tx_range(tx_range.clone())?
+        };
+
+        let body = self
+            .storage
+            .reader()
+            .read_block_bodies(self, vec![(header.as_ref(), transactions)])?
+            .pop()
+            .ok_or(ProviderError::InvalidStorageOutput)?;
+
+        let senders = if tx_range.is_empty() {
+            vec![]
+        } else {
+            let known_senders: HashMap<TxNumber, Address> =
+                EitherReader::new_senders(self)?.senders_by_tx_range(tx_range.clone())?;
+
+            let mut senders = Vec::with_capacity(body.transactions().len());
+            for (tx_num, tx) in tx_range.zip(body.transactions()) {
+                match known_senders.get(&tx_num) {
+                    None => {
+                        let sender = tx.recover_signer_unchecked()?;
+                        senders.push(sender);
+                    }
+                    Some(sender) => senders.push(*sender),
+                }
+            }
+            senders
+        };
+
+        construct_block(header, body, senders)
+    }
+
+    /// Returns a range of blocks from the database.
+    ///
+    /// Uses the provided `headers_range` to get the headers for the range, and `assemble_block` to
+    /// construct blocks from the following inputs:
+    ///     – Header
+    ///     - Range of transaction numbers
+    ///     – Ommers
+    ///     – Withdrawals
+    ///     – Senders
+    fn block_range<F, H, HF, R>(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+        headers_range: HF,
+        mut assemble_block: F,
+    ) -> ProviderResult<Vec<R>>
+    where
+        H: AsRef<HeaderTy<N>>,
+        HF: FnOnce(RangeInclusive<BlockNumber>) -> ProviderResult<Vec<H>>,
+        F: FnMut(H, BodyTy<N>, Range<TxNumber>) -> ProviderResult<R>,
+    {
+        if range.is_empty() {
+            return Ok(Vec::new())
+        }
+
+        let len = range.end().saturating_sub(*range.start()) as usize + 1;
+        let mut blocks = Vec::with_capacity(len);
+
+        let headers = headers_range(range.clone())?;
+
+        // If the body indices are not found, this means that the transactions either do
+        // not exist in the database yet, or they do exit but are
+        // not indexed. If they exist but are not indexed, we don't
+        // have enough information to return the block anyways, so
+        // we skip the block.
+        let present_headers = self
+            .block_body_indices_range(range)?
+            .into_iter()
+            .map(|b| b.tx_num_range())
+            .zip(headers)
+            .collect::<Vec<_>>();
+
+        let mut inputs = Vec::with_capacity(present_headers.len());
+        for (tx_range, header) in &present_headers {
+            let transactions = if tx_range.is_empty() {
+                Vec::new()
+            } else {
+                self.transactions_by_tx_range(tx_range.clone())?
+            };
+
+            inputs.push((header.as_ref(), transactions));
+        }
+
+        let bodies = self.storage.reader().read_block_bodies(self, inputs)?;
+
+        for ((tx_range, header), body) in present_headers.into_iter().zip(bodies) {
+            blocks.push(assemble_block(header, body, tx_range)?);
+        }
+
+        Ok(blocks)
+    }
+
+    /// Returns a range of blocks from the database, along with the senders of each
+    /// transaction in the blocks.
+    ///
+    /// Uses the provided `headers_range` to get the headers for the range, and `assemble_block` to
+    /// construct blocks from the following inputs:
+    ///     – Header
+    ///     - Transactions
+    ///     – Ommers
+    ///     – Withdrawals
+    ///     – Senders
+    fn block_with_senders_range<H, HF, B, BF>(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+        headers_range: HF,
+        assemble_block: BF,
+    ) -> ProviderResult<Vec<B>>
+    where
+        H: AsRef<HeaderTy<N>>,
+        HF: Fn(RangeInclusive<BlockNumber>) -> ProviderResult<Vec<H>>,
+        BF: Fn(H, BodyTy<N>, Vec<Address>) -> ProviderResult<B>,
+    {
+        self.block_range(range, headers_range, |header, body, tx_range| {
+            let senders = if tx_range.is_empty() {
+                Vec::new()
+            } else {
+                let known_senders: HashMap<TxNumber, Address> =
+                    EitherReader::new_senders(self)?.senders_by_tx_range(tx_range.clone())?;
+
+                let mut senders = Vec::with_capacity(body.transactions().len());
+                for (tx_num, tx) in tx_range.zip(body.transactions()) {
+                    match known_senders.get(&tx_num) {
+                        None => {
+                            // recover the sender from the transaction if not found
+                            let sender = tx.recover_signer_unchecked()?;
+                            senders.push(sender);
+                        }
+                        Some(sender) => senders.push(*sender),
+                    }
+                }
+
+                senders
+            };
+
+            assemble_block(header, body, senders)
+        })
+    }
+
+    /// Populate a [`BundleStateInit`] and [`RevertsInit`] using cursors over the
+    /// [`tables::PlainAccountState`] and [`tables::PlainStorageState`] tables, based on the given
+    /// storage and account changesets.
+    fn populate_bundle_state(
+        &self,
+        account_changeset: Vec<(u64, AccountBeforeTx)>,
+        storage_changeset: Vec<(BlockNumberAddress, StorageEntry)>,
+        mut get_account: impl FnMut(Address) -> ProviderResult<Option<Account>>,
+        mut get_storage: impl FnMut(Address, StorageKey) -> ProviderResult<Option<StorageValue>>,
+    ) -> ProviderResult<(BundleStateInit, RevertsInit)> {
+        // iterate previous value and get plain state value to create changeset
+        // Double option around Account represent if Account state is know (first option) and
+        // account is removed (Second Option)
+        let mut state: BundleStateInit = HashMap::default();
+
+        // This is not working for blocks that are not at tip. as plain state is not the last
+        // state of end range. We should rename the functions or add support to access
+        // History state. Accessing history state can be tricky but we are not gaining
+        // anything.
+
+        let mut reverts: RevertsInit = HashMap::default();
+
+        // add account changeset changes
+        for (block_number, account_before) in account_changeset.into_iter().rev() {
+            let AccountBeforeTx { info: old_info, address } = account_before;
+            match state.entry(address) {
+                hash_map::Entry::Vacant(entry) => {
+                    let new_info = get_account(address)?;
+                    entry.insert((old_info, new_info, HashMap::default()));
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    // overwrite old account state.
+                    entry.get_mut().0 = old_info;
+                }
+            }
+            // insert old info into reverts.
+            reverts.entry(block_number).or_default().entry(address).or_default().0 = Some(old_info);
+        }
+
+        // add storage changeset changes
+        for (block_and_address, old_storage) in storage_changeset.into_iter().rev() {
+            let BlockNumberAddress((block_number, address)) = block_and_address;
+            // get account state or insert from plain state.
+            let account_state = match state.entry(address) {
+                hash_map::Entry::Vacant(entry) => {
+                    let present_info = get_account(address)?;
+                    entry.insert((present_info, present_info, HashMap::default()))
+                }
+                hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            };
+
+            // match storage.
+            match account_state.2.entry(old_storage.key) {
+                hash_map::Entry::Vacant(entry) => {
+                    let new_storage = get_storage(address, old_storage.key)?.unwrap_or_default();
+                    entry.insert((old_storage.value, new_storage));
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().0 = old_storage.value;
+                }
+            };
+
+            reverts
+                .entry(block_number)
+                .or_default()
+                .entry(address)
+                .or_default()
+                .1
+                .push(old_storage);
+        }
+
+        Ok((state, reverts))
+    }
+
+    /// Invokes [`populate_bundle_state`](Self::populate_bundle_state) with the given plain state
+    /// cursors.
+    fn populate_bundle_state_plain(
+        &self,
+        account_changeset: Vec<(u64, AccountBeforeTx)>,
+        storage_changeset: Vec<(BlockNumberAddress, StorageEntry)>,
+        plain_accounts_cursor: &mut impl DbCursorRO<tables::PlainAccountState>,
+        plain_storage_cursor: &mut impl DbDupCursorRO<tables::PlainStorageState>,
+    ) -> ProviderResult<(BundleStateInit, RevertsInit)> {
+        self.populate_bundle_state(
+            account_changeset,
+            storage_changeset,
+            |address| Ok(plain_accounts_cursor.seek_exact(address)?.map(|kv| kv.1)),
+            |address, storage_key| {
+                Ok(plain_storage_cursor
+                    .seek_by_key_subkey(address, storage_key)?
+                    .filter(|s| s.key == storage_key)
+                    .map(|s| s.value))
+            },
+        )
+    }
+
+    /// Like [`populate_bundle_state`](Self::populate_bundle_state), but reads current values from
+    /// `HashedAccounts`/`HashedStorages`. Addresses and storage keys are hashed via `keccak256`
+    /// for DB lookups. The output `BundleStateInit`/`RevertsInit` structures remain keyed by
+    /// plain address and plain storage key.
+    fn populate_bundle_state_hashed(
+        &self,
+        account_changeset: Vec<(u64, AccountBeforeTx)>,
+        storage_changeset: Vec<(BlockNumberAddress, StorageEntry)>,
+        hashed_accounts_cursor: &mut impl DbCursorRO<tables::HashedAccounts>,
+        hashed_storage_cursor: &mut impl DbDupCursorRO<tables::HashedStorages>,
+    ) -> ProviderResult<(BundleStateInit, RevertsInit)> {
+        self.populate_bundle_state(
+            account_changeset,
+            storage_changeset,
+            |address| Ok(hashed_accounts_cursor.seek_exact(keccak256(address))?.map(|kv| kv.1)),
+            |address, storage_key| {
+                let hashed_storage_key = keccak256(storage_key);
+                Ok(hashed_storage_cursor
+                    .seek_by_key_subkey(keccak256(address), hashed_storage_key)?
+                    .filter(|s| s.key == hashed_storage_key)
+                    .map(|s| s.value))
+            },
+        )
+    }
+
+    fn populate_bundle_state_with_provider(
+        &self,
+        account_changeset: Vec<(u64, AccountBeforeTx)>,
+        storage_changeset: Vec<(BlockNumberAddress, StorageEntry)>,
+        state_provider: impl StateProvider,
+    ) -> ProviderResult<(BundleStateInit, RevertsInit)> {
+        self.populate_bundle_state(
+            account_changeset,
+            storage_changeset,
+            |address| state_provider.basic_account(&address),
+            |address, storage_key| state_provider.storage(address, storage_key),
+        )
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Insert history index to the database.
+    ///
+    /// For each updated partial key, this function retrieves the last shard from the database
+    /// (if any), appends the new indices to it, chunks the resulting list if needed, and upserts
+    /// the shards back into the database.
+    ///
+    /// This function is used by history indexing stages.
+    fn append_history_index<P, T>(
+        &self,
+        index_updates: impl IntoIterator<Item = (P, impl IntoIterator<Item = u64>)>,
+        mut sharded_key_factory: impl FnMut(P, BlockNumber) -> T::Key,
+    ) -> ProviderResult<()>
+    where
+        P: Copy,
+        T: Table<Value = BlockNumberList>,
+    {
+        // This function cannot be used with DUPSORT tables because `upsert` on DUPSORT tables
+        // will append duplicate entries instead of updating existing ones, causing data corruption.
+        assert!(!T::DUPSORT, "append_history_index cannot be used with DUPSORT tables");
+
+        let mut cursor = self.tx.cursor_write::<T>()?;
+
+        for (partial_key, indices) in index_updates {
+            let last_key = sharded_key_factory(partial_key, u64::MAX);
+            let mut last_shard = cursor
+                .seek_exact(last_key.clone())?
+                .map(|(_, list)| list)
+                .unwrap_or_else(BlockNumberList::empty);
+
+            last_shard.append(indices).map_err(ProviderError::other)?;
+
+            // fast path: all indices fit in one shard
+            if last_shard.len() <= sharded_key::NUM_OF_INDICES_IN_SHARD as u64 {
+                cursor.upsert(last_key, &last_shard)?;
+                continue;
+            }
+
+            // slow path: rechunk into multiple shards
+            let chunks = last_shard.iter().chunks(sharded_key::NUM_OF_INDICES_IN_SHARD);
+            let mut chunks_peekable = chunks.into_iter().peekable();
+
+            while let Some(chunk) = chunks_peekable.next() {
+                let shard = BlockNumberList::new_pre_sorted(chunk);
+                let highest_block_number = if chunks_peekable.peek().is_some() {
+                    shard.iter().next_back().expect("`chunks` does not return empty list")
+                } else {
+                    // Insert last list with `u64::MAX`.
+                    u64::MAX
+                };
+
+                cursor.upsert(sharded_key_factory(partial_key, highest_block_number), &shard)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<TX: DbTx, N: NodeTypes> AccountReader for DatabaseProvider<TX, N> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        if self.cached_storage_settings().use_hashed_state() {
+            let hashed_address = keccak256(address);
+            Ok(self.tx.get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)?)
+        } else {
+            Ok(self.tx.get_by_encoded_key::<tables::PlainAccountState>(address)?)
+        }
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> AccountExtReader for DatabaseProvider<TX, N> {
+    fn changed_accounts_with_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<BTreeSet<Address>> {
+        let mut reader = EitherReader::new_account_changesets(self)?;
+
+        reader.changed_accounts_with_range(range)
+    }
+
+    fn basic_accounts(
+        &self,
+        iter: impl IntoIterator<Item = Address>,
+    ) -> ProviderResult<Vec<(Address, Option<Account>)>> {
+        if self.cached_storage_settings().use_hashed_state() {
+            let mut hashed_accounts = self.tx.cursor_read::<tables::HashedAccounts>()?;
+            Ok(iter
+                .into_iter()
+                .map(|address| {
+                    let hashed_address = keccak256(address);
+                    hashed_accounts.seek_exact(hashed_address).map(|a| (address, a.map(|(_, v)| v)))
+                })
+                .collect::<Result<Vec<_>, _>>()?)
+        } else {
+            let mut plain_accounts = self.tx.cursor_read::<tables::PlainAccountState>()?;
+            Ok(iter
+                .into_iter()
+                .map(|address| {
+                    plain_accounts.seek_exact(address).map(|a| (address, a.map(|(_, v)| v)))
+                })
+                .collect::<Result<Vec<_>, _>>()?)
+        }
+    }
+
+    fn changed_accounts_and_blocks_with_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<BTreeMap<Address, Vec<u64>>> {
+        let highest_static_block = self
+            .static_file_provider
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
+
+        if let Some(highest) = highest_static_block &&
+            self.cached_storage_settings().storage_v2
+        {
+            let start = *range.start();
+            let static_end = (*range.end()).min(highest);
+
+            let mut changed_accounts_and_blocks: BTreeMap<_, Vec<u64>> = BTreeMap::default();
+            if start <= static_end {
+                for block in start..=static_end {
+                    let block_changesets = self.account_block_changeset(block)?;
+                    for changeset in block_changesets {
+                        changed_accounts_and_blocks
+                            .entry(changeset.address)
+                            .or_default()
+                            .push(block);
+                    }
+                }
+            }
+
+            Ok(changed_accounts_and_blocks)
+        } else {
+            let mut changeset_cursor = self.tx.cursor_read::<tables::AccountChangeSets>()?;
+
+            let account_transitions = changeset_cursor.walk_range(range)?.try_fold(
+                BTreeMap::new(),
+                |mut accounts: BTreeMap<Address, Vec<u64>>, entry| -> ProviderResult<_> {
+                    let (index, account) = entry?;
+                    accounts.entry(account.address).or_default().push(index);
+                    Ok(accounts)
+                },
+            )?;
+
+            Ok(account_transitions)
+        }
+    }
+}
+
+impl<TX: DbTx, N: NodeTypes> StorageChangeSetReader for DatabaseProvider<TX, N> {
+    fn storage_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        if self.cached_storage_settings().storage_v2 {
+            self.static_file_provider.storage_changeset(block_number)
+        } else {
+            let range = block_number..=block_number;
+            let storage_range = BlockNumberAddress::range(range);
+            self.tx
+                .cursor_dup_read::<tables::StorageChangeSets>()?
+                .walk_range(storage_range)?
+                .map(|r| {
+                    let (bna, entry) = r?;
+                    Ok((bna, entry))
+                })
+                .collect()
+        }
+    }
+
+    fn get_storage_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+        storage_key: B256,
+    ) -> ProviderResult<Option<StorageEntry>> {
+        if self.cached_storage_settings().storage_v2 {
+            self.static_file_provider.get_storage_before_block(block_number, address, storage_key)
+        } else {
+            Ok(self
+                .tx
+                .cursor_dup_read::<tables::StorageChangeSets>()?
+                .seek_by_key_subkey(BlockNumberAddress((block_number, address)), storage_key)?
+                .filter(|entry| entry.key == storage_key))
+        }
+    }
+
+    fn storage_changesets_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        if self.cached_storage_settings().storage_v2 {
+            self.static_file_provider.storage_changesets_range(range)
+        } else {
+            self.tx
+                .cursor_dup_read::<tables::StorageChangeSets>()?
+                .walk_range(BlockNumberAddressRange::from(range))?
+                .map(|r| {
+                    let (bna, entry) = r?;
+                    Ok((bna, entry))
+                })
+                .collect()
+        }
+    }
+}
+
+impl<TX: DbTx, N: NodeTypes> ChangeSetReader for DatabaseProvider<TX, N> {
+    fn account_block_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
+        if self.cached_storage_settings().storage_v2 {
+            let static_changesets =
+                self.static_file_provider.account_block_changeset(block_number)?;
+            Ok(static_changesets)
+        } else {
+            let range = block_number..=block_number;
+            self.tx
+                .cursor_read::<tables::AccountChangeSets>()?
+                .walk_range(range)?
+                .map(|result| -> ProviderResult<_> {
+                    let (_, account_before) = result?;
+                    Ok(account_before)
+                })
+                .collect()
+        }
+    }
+
+    fn get_account_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+    ) -> ProviderResult<Option<AccountBeforeTx>> {
+        if self.cached_storage_settings().storage_v2 {
+            Ok(self.static_file_provider.get_account_before_block(block_number, address)?)
+        } else {
+            self.tx
+                .cursor_dup_read::<tables::AccountChangeSets>()?
+                .seek_by_key_subkey(block_number, address)?
+                .filter(|acc| acc.address == address)
+                .map(Ok)
+                .transpose()
+        }
+    }
+
+    fn account_changesets_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
+        if self.cached_storage_settings().storage_v2 {
+            self.static_file_provider.account_changesets_range(range)
+        } else {
+            self.tx
+                .cursor_read::<tables::AccountChangeSets>()?
+                .walk_range(to_range(range))?
+                .map(|r| r.map_err(Into::into))
+                .collect()
+        }
+    }
+}
+
+impl<Tx: DbTx + 'static, N: NodeTypesForProvider> StateReader for DatabaseProvider<Tx, N> {
+    type Receipt = ReceiptTy<N>;
+
+    fn get_state(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+        let Some(block_body) = self.block_body_indices(block)? else { return Ok(None) };
+
+        let from_transaction_num = block_body.first_tx_num();
+        let to_transaction_num = block_body.last_tx_num();
+
+        let account_changeset = self.account_changesets_range(block..=block)?;
+        let storage_changeset = self.storage_changeset(block)?;
+
+        let Some(block_hash) = self.block_hash(block)? else { return Ok(None) };
+        let state_provider = self.history_by_block_hash(block_hash)?;
+        let (state, reverts) = self.populate_bundle_state_with_provider(
+            account_changeset,
+            storage_changeset,
+            state_provider,
+        )?;
+
+        let receipts = self.receipts_by_tx_range(from_transaction_num..=to_transaction_num)?;
+
+        Ok(Some(ExecutionOutcome::new_init(
+            state,
+            reverts,
+            // We skip new contracts since we never delete them from the database
+            Vec::new(),
+            vec![receipts],
+            block,
+            Vec::new(),
+        )))
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderSyncGapProvider
+    for DatabaseProvider<TX, N>
+{
+    type Header = HeaderTy<N>;
+
+    fn local_tip_header(
+        &self,
+        highest_uninterrupted_block: BlockNumber,
+    ) -> ProviderResult<SealedHeader<Self::Header>> {
+        let static_file_provider = self.static_file_provider();
+
+        // Make sure Headers static file is at the same height. If it's further, this
+        // input execution was interrupted previously and we need to unwind the static file.
+        let next_static_file_block_num = static_file_provider
+            .get_highest_static_file_block(StaticFileSegment::Headers)
+            .map(|id| id + 1)
+            .unwrap_or_default();
+        let next_block = highest_uninterrupted_block + 1;
+
+        match next_static_file_block_num.cmp(&next_block) {
+            // The node shutdown between an executed static file commit and before the database
+            // commit, so we need to unwind the static files.
+            Ordering::Greater => {
+                let mut static_file_producer =
+                    static_file_provider.latest_writer(StaticFileSegment::Headers)?;
+                static_file_producer.prune_headers(next_static_file_block_num - next_block)?;
+                // Since this is a database <-> static file inconsistency, we commit the change
+                // straight away.
+                static_file_producer.commit()?
+            }
+            Ordering::Less => {
+                // There's either missing or corrupted files.
+                return Err(ProviderError::HeaderNotFound(next_static_file_block_num.into()))
+            }
+            Ordering::Equal => {}
+        }
+
+        let local_head = static_file_provider
+            .sealed_header(highest_uninterrupted_block)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(highest_uninterrupted_block.into()))?;
+
+        Ok(local_head)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabaseProvider<TX, N> {
+    type Header = HeaderTy<N>;
+
+    fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        if let Some(num) = self.block_number(block_hash)? {
+            Ok(self.header_by_number(num)?)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+        self.static_file_provider.header_by_number(num)
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
+        self.static_file_provider.headers_range(range)
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        self.static_file_provider.sealed_header(number)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.static_file_provider.sealed_headers_while(range, predicate)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> BlockHashReader for DatabaseProvider<TX, N> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.static_file_provider.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.static_file_provider.canonical_hashes_range(start, end)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> BlockNumReader for DatabaseProvider<TX, N> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        let best_number = self.best_block_number()?;
+        let best_hash = self.block_hash(best_number)?.unwrap_or_default();
+        Ok(ChainInfo { best_hash, best_number })
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        // The best block number is tracked via the finished stage which gets updated in the same tx
+        // when new blocks committed
+        Ok(self
+            .get_stage_checkpoint(StageId::Finish)?
+            .map(|checkpoint| checkpoint.block_number)
+            .unwrap_or_default())
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.static_file_provider.last_block_number()
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        Ok(self.tx.get::<tables::HeaderNumbers>(hash)?)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvider<TX, N> {
+    type Block = BlockTy<N>;
+
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        source: BlockSource,
+    ) -> ProviderResult<Option<Self::Block>> {
+        if source.is_canonical() {
+            self.block(hash.into())
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Returns the block with matching number from database.
+    ///
+    /// If the header for this block is not found, this returns `None`.
+    /// If the header is found, but the transactions either do not exist, or are not indexed, this
+    /// will return None.
+    ///
+    /// Returns an error if the requested block is below the earliest available history.
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+        if let Some(number) = self.convert_hash_or_number(id)? {
+            let earliest_available = self.static_file_provider.earliest_history_height();
+            if number < earliest_available {
+                return Err(ProviderError::BlockExpired { requested: number, earliest_available })
+            }
+
+            let Some(header) = self.header_by_number(number)? else { return Ok(None) };
+
+            // If the body indices are not found, this means that the transactions either do not
+            // exist in the database yet, or they do exit but are not indexed.
+            // If they exist but are not indexed, we don't have enough
+            // information to return the block anyways, so we return `None`.
+            let Some(transactions) = self.transactions_by_block(number.into())? else {
+                return Ok(None)
+            };
+
+            let body = self
+                .storage
+                .reader()
+                .read_block_bodies(self, vec![(&header, transactions)])?
+                .pop()
+                .ok_or(ProviderError::InvalidStorageOutput)?;
+
+            return Ok(Some(Self::Block::new(header, body)))
+        }
+
+        Ok(None)
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn pending_block_and_receipts(
+        &self,
+    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<Self::Receipt>)>> {
+        Ok(None)
+    }
+
+    /// Returns the block with senders with matching number or hash from database.
+    ///
+    /// **NOTE: The transactions have invalid hashes, since they would need to be calculated on the
+    /// spot, and we want fast querying.**
+    ///
+    /// If the header for this block is not found, this returns `None`.
+    /// If the header is found, but the transactions either do not exist, or are not indexed, this
+    /// will return None.
+    fn recovered_block(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.recovered_block(
+            id,
+            transaction_kind,
+            |block_number| self.header_by_number(block_number),
+            |header, body, senders| {
+                Self::Block::new(header, body)
+                    // Note: we're using unchecked here because we know the block contains valid txs
+                    // wrt to its height and can ignore the s value check so pre
+                    // EIP-2 txs are allowed
+                    .try_into_recovered_unchecked(senders)
+                    .map(Some)
+                    .map_err(|_| ProviderError::SenderRecoveryError)
+            },
+        )
+    }
+
+    fn sealed_block_with_senders(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        self.recovered_block(
+            id,
+            transaction_kind,
+            |block_number| self.sealed_header(block_number),
+            |header, body, senders| {
+                Self::Block::new_sealed(header, body)
+                    // Note: we're using unchecked here because we know the block contains valid txs
+                    // wrt to its height and can ignore the s value check so pre
+                    // EIP-2 txs are allowed
+                    .try_with_senders_unchecked(senders)
+                    .map(Some)
+                    .map_err(|_| ProviderError::SenderRecoveryError)
+            },
+        )
+    }
+
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
+        self.block_range(
+            range,
+            |range| self.headers_range(range),
+            |header, body, _| Ok(Self::Block::new(header, body)),
+        )
+    }
+
+    fn block_with_senders_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.block_with_senders_range(
+            range,
+            |range| self.headers_range(range),
+            |header, body, senders| {
+                Self::Block::new(header, body)
+                    .try_into_recovered_unchecked(senders)
+                    .map_err(|_| ProviderError::SenderRecoveryError)
+            },
+        )
+    }
+
+    fn recovered_block_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        self.block_with_senders_range(
+            range,
+            |range| self.sealed_headers_range(range),
+            |header, body, senders| {
+                Self::Block::new_sealed(header, body)
+                    .try_with_senders(senders)
+                    .map_err(|_| ProviderError::SenderRecoveryError)
+            },
+        )
+    }
+
+    fn block_by_transaction_id(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        Ok(self
+            .tx
+            .cursor_read::<tables::TransactionBlocks>()?
+            .seek(id)
+            .map(|b| b.map(|(_, bn)| bn))?)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProviderExt
+    for DatabaseProvider<TX, N>
+{
+    /// Recovers transaction hashes by walking through `Transactions` table and
+    /// calculating them in a parallel manner. Returned unsorted.
+    fn transaction_hashes_by_range(
+        &self,
+        tx_range: Range<TxNumber>,
+    ) -> ProviderResult<Vec<(TxHash, TxNumber)>> {
+        self.static_file_provider.transaction_hashes_by_range(tx_range)
+    }
+}
+
+// Calculates the hash of the given transaction
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for DatabaseProvider<TX, N> {
+    type Transaction = TxTy<N>;
+
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        self.with_rocksdb_snapshot(|rocksdb_ref| {
+            let mut reader = EitherReader::new_transaction_hash_numbers(self, rocksdb_ref)?;
+            reader.get_transaction_hash_number(tx_hash)
+        })
+    }
+
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        self.static_file_provider.transaction_by_id(id)
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        id: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        self.static_file_provider.transaction_by_id_unhashed(id)
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        if let Some(id) = self.transaction_id(hash)? {
+            Ok(self.transaction_by_id_unhashed(id)?)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        if let Some(transaction_id) = self.transaction_id(tx_hash)? &&
+            let Some(transaction) = self.transaction_by_id_unhashed(transaction_id)? &&
+            let Some(block_number) = self.block_by_transaction_id(transaction_id)? &&
+            let Some(sealed_header) = self.sealed_header(block_number)?
+        {
+            let (header, block_hash) = sealed_header.split();
+            if let Some(block_body) = self.block_body_indices(block_number)? {
+                // the index of the tx in the block is the offset:
+                // len([start..tx_id])
+                // NOTE: `transaction_id` is always `>=` the block's first
+                // index
+                let index = transaction_id - block_body.first_tx_num();
+
+                let meta = TransactionMeta {
+                    tx_hash,
+                    index,
+                    block_hash,
+                    block_number,
+                    base_fee: header.base_fee_per_gas(),
+                    excess_blob_gas: header.excess_blob_gas(),
+                    timestamp: header.timestamp(),
+                };
+
+                return Ok(Some((transaction, meta)))
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn transactions_by_block(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        if let Some(block_number) = self.convert_hash_or_number(id)? &&
+            let Some(body) = self.block_body_indices(block_number)?
+        {
+            let tx_range = body.tx_num_range();
+            return if tx_range.is_empty() {
+                Ok(Some(Vec::new()))
+            } else {
+                self.transactions_by_tx_range(tx_range).map(Some)
+            }
+        }
+        Ok(None)
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        let range = to_range(range);
+
+        self.block_body_indices_range(range.start..=range.end.saturating_sub(1))?
+            .into_iter()
+            .map(|body| {
+                let tx_num_range = body.tx_num_range();
+                if tx_num_range.is_empty() {
+                    Ok(Vec::new())
+                } else {
+                    self.transactions_by_tx_range(tx_num_range)
+                }
+            })
+            .collect()
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        self.static_file_provider.transactions_by_tx_range(range)
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        if EitherWriterDestination::senders(self).is_static_file() {
+            self.static_file_provider.senders_by_tx_range(range)
+        } else {
+            self.cursor_read_collect::<tables::TransactionSenders>(range)
+        }
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        if EitherWriterDestination::senders(self).is_static_file() {
+            self.static_file_provider.transaction_sender(id)
+        } else {
+            Ok(self.tx.get::<tables::TransactionSenders>(id)?)
+        }
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabaseProvider<TX, N> {
+    type Receipt = ReceiptTy<N>;
+
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::Receipts,
+            id,
+            |static_file| static_file.receipt(id),
+            || Ok(self.tx.get::<tables::Receipts<Self::Receipt>>(id)?),
+        )
+    }
+
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+        if let Some(id) = self.transaction_id(hash)? {
+            self.receipt(id)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        if let Some(number) = self.convert_hash_or_number(block)? &&
+            let Some(body) = self.block_body_indices(number)?
+        {
+            let tx_range = body.tx_num_range();
+            return if tx_range.is_empty() {
+                Ok(Some(Vec::new()))
+            } else {
+                self.receipts_by_tx_range(tx_range).map(Some)
+            }
+        }
+        Ok(None)
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Receipt>> {
+        self.static_file_provider.get_range_with_static_file_or_database(
+            StaticFileSegment::Receipts,
+            to_range(range),
+            |static_file, range, _| static_file.receipts_by_tx_range(range),
+            |range, _| self.cursor_read_collect::<tables::Receipts<Self::Receipt>>(range),
+            |_| true,
+        )
+    }
+
+    fn receipts_by_block_range(
+        &self,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+        if block_range.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // collect block body indices for each block in the range
+        let range_len = block_range.end().saturating_sub(*block_range.start()) as usize + 1;
+        let mut block_body_indices = Vec::with_capacity(range_len);
+        for block_num in block_range {
+            if let Some(indices) = self.block_body_indices(block_num)? {
+                block_body_indices.push(indices);
+            } else {
+                // use default indices for missing blocks (empty block)
+                block_body_indices.push(StoredBlockBodyIndices::default());
+            }
+        }
+
+        if block_body_indices.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // find blocks with transactions to determine transaction range
+        let non_empty_blocks: Vec<_> =
+            block_body_indices.iter().filter(|indices| indices.tx_count > 0).collect();
+
+        if non_empty_blocks.is_empty() {
+            // all blocks are empty
+            return Ok(vec![Vec::new(); block_body_indices.len()]);
+        }
+
+        // calculate the overall transaction range
+        let first_tx = non_empty_blocks[0].first_tx_num();
+        let last_tx = non_empty_blocks[non_empty_blocks.len() - 1].last_tx_num();
+
+        // fetch all receipts in the transaction range
+        let all_receipts = self.receipts_by_tx_range(first_tx..=last_tx)?;
+        let mut receipts_iter = all_receipts.into_iter();
+
+        // distribute receipts to their respective blocks
+        let mut result = Vec::with_capacity(block_body_indices.len());
+        for indices in &block_body_indices {
+            if indices.tx_count == 0 {
+                result.push(Vec::new());
+            } else {
+                let block_receipts =
+                    receipts_iter.by_ref().take(indices.tx_count as usize).collect();
+                result.push(block_receipts);
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockBodyIndicesProvider
+    for DatabaseProvider<TX, N>
+{
+    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        Ok(self.tx.get::<tables::BlockBodyIndices>(num)?)
+    }
+
+    fn block_body_indices_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        self.cursor_read_collect::<tables::BlockBodyIndices>(range)
+    }
+}
+
+impl<TX: DbTx, N: NodeTypes> StageCheckpointReader for DatabaseProvider<TX, N> {
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
+        Ok(if let Some(encoded) = id.get_pre_encoded() {
+            self.tx.get_by_encoded_key::<tables::StageCheckpoints>(encoded)?
+        } else {
+            self.tx.get::<tables::StageCheckpoints>(id.to_string())?
+        })
+    }
+
+    /// Get stage checkpoint progress.
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>> {
+        Ok(self.tx.get::<tables::StageCheckpointProgresses>(id.to_string())?)
+    }
+
+    fn get_all_checkpoints(&self) -> ProviderResult<Vec<(String, StageCheckpoint)>> {
+        self.tx
+            .cursor_read::<tables::StageCheckpoints>()?
+            .walk(None)?
+            .collect::<Result<Vec<(String, StageCheckpoint)>, _>>()
+            .map_err(ProviderError::Database)
+    }
+}
+
+impl<TX: DbTxMut, N: NodeTypes> StageCheckpointWriter for DatabaseProvider<TX, N> {
+    /// Save stage checkpoint.
+    fn save_stage_checkpoint(
+        &self,
+        id: StageId,
+        checkpoint: StageCheckpoint,
+    ) -> ProviderResult<()> {
+        Ok(self.tx.put::<tables::StageCheckpoints>(id.to_string(), checkpoint)?)
+    }
+
+    /// Save stage checkpoint progress.
+    fn save_stage_checkpoint_progress(
+        &self,
+        id: StageId,
+        checkpoint: Vec<u8>,
+    ) -> ProviderResult<()> {
+        Ok(self.tx.put::<tables::StageCheckpointProgresses>(id.to_string(), checkpoint)?)
+    }
+
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn update_pipeline_stages(
+        &self,
+        block_number: BlockNumber,
+        drop_stage_checkpoint: bool,
+    ) -> ProviderResult<()> {
+        // iterate over all existing stages in the table and update its progress.
+        let mut cursor = self.tx.cursor_write::<tables::StageCheckpoints>()?;
+        for stage_id in StageId::ALL {
+            let (_, checkpoint) = cursor.seek_exact(stage_id.to_string())?.unwrap_or_default();
+            cursor.upsert(
+                stage_id.to_string(),
+                &StageCheckpoint {
+                    block_number,
+                    ..if drop_stage_checkpoint { Default::default() } else { checkpoint }
+                },
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> StorageReader for DatabaseProvider<TX, N> {
+    fn plain_state_storages(
+        &self,
+        addresses_with_keys: impl IntoIterator<Item = (Address, impl IntoIterator<Item = B256>)>,
+    ) -> ProviderResult<Vec<(Address, Vec<StorageEntry>)>> {
+        if self.cached_storage_settings().use_hashed_state() {
+            let mut hashed_storage = self.tx.cursor_dup_read::<tables::HashedStorages>()?;
+
+            addresses_with_keys
+                .into_iter()
+                .map(|(address, storage)| {
+                    let hashed_address = keccak256(address);
+                    storage
+                        .into_iter()
+                        .map(|key| -> ProviderResult<_> {
+                            let hashed_key = keccak256(key);
+                            let value = hashed_storage
+                                .seek_by_key_subkey(hashed_address, hashed_key)?
+                                .filter(|v| v.key == hashed_key)
+                                .map(|v| v.value)
+                                .unwrap_or_default();
+                            Ok(StorageEntry { key, value })
+                        })
+                        .collect::<ProviderResult<Vec<_>>>()
+                        .map(|storage| (address, storage))
+                })
+                .collect::<ProviderResult<Vec<(_, _)>>>()
+        } else {
+            let mut plain_storage = self.tx.cursor_dup_read::<tables::PlainStorageState>()?;
+
+            addresses_with_keys
+                .into_iter()
+                .map(|(address, storage)| {
+                    storage
+                        .into_iter()
+                        .map(|key| -> ProviderResult<_> {
+                            Ok(plain_storage
+                                .seek_by_key_subkey(address, key)?
+                                .filter(|v| v.key == key)
+                                .unwrap_or_else(|| StorageEntry { key, value: Default::default() }))
+                        })
+                        .collect::<ProviderResult<Vec<_>>>()
+                        .map(|storage| (address, storage))
+                })
+                .collect::<ProviderResult<Vec<(_, _)>>>()
+        }
+    }
+
+    fn changed_storages_with_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<BTreeMap<Address, BTreeSet<B256>>> {
+        if self.cached_storage_settings().storage_v2 {
+            self.storage_changesets_range(range)?.into_iter().try_fold(
+                BTreeMap::new(),
+                |mut accounts: BTreeMap<Address, BTreeSet<B256>>, entry| {
+                    let (BlockNumberAddress((_, address)), storage_entry) = entry;
+                    accounts.entry(address).or_default().insert(storage_entry.key);
+                    Ok(accounts)
+                },
+            )
+        } else {
+            self.tx
+                .cursor_read::<tables::StorageChangeSets>()?
+                .walk_range(BlockNumberAddress::range(range))?
+                // fold all storages and save its old state so we can remove it from HashedStorage
+                // it is needed as it is dup table.
+                .try_fold(
+                    BTreeMap::new(),
+                    |mut accounts: BTreeMap<Address, BTreeSet<B256>>, entry| {
+                        let (BlockNumberAddress((_, address)), storage_entry) = entry?;
+                        accounts.entry(address).or_default().insert(storage_entry.key);
+                        Ok(accounts)
+                    },
+                )
+        }
+    }
+
+    fn changed_storages_and_blocks_with_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<BTreeMap<(Address, B256), Vec<u64>>> {
+        if self.cached_storage_settings().storage_v2 {
+            self.storage_changesets_range(range)?.into_iter().try_fold(
+                BTreeMap::new(),
+                |mut storages: BTreeMap<(Address, B256), Vec<u64>>, (index, storage)| {
+                    storages
+                        .entry((index.address(), storage.key))
+                        .or_default()
+                        .push(index.block_number());
+                    Ok(storages)
+                },
+            )
+        } else {
+            let mut changeset_cursor = self.tx.cursor_read::<tables::StorageChangeSets>()?;
+
+            let storage_changeset_lists =
+                changeset_cursor.walk_range(BlockNumberAddress::range(range))?.try_fold(
+                    BTreeMap::new(),
+                    |mut storages: BTreeMap<(Address, B256), Vec<u64>>,
+                     entry|
+                     -> ProviderResult<_> {
+                        let (index, storage) = entry?;
+                        storages
+                            .entry((index.address(), storage.key))
+                            .or_default()
+                            .push(index.block_number());
+                        Ok(storages)
+                    },
+                )?;
+
+            Ok(storage_changeset_lists)
+        }
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
+    for DatabaseProvider<TX, N>
+{
+    type Receipt = ReceiptTy<N>;
+
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn write_state<'a>(
+        &self,
+        execution_outcome: impl Into<WriteStateInput<'a, Self::Receipt>>,
+        is_value_known: OriginalValuesKnown,
+        config: StateWriteConfig,
+    ) -> ProviderResult<()> {
+        let execution_outcome = execution_outcome.into();
+
+        if self.cached_storage_settings().use_hashed_state() &&
+            !config.write_receipts &&
+            !config.write_account_changesets &&
+            !config.write_storage_changesets
+        {
+            // In storage v2 with all outputs directed to static files, plain state and changesets
+            // are written elsewhere. Only bytecodes need MDBX writes, so skip the expensive
+            // to_plain_state_and_reverts conversion that iterates all accounts and storage.
+            self.write_bytecodes(
+                execution_outcome.state().contracts.iter().map(|(h, b)| (*h, Bytecode(b.clone()))),
+            )?;
+            return Ok(());
+        }
+
+        let first_block = execution_outcome.first_block();
+        let (plain_state, reverts) =
+            execution_outcome.state().to_plain_state_and_reverts(is_value_known);
+
+        self.write_state_reverts(reverts, first_block, config)?;
+        self.write_state_changes(plain_state)?;
+
+        if !config.write_receipts {
+            return Ok(());
+        }
+
+        let block_count = execution_outcome.len() as u64;
+        let last_block = execution_outcome.last_block();
+        let block_range = first_block..=last_block;
+
+        let tip = self.last_block_number()?.max(last_block);
+
+        // Fetch the first transaction number for each block in the range
+        let block_indices: Vec<_> = self
+            .block_body_indices_range(block_range)?
+            .into_iter()
+            .map(|b| b.first_tx_num)
+            .collect();
+
+        // Ensure all expected blocks are present.
+        if block_indices.len() < block_count as usize {
+            let missing_blocks = block_count - block_indices.len() as u64;
+            return Err(ProviderError::BlockBodyIndicesNotFound(
+                last_block.saturating_sub(missing_blocks - 1),
+            ));
+        }
+
+        let mut receipts_writer = EitherWriter::new_receipts(self, first_block)?;
+
+        let has_contract_log_filter = !self.prune_modes.receipts_log_filter.is_empty();
+        let contract_log_pruner = self.prune_modes.receipts_log_filter.group_by_block(tip, None)?;
+
+        // All receipts from the last 128 blocks are required for blockchain tree, even with
+        // [`PruneSegment::ContractLogs`].
+        //
+        // Receipts can only be skipped if we're dealing with legacy nodes that write them to
+        // Database, OR if receipts_in_static_files is enabled but no receipts exist in static
+        // files yet. Once receipts exist in static files, we must continue writing to maintain
+        // continuity and have no gaps.
+        let prunable_receipts = (EitherWriter::receipts_destination(self).is_database() ||
+            self.static_file_provider()
+                .get_highest_static_file_tx(StaticFileSegment::Receipts)
+                .is_none()) &&
+            PruneMode::Distance(self.minimum_pruning_distance).should_prune(first_block, tip);
+
+        // Prepare set of addresses which logs should not be pruned.
+        let mut allowed_addresses: AddressSet = AddressSet::default();
+        for (_, addresses) in contract_log_pruner.range(..first_block) {
+            allowed_addresses.extend(addresses.iter().copied());
+        }
+
+        for (idx, (receipts, first_tx_index)) in
+            execution_outcome.receipts().zip(block_indices).enumerate()
+        {
+            let block_number = first_block + idx as u64;
+
+            // Increment block number for receipts static file writer
+            receipts_writer.increment_block(block_number)?;
+
+            // Skip writing receipts if pruning configuration requires us to.
+            if prunable_receipts &&
+                self.prune_modes
+                    .receipts
+                    .is_some_and(|mode| mode.should_prune(block_number, tip))
+            {
+                continue
+            }
+
+            // If there are new addresses to retain after this block number, track them
+            if let Some(new_addresses) = contract_log_pruner.get(&block_number) {
+                allowed_addresses.extend(new_addresses.iter().copied());
+            }
+
+            for (idx, receipt) in receipts.iter().enumerate() {
+                let receipt_idx = first_tx_index + idx as u64;
+                // Skip writing receipt if log filter is active and it does not have any logs to
+                // retain
+                if prunable_receipts &&
+                    has_contract_log_filter &&
+                    !receipt.logs().iter().any(|log| allowed_addresses.contains(&log.address))
+                {
+                    continue
+                }
+
+                receipts_writer.append_receipt(receipt_idx, receipt)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write_state_reverts(
+        &self,
+        reverts: PlainStateReverts,
+        first_block: BlockNumber,
+        config: StateWriteConfig,
+    ) -> ProviderResult<()> {
+        // Write storage changes
+        if config.write_storage_changesets {
+            tracing::trace!("Writing storage changes");
+            let mut storages_cursor =
+                self.tx_ref().cursor_dup_write::<tables::PlainStorageState>()?;
+            for (block_index, mut storage_changes) in reverts.storage.into_iter().enumerate() {
+                let block_number = first_block + block_index as BlockNumber;
+
+                tracing::trace!(block_number, "Writing block change");
+                // sort changes by address.
+                storage_changes.par_sort_unstable_by_key(|a| a.address);
+                let total_changes =
+                    storage_changes.iter().map(|change| change.storage_revert.len()).sum();
+                let mut changeset = Vec::with_capacity(total_changes);
+                for PlainStorageRevert { address, wiped, storage_revert } in storage_changes {
+                    let mut storage = storage_revert
+                        .into_iter()
+                        .map(|(k, v)| (B256::from(k.to_be_bytes()), v))
+                        .collect::<Vec<_>>();
+                    // sort storage slots by key.
+                    storage.par_sort_unstable_by_key(|a| a.0);
+
+                    // If we are writing the primary storage wipe transition, the pre-existing
+                    // storage state has to be taken from the database and written to storage
+                    // history. See [StorageWipe::Primary] for more details.
+                    //
+                    // TODO(mediocregopher): This could be rewritten in a way which doesn't
+                    // require collecting wiped entries into a Vec like this, see
+                    // `write_storage_trie_changesets`.
+                    let mut wiped_storage = Vec::new();
+                    if wiped {
+                        tracing::trace!(?address, "Wiping storage");
+                        if let Some((_, entry)) = storages_cursor.seek_exact(address)? {
+                            wiped_storage.push((entry.key, entry.value));
+                            while let Some(entry) = storages_cursor.next_dup_val()? {
+                                wiped_storage.push((entry.key, entry.value))
+                            }
+                        }
+                    }
+
+                    tracing::trace!(?address, ?storage, "Writing storage reverts");
+                    for (key, value) in StorageRevertsIter::new(storage, wiped_storage) {
+                        changeset.push(StorageBeforeTx { address, key, value });
+                    }
+                }
+
+                let mut storage_changesets_writer =
+                    EitherWriter::new_storage_changesets(self, block_number)?;
+                storage_changesets_writer.append_storage_changeset(block_number, changeset)?;
+            }
+        }
+
+        if !config.write_account_changesets {
+            return Ok(());
+        }
+
+        // Write account changes
+        tracing::trace!(?first_block, "Writing account changes");
+        for (block_index, account_block_reverts) in reverts.accounts.into_iter().enumerate() {
+            let block_number = first_block + block_index as BlockNumber;
+            let changeset = account_block_reverts
+                .into_iter()
+                .map(|(address, info)| AccountBeforeTx { address, info: info.map(Into::into) })
+                .collect::<Vec<_>>();
+            let mut account_changesets_writer =
+                EitherWriter::new_account_changesets(self, block_number)?;
+
+            account_changesets_writer.append_account_changeset(block_number, changeset)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_state_changes(&self, mut changes: StateChangeset) -> ProviderResult<()> {
+        // sort all entries so they can be written to database in more performant way.
+        // and take smaller memory footprint.
+        changes.accounts.par_sort_by_key(|a| a.0);
+        changes.storage.par_sort_by_key(|a| a.address);
+        changes.contracts.par_sort_by_key(|a| a.0);
+
+        if !self.cached_storage_settings().use_hashed_state() {
+            // Write new account state
+            tracing::trace!(len = changes.accounts.len(), "Writing new account state");
+            let mut accounts_cursor = self.tx_ref().cursor_write::<tables::PlainAccountState>()?;
+            // write account to database.
+            for (address, account) in changes.accounts {
+                if let Some(account) = account {
+                    tracing::trace!(?address, "Updating plain state account");
+                    accounts_cursor.upsert(address, &account.into())?;
+                } else if accounts_cursor.seek_exact(address)?.is_some() {
+                    tracing::trace!(?address, "Deleting plain state account");
+                    accounts_cursor.delete_current()?;
+                }
+            }
+
+            // Write new storage state and wipe storage if needed.
+            tracing::trace!(len = changes.storage.len(), "Writing new storage state");
+            let mut storages_cursor =
+                self.tx_ref().cursor_dup_write::<tables::PlainStorageState>()?;
+            for PlainStorageChangeset { address, wipe_storage, storage } in changes.storage {
+                // Wiping of storage.
+                if wipe_storage && storages_cursor.seek_exact(address)?.is_some() {
+                    storages_cursor.delete_current_duplicates()?;
+                }
+                // cast storages to B256.
+                let mut storage = storage
+                    .into_iter()
+                    .map(|(k, value)| StorageEntry { key: k.into(), value })
+                    .collect::<Vec<_>>();
+                // sort storage slots by key.
+                storage.par_sort_unstable_by_key(|a| a.key);
+
+                for entry in storage {
+                    tracing::trace!(?address, ?entry.key, "Updating plain state storage");
+                    if let Some(db_entry) =
+                        storages_cursor.seek_by_key_subkey(address, entry.key)? &&
+                        db_entry.key == entry.key
+                    {
+                        storages_cursor.delete_current()?;
+                    }
+
+                    if !entry.value.is_zero() {
+                        storages_cursor.upsert(address, &entry)?;
+                    }
+                }
+            }
+        }
+
+        // Write bytecode
+        tracing::trace!(len = changes.contracts.len(), "Writing bytecodes");
+        self.write_bytecodes(
+            changes.contracts.into_iter().map(|(hash, bytecode)| (hash, Bytecode(bytecode))),
+        )?;
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn write_hashed_state(&self, hashed_state: &HashedPostStateSorted) -> ProviderResult<()> {
+        // Write hashed account updates.
+        let mut hashed_accounts_cursor = self.tx_ref().cursor_write::<tables::HashedAccounts>()?;
+        for (hashed_address, account) in hashed_state.accounts() {
+            if let Some(account) = account {
+                hashed_accounts_cursor.upsert(*hashed_address, account)?;
+            } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
+                hashed_accounts_cursor.delete_current()?;
+            }
+        }
+
+        // Write hashed storage changes.
+        let sorted_storages = hashed_state.account_storages().iter().sorted_by_key(|(key, _)| *key);
+        let mut hashed_storage_cursor =
+            self.tx_ref().cursor_dup_write::<tables::HashedStorages>()?;
+        for (hashed_address, storage) in sorted_storages {
+            if storage.is_wiped() && hashed_storage_cursor.seek_exact(*hashed_address)?.is_some() {
+                hashed_storage_cursor.delete_current_duplicates()?;
+            }
+
+            for (hashed_slot, value) in storage.storage_slots_ref() {
+                let entry = StorageEntry { key: *hashed_slot, value: *value };
+
+                if let Some(db_entry) =
+                    hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)? &&
+                    db_entry.key == entry.key
+                {
+                    hashed_storage_cursor.delete_current()?;
+                }
+
+                if !entry.value.is_zero() {
+                    hashed_storage_cursor.upsert(*hashed_address, &entry)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove the last N blocks of state.
+    ///
+    /// The latest state will be unwound
+    ///
+    /// 1. Iterate over the [`BlockBodyIndices`][tables::BlockBodyIndices] table to get all the
+    ///    transaction ids.
+    /// 2. Iterate over the [`StorageChangeSets`][tables::StorageChangeSets] table and the
+    ///    [`AccountChangeSets`][tables::AccountChangeSets] tables in reverse order to reconstruct
+    ///    the changesets.
+    ///    - In order to have both the old and new values in the changesets, we also access the
+    ///      plain state tables.
+    /// 3. While iterating over the changeset tables, if we encounter a new account or storage slot,
+    ///    we:
+    ///     1. Take the old value from the changeset
+    ///     2. Take the new value from the plain state
+    ///     3. Save the old value to the local state
+    /// 4. While iterating over the changeset tables, if we encounter an account/storage slot we
+    ///    have seen before we:
+    ///     1. Take the old value from the changeset
+    ///     2. Take the new value from the local state
+    ///     3. Set the local state to the value in the changeset
+    fn remove_state_above(&self, block: BlockNumber) -> ProviderResult<()> {
+        let range = block + 1..=self.last_block_number()?;
+
+        if range.is_empty() {
+            return Ok(());
+        }
+
+        // We are not removing block meta as it is used to get block changesets.
+        let block_bodies = self.block_body_indices_range(range.clone())?;
+
+        // get transaction receipts
+        let from_transaction_num =
+            block_bodies.first().expect("already checked if there are blocks").first_tx_num();
+
+        let storage_range = BlockNumberAddress::range(range.clone());
+        let storage_changeset = if self.cached_storage_settings().storage_v2 {
+            let changesets = self.storage_changesets_range(range.clone())?;
+            let mut changeset_writer =
+                self.static_file_provider.latest_writer(StaticFileSegment::StorageChangeSets)?;
+            changeset_writer.prune_storage_changesets(block)?;
+            changesets
+        } else {
+            self.take::<tables::StorageChangeSets>(storage_range)?.into_iter().collect()
+        };
+        let account_changeset = if self.cached_storage_settings().storage_v2 {
+            let changesets = self.account_changesets_range(range)?;
+            let mut changeset_writer =
+                self.static_file_provider.latest_writer(StaticFileSegment::AccountChangeSets)?;
+            changeset_writer.prune_account_changesets(block)?;
+            changesets
+        } else {
+            self.take::<tables::AccountChangeSets>(range)?
+        };
+
+        if self.cached_storage_settings().use_hashed_state() {
+            let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccounts>()?;
+            let mut hashed_storage_cursor = self.tx.cursor_dup_write::<tables::HashedStorages>()?;
+
+            let (state, _) = self.populate_bundle_state_hashed(
+                account_changeset,
+                storage_changeset,
+                &mut hashed_accounts_cursor,
+                &mut hashed_storage_cursor,
+            )?;
+
+            for (address, (old_account, new_account, storage)) in &state {
+                if old_account != new_account {
+                    let hashed_address = keccak256(address);
+                    let existing_entry = hashed_accounts_cursor.seek_exact(hashed_address)?;
+                    if let Some(account) = old_account {
+                        hashed_accounts_cursor.upsert(hashed_address, account)?;
+                    } else if existing_entry.is_some() {
+                        hashed_accounts_cursor.delete_current()?;
+                    }
+                }
+
+                for (storage_key, (old_storage_value, _new_storage_value)) in storage {
+                    let hashed_address = keccak256(address);
+                    let hashed_storage_key = keccak256(storage_key);
+                    let storage_entry =
+                        StorageEntry { key: hashed_storage_key, value: *old_storage_value };
+                    if hashed_storage_cursor
+                        .seek_by_key_subkey(hashed_address, hashed_storage_key)?
+                        .is_some_and(|s| s.key == hashed_storage_key)
+                    {
+                        hashed_storage_cursor.delete_current()?
+                    }
+
+                    if !old_storage_value.is_zero() {
+                        hashed_storage_cursor.upsert(hashed_address, &storage_entry)?;
+                    }
+                }
+            }
+        } else {
+            // This is not working for blocks that are not at tip. as plain state is not the last
+            // state of end range. We should rename the functions or add support to access
+            // History state. Accessing history state can be tricky but we are not gaining
+            // anything.
+            let mut plain_accounts_cursor = self.tx.cursor_write::<tables::PlainAccountState>()?;
+            let mut plain_storage_cursor =
+                self.tx.cursor_dup_write::<tables::PlainStorageState>()?;
+
+            let (state, _) = self.populate_bundle_state_plain(
+                account_changeset,
+                storage_changeset,
+                &mut plain_accounts_cursor,
+                &mut plain_storage_cursor,
+            )?;
+
+            for (address, (old_account, new_account, storage)) in &state {
+                if old_account != new_account {
+                    let existing_entry = plain_accounts_cursor.seek_exact(*address)?;
+                    if let Some(account) = old_account {
+                        plain_accounts_cursor.upsert(*address, account)?;
+                    } else if existing_entry.is_some() {
+                        plain_accounts_cursor.delete_current()?;
+                    }
+                }
+
+                for (storage_key, (old_storage_value, _new_storage_value)) in storage {
+                    let storage_entry =
+                        StorageEntry { key: *storage_key, value: *old_storage_value };
+                    if plain_storage_cursor
+                        .seek_by_key_subkey(*address, *storage_key)?
+                        .is_some_and(|s| s.key == *storage_key)
+                    {
+                        plain_storage_cursor.delete_current()?
+                    }
+
+                    if !old_storage_value.is_zero() {
+                        plain_storage_cursor.upsert(*address, &storage_entry)?;
+                    }
+                }
+            }
+        }
+
+        self.remove_receipts_from(from_transaction_num, block)?;
+
+        Ok(())
+    }
+
+    /// Take the last N blocks of state, recreating the [`ExecutionOutcome`].
+    ///
+    /// The latest state will be unwound and returned back with all the blocks
+    ///
+    /// 1. Iterate over the [`BlockBodyIndices`][tables::BlockBodyIndices] table to get all the
+    ///    transaction ids.
+    /// 2. Iterate over the [`StorageChangeSets`][tables::StorageChangeSets] table and the
+    ///    [`AccountChangeSets`][tables::AccountChangeSets] tables in reverse order to reconstruct
+    ///    the changesets.
+    ///    - In order to have both the old and new values in the changesets, we also access the
+    ///      plain state tables.
+    /// 3. While iterating over the changeset tables, if we encounter a new account or storage slot,
+    ///    we:
+    ///     1. Take the old value from the changeset
+    ///     2. Take the new value from the plain state
+    ///     3. Save the old value to the local state
+    /// 4. While iterating over the changeset tables, if we encounter an account/storage slot we
+    ///    have seen before we:
+    ///     1. Take the old value from the changeset
+    ///     2. Take the new value from the local state
+    ///     3. Set the local state to the value in the changeset
+    fn take_state_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<ExecutionOutcome<Self::Receipt>> {
+        let range = block + 1..=self.last_block_number()?;
+
+        if range.is_empty() {
+            return Ok(ExecutionOutcome::default())
+        }
+        let start_block_number = *range.start();
+
+        // We are not removing block meta as it is used to get block changesets.
+        let block_bodies = self.block_body_indices_range(range.clone())?;
+
+        // get transaction receipts
+        let from_transaction_num =
+            block_bodies.first().expect("already checked if there are blocks").first_tx_num();
+        let to_transaction_num =
+            block_bodies.last().expect("already checked if there are blocks").last_tx_num();
+
+        let storage_range = BlockNumberAddress::range(range.clone());
+        let storage_changeset = if let Some(highest_block) = self
+            .static_file_provider
+            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets) &&
+            self.cached_storage_settings().storage_v2
+        {
+            let changesets = self.storage_changesets_range(block + 1..=highest_block)?;
+            let mut changeset_writer =
+                self.static_file_provider.latest_writer(StaticFileSegment::StorageChangeSets)?;
+            changeset_writer.prune_storage_changesets(block)?;
+            changesets
+        } else {
+            self.take::<tables::StorageChangeSets>(storage_range)?.into_iter().collect()
+        };
+
+        // if there are static files for this segment, prune them.
+        let highest_changeset_block = self
+            .static_file_provider
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
+        let account_changeset = if let Some(highest_block) = highest_changeset_block &&
+            self.cached_storage_settings().storage_v2
+        {
+            // TODO: add a `take` method that removes and returns the items instead of doing this
+            let changesets = self.account_changesets_range(block + 1..highest_block + 1)?;
+            let mut changeset_writer =
+                self.static_file_provider.latest_writer(StaticFileSegment::AccountChangeSets)?;
+            changeset_writer.prune_account_changesets(block)?;
+
+            changesets
+        } else {
+            // Have to remove from static files if they exist, otherwise remove using `take` for the
+            // changeset tables
+            self.take::<tables::AccountChangeSets>(range)?
+        };
+
+        let (state, reverts) = if self.cached_storage_settings().use_hashed_state() {
+            let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccounts>()?;
+            let mut hashed_storage_cursor = self.tx.cursor_dup_write::<tables::HashedStorages>()?;
+
+            let (state, reverts) = self.populate_bundle_state_hashed(
+                account_changeset,
+                storage_changeset,
+                &mut hashed_accounts_cursor,
+                &mut hashed_storage_cursor,
+            )?;
+
+            for (address, (old_account, new_account, storage)) in &state {
+                if old_account != new_account {
+                    let hashed_address = keccak256(address);
+                    let existing_entry = hashed_accounts_cursor.seek_exact(hashed_address)?;
+                    if let Some(account) = old_account {
+                        hashed_accounts_cursor.upsert(hashed_address, account)?;
+                    } else if existing_entry.is_some() {
+                        hashed_accounts_cursor.delete_current()?;
+                    }
+                }
+
+                for (storage_key, (old_storage_value, _new_storage_value)) in storage {
+                    let hashed_address = keccak256(address);
+                    let hashed_storage_key = keccak256(storage_key);
+                    let storage_entry =
+                        StorageEntry { key: hashed_storage_key, value: *old_storage_value };
+                    if hashed_storage_cursor
+                        .seek_by_key_subkey(hashed_address, hashed_storage_key)?
+                        .is_some_and(|s| s.key == hashed_storage_key)
+                    {
+                        hashed_storage_cursor.delete_current()?
+                    }
+
+                    if !old_storage_value.is_zero() {
+                        hashed_storage_cursor.upsert(hashed_address, &storage_entry)?;
+                    }
+                }
+            }
+
+            (state, reverts)
+        } else {
+            // This is not working for blocks that are not at tip. as plain state is not the last
+            // state of end range. We should rename the functions or add support to access
+            // History state. Accessing history state can be tricky but we are not gaining
+            // anything.
+            let mut plain_accounts_cursor = self.tx.cursor_write::<tables::PlainAccountState>()?;
+            let mut plain_storage_cursor =
+                self.tx.cursor_dup_write::<tables::PlainStorageState>()?;
+
+            let (state, reverts) = self.populate_bundle_state_plain(
+                account_changeset,
+                storage_changeset,
+                &mut plain_accounts_cursor,
+                &mut plain_storage_cursor,
+            )?;
+
+            for (address, (old_account, new_account, storage)) in &state {
+                if old_account != new_account {
+                    let existing_entry = plain_accounts_cursor.seek_exact(*address)?;
+                    if let Some(account) = old_account {
+                        plain_accounts_cursor.upsert(*address, account)?;
+                    } else if existing_entry.is_some() {
+                        plain_accounts_cursor.delete_current()?;
+                    }
+                }
+
+                for (storage_key, (old_storage_value, _new_storage_value)) in storage {
+                    let storage_entry =
+                        StorageEntry { key: *storage_key, value: *old_storage_value };
+                    if plain_storage_cursor
+                        .seek_by_key_subkey(*address, *storage_key)?
+                        .is_some_and(|s| s.key == *storage_key)
+                    {
+                        plain_storage_cursor.delete_current()?
+                    }
+
+                    if !old_storage_value.is_zero() {
+                        plain_storage_cursor.upsert(*address, &storage_entry)?;
+                    }
+                }
+            }
+
+            (state, reverts)
+        };
+
+        // Collect receipts into tuples (tx_num, receipt) to correctly handle pruned receipts
+        let mut receipts_iter = self
+            .static_file_provider
+            .get_range_with_static_file_or_database(
+                StaticFileSegment::Receipts,
+                from_transaction_num..to_transaction_num + 1,
+                |static_file, range, _| {
+                    static_file
+                        .receipts_by_tx_range(range.clone())
+                        .map(|r| range.into_iter().zip(r).collect())
+                },
+                |range, _| {
+                    self.tx
+                        .cursor_read::<tables::Receipts<Self::Receipt>>()?
+                        .walk_range(range)?
+                        .map(|r| r.map_err(Into::into))
+                        .collect()
+                },
+                |_| true,
+            )?
+            .into_iter()
+            .peekable();
+
+        let mut receipts = Vec::with_capacity(block_bodies.len());
+        // loop break if we are at the end of the blocks.
+        for block_body in block_bodies {
+            let mut block_receipts = Vec::with_capacity(block_body.tx_count as usize);
+            for num in block_body.tx_num_range() {
+                if receipts_iter.peek().is_some_and(|(n, _)| *n == num) {
+                    block_receipts.push(receipts_iter.next().unwrap().1);
+                }
+            }
+            receipts.push(block_receipts);
+        }
+
+        self.remove_receipts_from(from_transaction_num, block)?;
+
+        Ok(ExecutionOutcome::new_init(
+            state,
+            reverts,
+            Vec::new(),
+            receipts,
+            start_block_number,
+            Vec::new(),
+        ))
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    fn write_account_trie_updates<A: TrieTableAdapter>(
+        tx: &TX,
+        trie_updates: &TrieUpdatesSorted,
+        num_entries: &mut usize,
+    ) -> ProviderResult<()>
+    where
+        TX: DbTxMut,
+    {
+        let mut account_trie_cursor = tx.cursor_write::<A::AccountTrieTable>()?;
+        // Process sorted account nodes
+        for (key, updated_node) in trie_updates.account_nodes_ref() {
+            let nibbles = A::AccountKey::from(*key);
+            match updated_node {
+                Some(node) => {
+                    if !key.is_empty() {
+                        *num_entries += 1;
+                        account_trie_cursor.upsert(nibbles, node)?;
+                    }
+                }
+                None => {
+                    *num_entries += 1;
+                    if account_trie_cursor.seek_exact(nibbles)?.is_some() {
+                        account_trie_cursor.delete_current()?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn write_storage_tries<A: TrieTableAdapter>(
+        tx: &TX,
+        storage_tries: Vec<(&B256, &StorageTrieUpdatesSorted)>,
+        num_entries: &mut usize,
+    ) -> ProviderResult<()>
+    where
+        TX: DbTxMut,
+    {
+        let mut cursor = tx.cursor_dup_write::<A::StorageTrieTable>()?;
+        for (hashed_address, storage_trie_updates) in storage_tries {
+            let mut db_storage_trie_cursor: DatabaseStorageTrieCursor<_, A> =
+                DatabaseStorageTrieCursor::new(cursor, *hashed_address);
+            *num_entries +=
+                db_storage_trie_cursor.write_storage_trie_updates_sorted(storage_trie_updates)?;
+            cursor = db_storage_trie_cursor.cursor;
+        }
+        Ok(())
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider<TX, N> {
+    /// Writes trie updates to the database with already sorted updates.
+    ///
+    /// Returns the number of entries modified.
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize> {
+        if trie_updates.is_empty() {
+            return Ok(0)
+        }
+
+        // Track the number of inserted entries.
+        let mut num_entries = 0;
+
+        reth_trie_db::with_adapter!(self, |A| {
+            Self::write_account_trie_updates::<A>(self.tx_ref(), trie_updates, &mut num_entries)?;
+        });
+
+        num_entries +=
+            self.write_storage_trie_updates_sorted(trie_updates.storage_tries_ref().iter())?;
+
+        Ok(num_entries)
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> StorageTrieWriter for DatabaseProvider<TX, N> {
+    /// Writes storage trie updates from the given storage trie map with already sorted updates.
+    ///
+    /// Expects the storage trie updates to already be sorted by the hashed address key.
+    ///
+    /// Returns the number of entries modified.
+    fn write_storage_trie_updates_sorted<'a>(
+        &self,
+        storage_tries: impl Iterator<Item = (&'a B256, &'a StorageTrieUpdatesSorted)>,
+    ) -> ProviderResult<usize> {
+        let mut num_entries = 0;
+        let mut storage_tries = storage_tries.collect::<Vec<_>>();
+        storage_tries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        reth_trie_db::with_adapter!(self, |A| {
+            Self::write_storage_tries::<A>(self.tx_ref(), storage_tries, &mut num_entries)?;
+        });
+        Ok(num_entries)
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HashingWriter for DatabaseProvider<TX, N> {
+    fn unwind_account_hashing<'a>(
+        &self,
+        changesets: impl Iterator<Item = &'a (BlockNumber, AccountBeforeTx)>,
+    ) -> ProviderResult<BTreeMap<B256, Option<Account>>> {
+        // Aggregate all block changesets and make a list of accounts that have been changed.
+        // Note that collecting and then reversing the order is necessary to ensure that the
+        // changes are applied in the correct order.
+        let hashed_accounts = changesets
+            .into_iter()
+            .map(|(_, e)| (keccak256(e.address), e.info))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<BTreeMap<_, _>>();
+
+        // Apply values to HashedState, and remove the account if it's None.
+        let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccounts>()?;
+        for (hashed_address, account) in &hashed_accounts {
+            if let Some(account) = account {
+                hashed_accounts_cursor.upsert(*hashed_address, account)?;
+            } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
+                hashed_accounts_cursor.delete_current()?;
+            }
+        }
+
+        Ok(hashed_accounts)
+    }
+
+    fn unwind_account_hashing_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<BTreeMap<B256, Option<Account>>> {
+        let changesets = self.account_changesets_range(range)?;
+        self.unwind_account_hashing(changesets.iter())
+    }
+
+    fn insert_account_for_hashing(
+        &self,
+        changesets: impl IntoIterator<Item = (Address, Option<Account>)>,
+    ) -> ProviderResult<BTreeMap<B256, Option<Account>>> {
+        let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccounts>()?;
+        let hashed_accounts =
+            changesets.into_iter().map(|(ad, ac)| (keccak256(ad), ac)).collect::<BTreeMap<_, _>>();
+        for (hashed_address, account) in &hashed_accounts {
+            if let Some(account) = account {
+                hashed_accounts_cursor.upsert(*hashed_address, account)?;
+            } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
+                hashed_accounts_cursor.delete_current()?;
+            }
+        }
+        Ok(hashed_accounts)
+    }
+
+    fn unwind_storage_hashing(
+        &self,
+        changesets: impl Iterator<Item = (BlockNumberAddress, StorageEntry)>,
+    ) -> ProviderResult<B256Map<BTreeSet<B256>>> {
+        // Aggregate all block changesets and make list of accounts that have been changed.
+        let mut hashed_storages = changesets
+            .into_iter()
+            .map(|(BlockNumberAddress((_, address)), storage_entry)| {
+                let hashed_key = keccak256(storage_entry.key);
+                (keccak256(address), hashed_key, storage_entry.value)
+            })
+            .collect::<Vec<_>>();
+        hashed_storages.sort_by_key(|(ha, hk, _)| (*ha, *hk));
+
+        // Apply values to HashedState, and remove the account if it's None.
+        let mut hashed_storage_keys: B256Map<BTreeSet<B256>> =
+            B256Map::with_capacity_and_hasher(hashed_storages.len(), Default::default());
+        let mut hashed_storage = self.tx.cursor_dup_write::<tables::HashedStorages>()?;
+        for (hashed_address, key, value) in hashed_storages.into_iter().rev() {
+            hashed_storage_keys.entry(hashed_address).or_default().insert(key);
+
+            if hashed_storage
+                .seek_by_key_subkey(hashed_address, key)?
+                .is_some_and(|entry| entry.key == key)
+            {
+                hashed_storage.delete_current()?;
+            }
+
+            if !value.is_zero() {
+                hashed_storage.upsert(hashed_address, &StorageEntry { key, value })?;
+            }
+        }
+        Ok(hashed_storage_keys)
+    }
+
+    fn unwind_storage_hashing_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<B256Map<BTreeSet<B256>>> {
+        let changesets = self.storage_changesets_range(range)?;
+        self.unwind_storage_hashing(changesets.into_iter())
+    }
+
+    fn insert_storage_for_hashing(
+        &self,
+        storages: impl IntoIterator<Item = (Address, impl IntoIterator<Item = StorageEntry>)>,
+    ) -> ProviderResult<B256Map<BTreeSet<B256>>> {
+        // hash values
+        let hashed_storages =
+            storages.into_iter().fold(BTreeMap::new(), |mut map, (address, storage)| {
+                let storage = storage.into_iter().fold(BTreeMap::new(), |mut map, entry| {
+                    map.insert(keccak256(entry.key), entry.value);
+                    map
+                });
+                map.insert(keccak256(address), storage);
+                map
+            });
+
+        let hashed_storage_keys = hashed_storages
+            .iter()
+            .map(|(hashed_address, entries)| (*hashed_address, entries.keys().copied().collect()))
+            .collect();
+
+        let mut hashed_storage_cursor = self.tx.cursor_dup_write::<tables::HashedStorages>()?;
+        // Hash the address and key and apply them to HashedStorage (if Storage is None
+        // just remove it);
+        hashed_storages.into_iter().try_for_each(|(hashed_address, storage)| {
+            storage.into_iter().try_for_each(|(key, value)| -> ProviderResult<()> {
+                if hashed_storage_cursor
+                    .seek_by_key_subkey(hashed_address, key)?
+                    .is_some_and(|entry| entry.key == key)
+                {
+                    hashed_storage_cursor.delete_current()?;
+                }
+
+                if !value.is_zero() {
+                    hashed_storage_cursor.upsert(hashed_address, &StorageEntry { key, value })?;
+                }
+                Ok(())
+            })
+        })?;
+
+        Ok(hashed_storage_keys)
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HistoryWriter for DatabaseProvider<TX, N> {
+    fn unwind_account_history_indices<'a>(
+        &self,
+        changesets: impl Iterator<Item = &'a (BlockNumber, AccountBeforeTx)>,
+    ) -> ProviderResult<usize> {
+        let mut last_indices = changesets
+            .into_iter()
+            .map(|(index, account)| (account.address, *index))
+            .collect::<Vec<_>>();
+        last_indices.sort_unstable_by_key(|(a, _)| *a);
+
+        if self.cached_storage_settings().storage_v2 {
+            let batch = self.rocksdb_provider.unwind_account_history_indices(&last_indices)?;
+            self.pending_rocksdb_batches.lock().push(batch);
+        } else {
+            // Unwind the account history index in MDBX.
+            let mut cursor = self.tx.cursor_write::<tables::AccountsHistory>()?;
+            for &(address, rem_index) in &last_indices {
+                let partial_shard = unwind_history_shards::<_, tables::AccountsHistory, _>(
+                    &mut cursor,
+                    ShardedKey::last(address),
+                    rem_index,
+                    |sharded_key| sharded_key.key == address,
+                )?;
+
+                // Check the last returned partial shard.
+                // If it's not empty, the shard needs to be reinserted.
+                if !partial_shard.is_empty() {
+                    cursor.insert(
+                        ShardedKey::last(address),
+                        &BlockNumberList::new_pre_sorted(partial_shard),
+                    )?;
+                }
+            }
+        }
+
+        let changesets = last_indices.len();
+        Ok(changesets)
+    }
+
+    fn unwind_account_history_indices_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<usize> {
+        let changesets = self.account_changesets_range(range)?;
+        self.unwind_account_history_indices(changesets.iter())
+    }
+
+    fn insert_account_history_index(
+        &self,
+        account_transitions: impl IntoIterator<Item = (Address, impl IntoIterator<Item = u64>)>,
+    ) -> ProviderResult<()> {
+        self.append_history_index::<_, tables::AccountsHistory>(
+            account_transitions,
+            ShardedKey::new,
+        )
+    }
+
+    fn unwind_storage_history_indices(
+        &self,
+        changesets: impl Iterator<Item = (BlockNumberAddress, StorageEntry)>,
+    ) -> ProviderResult<usize> {
+        let mut storage_changesets = changesets
+            .into_iter()
+            .map(|(BlockNumberAddress((bn, address)), storage)| (address, storage.key, bn))
+            .collect::<Vec<_>>();
+        storage_changesets.sort_unstable_by_key(|(address, key, _)| (*address, *key));
+
+        if self.cached_storage_settings().storage_v2 {
+            let batch =
+                self.rocksdb_provider.unwind_storage_history_indices(&storage_changesets)?;
+            self.pending_rocksdb_batches.lock().push(batch);
+        } else {
+            // Unwind the storage history index in MDBX.
+            let mut cursor = self.tx.cursor_write::<tables::StoragesHistory>()?;
+            for &(address, storage_key, rem_index) in &storage_changesets {
+                let partial_shard = unwind_history_shards::<_, tables::StoragesHistory, _>(
+                    &mut cursor,
+                    StorageShardedKey::last(address, storage_key),
+                    rem_index,
+                    |storage_sharded_key| {
+                        storage_sharded_key.address == address &&
+                            storage_sharded_key.sharded_key.key == storage_key
+                    },
+                )?;
+
+                // Check the last returned partial shard.
+                // If it's not empty, the shard needs to be reinserted.
+                if !partial_shard.is_empty() {
+                    cursor.insert(
+                        StorageShardedKey::last(address, storage_key),
+                        &BlockNumberList::new_pre_sorted(partial_shard),
+                    )?;
+                }
+            }
+        }
+
+        let changesets = storage_changesets.len();
+        Ok(changesets)
+    }
+
+    fn unwind_storage_history_indices_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<usize> {
+        let changesets = self.storage_changesets_range(range)?;
+        self.unwind_storage_history_indices(changesets.into_iter())
+    }
+
+    fn insert_storage_history_index(
+        &self,
+        storage_transitions: impl IntoIterator<Item = ((Address, B256), impl IntoIterator<Item = u64>)>,
+    ) -> ProviderResult<()> {
+        self.append_history_index::<_, tables::StoragesHistory>(
+            storage_transitions,
+            |(address, storage_key), highest_block_number| {
+                StorageShardedKey::new(address, storage_key, highest_block_number)
+            },
+        )
+    }
+
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn update_history_indices(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<()> {
+        let storage_settings = self.cached_storage_settings();
+        if !storage_settings.storage_v2 {
+            let indices = self.changed_accounts_and_blocks_with_range(range.clone())?;
+            self.insert_account_history_index(indices)?;
+        }
+
+        if !storage_settings.storage_v2 {
+            let indices = self.changed_storages_and_blocks_with_range(range)?;
+            self.insert_storage_history_index(indices)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockExecutionWriter
+    for DatabaseProvider<TX, N>
+{
+    fn take_block_and_execution_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Chain<Self::Primitives>> {
+        let range = block + 1..=self.last_block_number()?;
+
+        self.unwind_trie_state_from(block + 1)?;
+
+        // get execution res
+        let execution_state = self.take_state_above(block)?;
+
+        let blocks = self.recovered_block_range(range)?;
+
+        // remove block bodies it is needed for both get block range and get block execution results
+        // that is why it is deleted afterwards.
+        self.remove_blocks_above(block)?;
+
+        // Update pipeline progress
+        self.update_pipeline_stages(block, true)?;
+
+        Ok(Chain::new(blocks, execution_state, BTreeMap::new()))
+    }
+
+    fn remove_block_and_execution_above(&self, block: BlockNumber) -> ProviderResult<()> {
+        self.unwind_trie_state_from(block + 1)?;
+
+        // remove execution res
+        self.remove_state_above(block)?;
+
+        // remove block bodies it is needed for both get block range and get block execution results
+        // that is why it is deleted afterwards.
+        self.remove_blocks_above(block)?;
+
+        // Update pipeline progress
+        self.update_pipeline_stages(block, true)?;
+
+        Ok(())
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
+    for DatabaseProvider<TX, N>
+{
+    type Block = BlockTy<N>;
+    type Receipt = ReceiptTy<N>;
+
+    /// Inserts the block into the database, writing to both static files and MDBX.
+    ///
+    /// This is a convenience method primarily used in tests. For production use,
+    /// prefer [`Self::save_blocks`] which handles execution output and trie data.
+    fn insert_block(
+        &self,
+        block: &RecoveredBlock<Self::Block>,
+    ) -> ProviderResult<StoredBlockBodyIndices> {
+        let block_number = block.number();
+
+        // Wrap block in ExecutedBlock with empty execution output (no receipts/state/trie)
+        let executed_block = ExecutedBlock::new(
+            Arc::new(block.clone()),
+            Arc::new(BlockExecutionOutput {
+                result: BlockExecutionResult {
+                    receipts: Default::default(),
+                    requests: Default::default(),
+                    gas_used: 0,
+                    blob_gas_used: 0,
+                },
+                state: Default::default(),
+            }),
+            ComputedTrieData::default(),
+        );
+
+        // Delegate to save_blocks with BlocksOnly mode (skips receipts/state/trie)
+        self.save_blocks(vec![executed_block], SaveBlocksMode::BlocksOnly)?;
+
+        // Return the body indices
+        self.block_body_indices(block_number)?
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(block_number))
+    }
+
+    fn append_block_bodies(
+        &self,
+        bodies: Vec<(BlockNumber, Option<&BodyTy<N>>)>,
+    ) -> ProviderResult<()> {
+        let Some(from_block) = bodies.first().map(|(block, _)| *block) else { return Ok(()) };
+
+        // Initialize writer if we will be writing transactions to staticfiles
+        let mut tx_writer =
+            self.static_file_provider.get_writer(from_block, StaticFileSegment::Transactions)?;
+
+        let mut block_indices_cursor = self.tx.cursor_write::<tables::BlockBodyIndices>()?;
+        let mut tx_block_cursor = self.tx.cursor_write::<tables::TransactionBlocks>()?;
+
+        // Get id for the next tx_num or zero if there are no transactions.
+        let mut next_tx_num = tx_block_cursor.last()?.map(|(id, _)| id + 1).unwrap_or_default();
+
+        for (block_number, body) in &bodies {
+            // Increment block on static file header.
+            tx_writer.increment_block(*block_number)?;
+
+            let tx_count = body.as_ref().map(|b| b.transactions().len() as u64).unwrap_or_default();
+            let block_indices = StoredBlockBodyIndices { first_tx_num: next_tx_num, tx_count };
+
+            let mut durations_recorder = metrics::DurationsRecorder::new(&self.metrics);
+
+            // insert block meta
+            block_indices_cursor.append(*block_number, &block_indices)?;
+
+            durations_recorder.record_relative(metrics::Action::InsertBlockBodyIndices);
+
+            let Some(body) = body else { continue };
+
+            // write transaction block index
+            if !body.transactions().is_empty() {
+                tx_block_cursor.append(block_indices.last_tx_num(), block_number)?;
+                durations_recorder.record_relative(metrics::Action::InsertTransactionBlocks);
+            }
+
+            // write transactions
+            for transaction in body.transactions() {
+                tx_writer.append_transaction(next_tx_num, transaction)?;
+
+                // Increment transaction id for each transaction.
+                next_tx_num += 1;
+            }
+        }
+
+        self.storage.writer().write_block_bodies(self, bodies)?;
+
+        Ok(())
+    }
+
+    fn remove_blocks_above(&self, block: BlockNumber) -> ProviderResult<()> {
+        let last_block_number = self.last_block_number()?;
+        // Clean up HeaderNumbers for blocks being removed, we must clear all indexes from MDBX.
+        for hash in self.canonical_hashes_range(block + 1, last_block_number + 1)? {
+            self.tx.delete::<tables::HeaderNumbers>(hash, None)?;
+        }
+
+        // Get highest static file block for the total block range
+        let highest_static_file_block = self
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::Headers)
+            .expect("todo: error handling, headers should exist");
+
+        // IMPORTANT: we use `highest_static_file_block.saturating_sub(block_number)` to make sure
+        // we remove only what is ABOVE the block.
+        //
+        // i.e., if the highest static file block is 8, we want to remove above block 5 only, we
+        // will have three blocks to remove, which will be block 8, 7, and 6.
+        debug!(target: "providers::db", ?block, "Removing static file blocks above block_number");
+        self.static_file_provider()
+            .get_writer(block, StaticFileSegment::Headers)?
+            .prune_headers(highest_static_file_block.saturating_sub(block))?;
+
+        // First transaction to be removed
+        let unwind_tx_from = self
+            .block_body_indices(block)?
+            .map(|b| b.next_tx_num())
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(block))?;
+
+        // Last transaction to be removed
+        let unwind_tx_to = self
+            .tx
+            .cursor_read::<tables::BlockBodyIndices>()?
+            .last()?
+            // shouldn't happen because this was OK above
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(block))?
+            .1
+            .last_tx_num();
+
+        if unwind_tx_from <= unwind_tx_to {
+            let hashes = self.transaction_hashes_by_range(unwind_tx_from..(unwind_tx_to + 1))?;
+            self.with_rocksdb_batch(|batch| {
+                let mut writer = EitherWriter::new_transaction_hash_numbers(self, batch)?;
+                for (hash, _) in hashes {
+                    writer.delete_transaction_hash_number(hash)?;
+                }
+                Ok(((), writer.into_raw_rocksdb_batch()))
+            })?;
+        }
+
+        // Skip sender pruning when sender_recovery is fully pruned, since no sender data
+        // exists in static files or the database.
+        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()) {
+            EitherWriter::new_senders(self, last_block_number)?
+                .prune_senders(unwind_tx_from, block)?;
+        }
+
+        self.remove_bodies_above(block)?;
+
+        Ok(())
+    }
+
+    fn remove_bodies_above(&self, block: BlockNumber) -> ProviderResult<()> {
+        self.storage.writer().remove_block_bodies_above(self, block)?;
+
+        // First transaction to be removed
+        let unwind_tx_from = self
+            .block_body_indices(block)?
+            .map(|b| b.next_tx_num())
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(block))?;
+
+        self.remove::<tables::BlockBodyIndices>(block + 1..)?;
+        self.remove::<tables::TransactionBlocks>(unwind_tx_from..)?;
+
+        let static_file_tx_num =
+            self.static_file_provider.get_highest_static_file_tx(StaticFileSegment::Transactions);
+
+        let to_delete = static_file_tx_num
+            .map(|static_tx| (static_tx + 1).saturating_sub(unwind_tx_from))
+            .unwrap_or_default();
+
+        self.static_file_provider
+            .latest_writer(StaticFileSegment::Transactions)?
+            .prune_transactions(to_delete, block)?;
+
+        Ok(())
+    }
+
+    /// Appends blocks with their execution state to the database.
+    ///
+    /// **Note:** This function is only used in tests.
+    ///
+    /// History indices are written to the appropriate backend based on storage settings:
+    /// MDBX when `*_history_in_rocksdb` is false, `RocksDB` when true.
+    ///
+    /// TODO(joshie): this fn should be moved to `UnifiedStorageWriter` eventually
+    fn append_blocks_with_state(
+        &self,
+        blocks: Vec<RecoveredBlock<Self::Block>>,
+        execution_outcome: &ExecutionOutcome<Self::Receipt>,
+        hashed_state: HashedPostStateSorted,
+    ) -> ProviderResult<()> {
+        if blocks.is_empty() {
+            debug!(target: "providers::db", "Attempted to append empty block range");
+            return Ok(())
+        }
+
+        // Blocks are not empty, so no need to handle the case of `blocks.first()` being
+        // `None`.
+        let first_number = blocks[0].number();
+
+        // Blocks are not empty, so no need to handle the case of `blocks.last()` being
+        // `None`.
+        let last_block_number = blocks[blocks.len() - 1].number();
+
+        let mut durations_recorder = metrics::DurationsRecorder::new(&self.metrics);
+
+        // Extract account and storage transitions from the bundle reverts BEFORE writing state.
+        // This is necessary because with edge storage, changesets are written to static files
+        // whose index isn't updated until commit, making them invisible to subsequent reads
+        // within the same transaction.
+        let (account_transitions, storage_transitions) = {
+            let mut account_transitions: BTreeMap<Address, Vec<u64>> = BTreeMap::new();
+            let mut storage_transitions: BTreeMap<(Address, B256), Vec<u64>> = BTreeMap::new();
+            for (block_idx, block_reverts) in execution_outcome.bundle.reverts.iter().enumerate() {
+                let block_number = first_number + block_idx as u64;
+                for (address, account_revert) in block_reverts {
+                    account_transitions.entry(*address).or_default().push(block_number);
+                    for storage_key in account_revert.storage.keys() {
+                        let key = B256::from(storage_key.to_be_bytes());
+                        storage_transitions.entry((*address, key)).or_default().push(block_number);
+                    }
+                }
+            }
+            (account_transitions, storage_transitions)
+        };
+
+        // Insert the blocks
+        for block in blocks {
+            self.insert_block(&block)?;
+            durations_recorder.record_relative(metrics::Action::InsertBlock);
+        }
+
+        self.write_state(execution_outcome, OriginalValuesKnown::No, StateWriteConfig::default())?;
+        durations_recorder.record_relative(metrics::Action::InsertState);
+
+        // insert hashes and intermediate merkle nodes
+        self.write_hashed_state(&hashed_state)?;
+        durations_recorder.record_relative(metrics::Action::InsertHashes);
+
+        // Use pre-computed transitions for history indices since static file
+        // writes aren't visible until commit.
+        // Note: For MDBX we use insert_*_history_index. For RocksDB we use
+        // append_*_history_shard which handles read-merge-write internally.
+        let storage_settings = self.cached_storage_settings();
+        if storage_settings.storage_v2 {
+            self.with_rocksdb_batch(|mut batch| {
+                for (address, blocks) in account_transitions {
+                    batch.append_account_history_shard(address, blocks)?;
+                }
+                Ok(((), Some(batch.into_inner())))
+            })?;
+        } else {
+            self.insert_account_history_index(account_transitions)?;
+        }
+        if storage_settings.storage_v2 {
+            self.with_rocksdb_batch(|mut batch| {
+                for ((address, key), blocks) in storage_transitions {
+                    batch.append_storage_history_shard(address, key, blocks)?;
+                }
+                Ok(((), Some(batch.into_inner())))
+            })?;
+        } else {
+            self.insert_storage_history_index(storage_transitions)?;
+        }
+        durations_recorder.record_relative(metrics::Action::InsertHistoryIndices);
+
+        // Update pipeline progress
+        self.update_pipeline_stages(last_block_number, false)?;
+        durations_recorder.record_relative(metrics::Action::UpdatePipelineStages);
+
+        debug!(target: "providers::db", range = ?first_number..=last_block_number, actions = ?durations_recorder.actions, "Appended blocks");
+
+        Ok(())
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> PruneCheckpointReader for DatabaseProvider<TX, N> {
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
+        Ok(self.tx.get::<tables::PruneCheckpoints>(segment)?)
+    }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        Ok(PruneSegment::variants()
+            .filter_map(|segment| {
+                self.tx
+                    .get::<tables::PruneCheckpoints>(segment)
+                    .transpose()
+                    .map(|chk| chk.map(|chk| (segment, chk)))
+            })
+            .collect::<Result<_, _>>()?)
+    }
+}
+
+impl<TX: DbTxMut, N: NodeTypes> PruneCheckpointWriter for DatabaseProvider<TX, N> {
+    fn save_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+        checkpoint: PruneCheckpoint,
+    ) -> ProviderResult<()> {
+        Ok(self.tx.put::<tables::PruneCheckpoints>(segment, checkpoint)?)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> StatsReader for DatabaseProvider<TX, N> {
+    fn count_entries<T: Table>(&self) -> ProviderResult<usize> {
+        let db_entries = self.tx.entries::<T>()?;
+        let static_file_entries = match self.static_file_provider.count_entries::<T>() {
+            Ok(entries) => entries,
+            Err(ProviderError::UnsupportedProvider) => 0,
+            Err(err) => return Err(err),
+        };
+
+        Ok(db_entries + static_file_entries)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> ChainStateBlockReader for DatabaseProvider<TX, N> {
+    fn last_finalized_block_number(&self) -> ProviderResult<Option<BlockNumber>> {
+        let mut finalized_blocks = self
+            .tx
+            .cursor_read::<tables::ChainState>()?
+            .walk(Some(tables::ChainStateKey::LastFinalizedBlock))?
+            .take(1)
+            .collect::<Result<BTreeMap<tables::ChainStateKey, BlockNumber>, _>>()?;
+
+        let last_finalized_block_number = finalized_blocks.pop_first().map(|pair| pair.1);
+        Ok(last_finalized_block_number)
+    }
+
+    fn last_safe_block_number(&self) -> ProviderResult<Option<BlockNumber>> {
+        let mut finalized_blocks = self
+            .tx
+            .cursor_read::<tables::ChainState>()?
+            .walk(Some(tables::ChainStateKey::LastSafeBlock))?
+            .take(1)
+            .collect::<Result<BTreeMap<tables::ChainStateKey, BlockNumber>, _>>()?;
+
+        let last_finalized_block_number = finalized_blocks.pop_first().map(|pair| pair.1);
+        Ok(last_finalized_block_number)
+    }
+}
+
+impl<TX: DbTxMut, N: NodeTypes> ChainStateBlockWriter for DatabaseProvider<TX, N> {
+    fn save_finalized_block_number(&self, block_number: BlockNumber) -> ProviderResult<()> {
+        Ok(self
+            .tx
+            .put::<tables::ChainState>(tables::ChainStateKey::LastFinalizedBlock, block_number)?)
+    }
+
+    fn save_safe_block_number(&self, block_number: BlockNumber) -> ProviderResult<()> {
+        Ok(self.tx.put::<tables::ChainState>(tables::ChainStateKey::LastSafeBlock, block_number)?)
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider<TX, N> {
+    type Tx = TX;
+
+    fn tx_ref(&self) -> &Self::Tx {
+        &self.tx
+    }
+
+    fn tx_mut(&mut self) -> &mut Self::Tx {
+        &mut self.tx
+    }
+
+    fn into_tx(self) -> Self::Tx {
+        self.tx
+    }
+
+    fn prune_modes_ref(&self) -> &PruneModes {
+        self.prune_modes_ref()
+    }
+
+    /// Commit database transaction, static files, and pending `RocksDB` batches.
+    #[instrument(
+        name = "DatabaseProvider::commit",
+        level = "debug",
+        target = "providers::db",
+        skip_all
+    )]
+    fn commit(self) -> ProviderResult<()> {
+        if self.static_file_provider.has_unwind_queued() || self.commit_order.is_unwind() {
+            self.commit_unwind()?;
+        } else {
+            // Normal path: finalize() will call sync_all() if not already synced
+            let mut timings = metrics::CommitTimings::default();
+
+            let start = Instant::now();
+            self.static_file_provider.finalize()?;
+            timings.sf = start.elapsed();
+
+            let start = Instant::now();
+            let batches = std::mem::take(&mut *self.pending_rocksdb_batches.lock());
+            for batch in batches {
+                self.rocksdb_provider.commit_batch(batch)?;
+            }
+            timings.rocksdb = start.elapsed();
+
+            let start = Instant::now();
+            self.tx.commit()?;
+            timings.mdbx = start.elapsed();
+
+            self.metrics.record_commit(&timings);
+        }
+
+        Ok(())
+    }
+}
+
+impl<TX: DbTx, N: NodeTypes> MetadataProvider for DatabaseProvider<TX, N> {
+    fn get_metadata(&self, key: &str) -> ProviderResult<Option<Vec<u8>>> {
+        self.tx.get::<tables::Metadata>(key.to_string()).map_err(Into::into)
+    }
+}
+
+impl<TX: DbTxMut, N: NodeTypes> MetadataWriter for DatabaseProvider<TX, N> {
+    fn write_metadata(&self, key: &str, value: Vec<u8>) -> ProviderResult<()> {
+        self.tx.put::<tables::Metadata>(key.to_string(), value).map_err(Into::into)
+    }
+}
+
+impl<TX: Send, N: NodeTypes> StorageSettingsCache for DatabaseProvider<TX, N> {
+    fn cached_storage_settings(&self) -> StorageSettings {
+        *self.storage_settings.read()
+    }
+
+    fn set_storage_settings_cache(&self, settings: StorageSettings) {
+        *self.storage_settings.write() = settings;
+    }
+}
+
+impl<TX: Send, N: NodeTypes> StoragePath for DatabaseProvider<TX, N> {
+    fn storage_path(&self) -> PathBuf {
+        self.db_path.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_utils::{blocks::BlockchainTestData, create_test_provider_factory},
+        BlockWriter,
+    };
+    use alloy_consensus::Header;
+    use alloy_primitives::{
+        map::{AddressMap, B256Map},
+        U256,
+    };
+    use reth_chain_state::ExecutedBlock;
+    use reth_db_api::models::StorageSettings;
+    use reth_ethereum_primitives::Receipt;
+    use reth_execution_types::{AccountRevertInit, BlockExecutionOutput, BlockExecutionResult};
+    use reth_primitives_traits::SealedBlock;
+    use reth_storage_api::MetadataWriter;
+    use reth_testing_utils::generators::{self, random_block, BlockParams};
+    use reth_trie::{
+        HashedPostState, KeccakKeyHasher, Nibbles, StoredNibbles, StoredNibblesSubKey,
+    };
+    use revm_database::BundleState;
+    use revm_state::AccountInfo;
+    use std::{sync::mpsc, time::Duration};
+
+    #[test]
+    fn test_receipts_by_block_range_empty_range() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider().unwrap();
+
+        // empty range should return empty vec
+        let start = 10u64;
+        let end = 9u64;
+        let result = provider.receipts_by_block_range(start..=end).unwrap();
+        assert_eq!(result, Vec::<Vec<reth_ethereum_primitives::Receipt>>::new());
+    }
+
+    #[test]
+    fn unwind_commit_waits_for_pre_commit_readers() {
+        let factory = create_test_provider_factory();
+
+        let reader = factory.provider().unwrap();
+        let provider_rw = factory.unwind_provider_rw().unwrap();
+        provider_rw.write_metadata("unwind-wait-test", vec![1]).unwrap();
+        let (done_tx, done_rx) = mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            let result = provider_rw.commit();
+            done_tx.send(result).unwrap();
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "unwind commit should wait while an older read transaction is still open"
+        );
+
+        drop(reader);
+
+        done_rx.recv_timeout(Duration::from_secs(1)).unwrap().unwrap();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_receipts_by_block_range_nonexistent_blocks() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider().unwrap();
+
+        // non-existent blocks should return empty vecs for each block
+        let result = provider.receipts_by_block_range(10..=12).unwrap();
+        assert_eq!(result, vec![vec![], vec![], vec![]]);
+    }
+
+    #[test]
+    fn test_receipts_by_block_range_single_block() {
+        let factory = create_test_provider_factory();
+        let data = BlockchainTestData::default();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
+        provider_rw
+            .write_state(
+                &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
+                crate::OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )
+            .unwrap();
+        provider_rw.insert_block(&data.blocks[0].0).unwrap();
+        provider_rw
+            .write_state(
+                &data.blocks[0].1,
+                crate::OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let result = provider.receipts_by_block_range(1..=1).unwrap();
+
+        // should have one vec with one receipt
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].len(), 1);
+        assert_eq!(result[0][0], data.blocks[0].1.receipts()[0][0]);
+    }
+
+    #[test]
+    fn test_receipts_by_block_range_multiple_blocks() {
+        let factory = create_test_provider_factory();
+        let data = BlockchainTestData::default();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
+        provider_rw
+            .write_state(
+                &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
+                crate::OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )
+            .unwrap();
+        for i in 0..3 {
+            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+            provider_rw
+                .write_state(
+                    &data.blocks[i].1,
+                    crate::OriginalValuesKnown::No,
+                    StateWriteConfig::default(),
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let result = provider.receipts_by_block_range(1..=3).unwrap();
+
+        // should have 3 vecs, each with one receipt
+        assert_eq!(result.len(), 3);
+        for (i, block_receipts) in result.iter().enumerate() {
+            assert_eq!(block_receipts.len(), 1);
+            assert_eq!(block_receipts[0], data.blocks[i].1.receipts()[0][0]);
+        }
+    }
+
+    #[test]
+    fn test_receipts_by_block_range_blocks_with_varying_tx_counts() {
+        let factory = create_test_provider_factory();
+        let data = BlockchainTestData::default();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
+        provider_rw
+            .write_state(
+                &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
+                crate::OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )
+            .unwrap();
+
+        // insert blocks 1-3 with receipts
+        for i in 0..3 {
+            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+            provider_rw
+                .write_state(
+                    &data.blocks[i].1,
+                    crate::OriginalValuesKnown::No,
+                    StateWriteConfig::default(),
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let result = provider.receipts_by_block_range(1..=3).unwrap();
+
+        // verify each block has one receipt
+        assert_eq!(result.len(), 3);
+        for block_receipts in &result {
+            assert_eq!(block_receipts.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_receipts_by_block_range_partial_range() {
+        let factory = create_test_provider_factory();
+        let data = BlockchainTestData::default();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
+        provider_rw
+            .write_state(
+                &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
+                crate::OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )
+            .unwrap();
+        for i in 0..3 {
+            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+            provider_rw
+                .write_state(
+                    &data.blocks[i].1,
+                    crate::OriginalValuesKnown::No,
+                    StateWriteConfig::default(),
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+
+        // request range that includes both existing and non-existing blocks
+        let result = provider.receipts_by_block_range(2..=5).unwrap();
+        assert_eq!(result.len(), 4);
+
+        // blocks 2-3 should have receipts, blocks 4-5 should be empty
+        assert_eq!(result[0].len(), 1); // block 2
+        assert_eq!(result[1].len(), 1); // block 3
+        assert_eq!(result[2].len(), 0); // block 4 (doesn't exist)
+        assert_eq!(result[3].len(), 0); // block 5 (doesn't exist)
+
+        assert_eq!(result[0][0], data.blocks[1].1.receipts()[0][0]);
+        assert_eq!(result[1][0], data.blocks[2].1.receipts()[0][0]);
+    }
+
+    #[test]
+    fn test_receipts_by_block_range_all_empty_blocks() {
+        let factory = create_test_provider_factory();
+        let mut rng = generators::rng();
+
+        // create blocks with no transactions
+        let mut blocks = Vec::new();
+        for i in 0..3 {
+            let block =
+                random_block(&mut rng, i, BlockParams { tx_count: Some(0), ..Default::default() });
+            blocks.push(block);
+        }
+
+        let provider_rw = factory.provider_rw().unwrap();
+        for block in blocks {
+            provider_rw.insert_block(&block.try_recover().unwrap()).unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let result = provider.receipts_by_block_range(1..=3).unwrap();
+
+        assert_eq!(result.len(), 3);
+        for block_receipts in result {
+            assert_eq!(block_receipts.len(), 0);
+        }
+    }
+
+    #[test]
+    fn test_receipts_by_block_range_consistency_with_individual_calls() {
+        let factory = create_test_provider_factory();
+        let data = BlockchainTestData::default();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
+        provider_rw
+            .write_state(
+                &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
+                crate::OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )
+            .unwrap();
+        for i in 0..3 {
+            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+            provider_rw
+                .write_state(
+                    &data.blocks[i].1,
+                    crate::OriginalValuesKnown::No,
+                    StateWriteConfig::default(),
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+
+        // get receipts using block range method
+        let range_result = provider.receipts_by_block_range(1..=3).unwrap();
+
+        // get receipts using individual block calls
+        let mut individual_results = Vec::new();
+        for block_num in 1..=3 {
+            let receipts =
+                provider.receipts_by_block(block_num.into()).unwrap().unwrap_or_default();
+            individual_results.push(receipts);
+        }
+
+        assert_eq!(range_result, individual_results);
+    }
+
+    #[test]
+    fn test_write_trie_updates_sorted() {
+        use reth_trie::{
+            updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
+            BranchNodeCompact, StorageTrieEntry,
+        };
+
+        let factory = create_test_provider_factory();
+        let provider_rw = factory.provider_rw().unwrap();
+
+        // Pre-populate account trie with data that will be deleted
+        {
+            let tx = provider_rw.tx_ref();
+            let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+
+            // Add account node that will be deleted
+            let to_delete = StoredNibbles(Nibbles::from_nibbles([0x3, 0x4]));
+            cursor
+                .upsert(
+                    to_delete,
+                    &BranchNodeCompact::new(
+                        0b1010_1010_1010_1010, // state_mask
+                        0b0000_0000_0000_0000, // tree_mask
+                        0b0000_0000_0000_0000, // hash_mask
+                        vec![],
+                        None,
+                    ),
+                )
+                .unwrap();
+
+            // Add account node that will be updated
+            let to_update = StoredNibbles(Nibbles::from_nibbles([0x1, 0x2]));
+            cursor
+                .upsert(
+                    to_update,
+                    &BranchNodeCompact::new(
+                        0b0101_0101_0101_0101, // old state_mask (will be updated)
+                        0b0000_0000_0000_0000, // tree_mask
+                        0b0000_0000_0000_0000, // hash_mask
+                        vec![],
+                        None,
+                    ),
+                )
+                .unwrap();
+        }
+
+        // Pre-populate storage tries with data
+        let storage_address1 = B256::from([1u8; 32]);
+        let storage_address2 = B256::from([2u8; 32]);
+        {
+            let tx = provider_rw.tx_ref();
+            let mut storage_cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+
+            // Add storage nodes for address1 (one will be deleted)
+            storage_cursor
+                .upsert(
+                    storage_address1,
+                    &StorageTrieEntry {
+                        nibbles: StoredNibblesSubKey(Nibbles::from_nibbles([0x2, 0x0])),
+                        node: BranchNodeCompact::new(
+                            0b0011_0011_0011_0011, // will be deleted
+                            0b0000_0000_0000_0000,
+                            0b0000_0000_0000_0000,
+                            vec![],
+                            None,
+                        ),
+                    },
+                )
+                .unwrap();
+
+            // Add storage nodes for address2 (will be wiped)
+            storage_cursor
+                .upsert(
+                    storage_address2,
+                    &StorageTrieEntry {
+                        nibbles: StoredNibblesSubKey(Nibbles::from_nibbles([0xa, 0xb])),
+                        node: BranchNodeCompact::new(
+                            0b1100_1100_1100_1100, // will be wiped
+                            0b0000_0000_0000_0000,
+                            0b0000_0000_0000_0000,
+                            vec![],
+                            None,
+                        ),
+                    },
+                )
+                .unwrap();
+            storage_cursor
+                .upsert(
+                    storage_address2,
+                    &StorageTrieEntry {
+                        nibbles: StoredNibblesSubKey(Nibbles::from_nibbles([0xc, 0xd])),
+                        node: BranchNodeCompact::new(
+                            0b0011_1100_0011_1100, // will be wiped
+                            0b0000_0000_0000_0000,
+                            0b0000_0000_0000_0000,
+                            vec![],
+                            None,
+                        ),
+                    },
+                )
+                .unwrap();
+        }
+
+        // Create sorted account trie updates
+        let account_nodes = vec![
+            (
+                Nibbles::from_nibbles([0x1, 0x2]),
+                Some(BranchNodeCompact::new(
+                    0b1111_1111_1111_1111, // state_mask (updated)
+                    0b0000_0000_0000_0000, // tree_mask
+                    0b0000_0000_0000_0000, // hash_mask (no hashes)
+                    vec![],
+                    None,
+                )),
+            ),
+            (Nibbles::from_nibbles([0x3, 0x4]), None), // Deletion
+            (
+                Nibbles::from_nibbles([0x5, 0x6]),
+                Some(BranchNodeCompact::new(
+                    0b1111_1111_1111_1111, // state_mask
+                    0b0000_0000_0000_0000, // tree_mask
+                    0b0000_0000_0000_0000, // hash_mask (no hashes)
+                    vec![],
+                    None,
+                )),
+            ),
+        ];
+
+        // Create sorted storage trie updates
+        let storage_trie1 = StorageTrieUpdatesSorted {
+            is_deleted: false,
+            storage_nodes: vec![
+                (
+                    Nibbles::from_nibbles([0x1, 0x0]),
+                    Some(BranchNodeCompact::new(
+                        0b1111_0000_0000_0000, // state_mask
+                        0b0000_0000_0000_0000, // tree_mask
+                        0b0000_0000_0000_0000, // hash_mask (no hashes)
+                        vec![],
+                        None,
+                    )),
+                ),
+                (Nibbles::from_nibbles([0x2, 0x0]), None), // Deletion of existing node
+            ],
+        };
+
+        let storage_trie2 = StorageTrieUpdatesSorted {
+            is_deleted: true, // Wipe all storage for this address
+            storage_nodes: vec![],
+        };
+
+        let mut storage_tries = B256Map::default();
+        storage_tries.insert(storage_address1, storage_trie1);
+        storage_tries.insert(storage_address2, storage_trie2);
+
+        let trie_updates = TrieUpdatesSorted::new(account_nodes, storage_tries);
+
+        // Write the sorted trie updates
+        let num_entries = provider_rw.write_trie_updates_sorted(&trie_updates).unwrap();
+
+        // We should have 2 account insertions + 1 account deletion + 1 storage insertion + 1
+        // storage deletion = 5
+        assert_eq!(num_entries, 5);
+
+        // Verify account trie updates were written correctly
+        let tx = provider_rw.tx_ref();
+        let mut cursor = tx.cursor_read::<tables::AccountsTrie>().unwrap();
+
+        // Check first account node was updated
+        let nibbles1 = StoredNibbles(Nibbles::from_nibbles([0x1, 0x2]));
+        let entry1 = cursor.seek_exact(nibbles1).unwrap();
+        assert!(entry1.is_some(), "Updated account node should exist");
+        let expected_mask = reth_trie::TrieMask::new(0b1111_1111_1111_1111);
+        assert_eq!(
+            entry1.unwrap().1.state_mask,
+            expected_mask,
+            "Account node should have updated state_mask"
+        );
+
+        // Check deleted account node no longer exists
+        let nibbles2 = StoredNibbles(Nibbles::from_nibbles([0x3, 0x4]));
+        let entry2 = cursor.seek_exact(nibbles2).unwrap();
+        assert!(entry2.is_none(), "Deleted account node should not exist");
+
+        // Check new account node exists
+        let nibbles3 = StoredNibbles(Nibbles::from_nibbles([0x5, 0x6]));
+        let entry3 = cursor.seek_exact(nibbles3).unwrap();
+        assert!(entry3.is_some(), "New account node should exist");
+
+        // Verify storage trie updates were written correctly
+        let mut storage_cursor = tx.cursor_dup_read::<tables::StoragesTrie>().unwrap();
+
+        // Check storage for address1
+        let storage_entries1: Vec<_> = storage_cursor
+            .walk_dup(Some(storage_address1), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            storage_entries1.len(),
+            1,
+            "Storage address1 should have 1 entry after deletion"
+        );
+        assert_eq!(
+            storage_entries1[0].1.nibbles.0,
+            Nibbles::from_nibbles([0x1, 0x0]),
+            "Remaining entry should be [0x1, 0x0]"
+        );
+
+        // Check storage for address2 was wiped
+        let storage_entries2: Vec<_> = storage_cursor
+            .walk_dup(Some(storage_address2), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(storage_entries2.len(), 0, "Storage address2 should be empty after wipe");
+
+        provider_rw.commit().unwrap();
+    }
+
+    #[test]
+    fn test_prunable_receipts_logic() {
+        let insert_blocks =
+            |provider_rw: &DatabaseProviderRW<_, _>, tip_block: u64, tx_count: u8| {
+                let mut rng = generators::rng();
+                for block_num in 0..=tip_block {
+                    let block = random_block(
+                        &mut rng,
+                        block_num,
+                        BlockParams { tx_count: Some(tx_count), ..Default::default() },
+                    );
+                    provider_rw.insert_block(&block.try_recover().unwrap()).unwrap();
+                }
+            };
+
+        let write_receipts = |provider_rw: DatabaseProviderRW<_, _>, block: u64| {
+            let outcome = ExecutionOutcome {
+                first_block: block,
+                receipts: vec![vec![Receipt {
+                    tx_type: Default::default(),
+                    success: true,
+                    cumulative_gas_used: block, // identifier to assert against
+                    logs: vec![],
+                }]],
+                ..Default::default()
+            };
+            provider_rw
+                .write_state(&outcome, crate::OriginalValuesKnown::No, StateWriteConfig::default())
+                .unwrap();
+            provider_rw.commit().unwrap();
+        };
+
+        // Legacy mode (receipts in DB) - should be prunable
+        {
+            let factory = create_test_provider_factory();
+            let storage_settings = StorageSettings::v1();
+            factory.set_storage_settings_cache(storage_settings);
+            let factory = factory.with_prune_modes(PruneModes {
+                receipts: Some(PruneMode::Before(100)),
+                ..Default::default()
+            });
+
+            let tip_block = 200u64;
+            let first_block = 1u64;
+
+            // create chain
+            let provider_rw = factory.provider_rw().unwrap();
+            insert_blocks(&provider_rw, tip_block, 1);
+            provider_rw.commit().unwrap();
+
+            write_receipts(
+                factory.provider_rw().unwrap().with_minimum_pruning_distance(100),
+                first_block,
+            );
+            write_receipts(
+                factory.provider_rw().unwrap().with_minimum_pruning_distance(100),
+                tip_block - 1,
+            );
+
+            let provider = factory.provider().unwrap();
+
+            for (block, num_receipts) in [(0, 0), (tip_block - 1, 1)] {
+                assert!(provider
+                    .receipts_by_block(block.into())
+                    .unwrap()
+                    .is_some_and(|r| r.len() == num_receipts));
+            }
+        }
+
+        // Static files mode
+        {
+            let factory = create_test_provider_factory();
+            let storage_settings = StorageSettings::v2();
+            factory.set_storage_settings_cache(storage_settings);
+            let factory = factory.with_prune_modes(PruneModes {
+                receipts: Some(PruneMode::Before(2)),
+                ..Default::default()
+            });
+
+            let tip_block = 200u64;
+
+            // create chain
+            let provider_rw = factory.provider_rw().unwrap();
+            insert_blocks(&provider_rw, tip_block, 1);
+            provider_rw.commit().unwrap();
+
+            // Attempt to write receipts for block 0 and 1 (should be skipped)
+            write_receipts(factory.provider_rw().unwrap().with_minimum_pruning_distance(100), 0);
+            write_receipts(factory.provider_rw().unwrap().with_minimum_pruning_distance(100), 1);
+
+            assert!(factory
+                .static_file_provider()
+                .get_highest_static_file_tx(StaticFileSegment::Receipts)
+                .is_none(),);
+            assert!(factory
+                .static_file_provider()
+                .get_highest_static_file_block(StaticFileSegment::Receipts)
+                .is_some_and(|b| b == 1),);
+
+            // Since we have prune mode Before(2), the next receipt (block 2) should be written to
+            // static files.
+            write_receipts(factory.provider_rw().unwrap().with_minimum_pruning_distance(100), 2);
+            assert!(factory
+                .static_file_provider()
+                .get_highest_static_file_tx(StaticFileSegment::Receipts)
+                .is_some_and(|num| num == 2),);
+
+            // After having a receipt already in static files, attempt to skip the next receipt by
+            // changing the prune mode. It should NOT skip it and should still write the receipt,
+            // since static files do not support gaps.
+            let factory = factory.with_prune_modes(PruneModes {
+                receipts: Some(PruneMode::Before(100)),
+                ..Default::default()
+            });
+            let provider_rw = factory.provider_rw().unwrap().with_minimum_pruning_distance(1);
+            assert!(PruneMode::Distance(1).should_prune(3, tip_block));
+            write_receipts(provider_rw, 3);
+
+            // Ensure we can only fetch the 2 last receipts.
+            //
+            // Test setup only has 1 tx per block and each receipt has its cumulative_gas_used set
+            // to the block number it belongs to easily identify and assert.
+            let provider = factory.provider().unwrap();
+            assert!(EitherWriter::receipts_destination(&provider).is_static_file());
+            for (num, num_receipts) in [(0, 0), (1, 0), (2, 1), (3, 1)] {
+                assert!(provider
+                    .receipts_by_block(num.into())
+                    .unwrap()
+                    .is_some_and(|r| r.len() == num_receipts));
+
+                let receipt = provider.receipt(num).unwrap();
+                if num_receipts > 0 {
+                    assert!(receipt.is_some_and(|r| r.cumulative_gas_used == num));
+                } else {
+                    assert!(receipt.is_none());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_try_into_history_rejects_unexecuted_blocks() {
+        use reth_storage_api::TryIntoHistoricalStateProvider;
+
+        let factory = create_test_provider_factory();
+
+        // Insert genesis block to have some data
+        let data = BlockchainTestData::default();
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
+        provider_rw
+            .write_state(
+                &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
+                crate::OriginalValuesKnown::No,
+                StateWriteConfig::default(),
+            )
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        // Get a fresh provider - Execution checkpoint is 0, no receipts written beyond genesis
+        let provider = factory.provider().unwrap();
+
+        // Requesting historical state for block 0 (executed) should succeed
+        let result = provider.try_into_history_at_block(0);
+        assert!(result.is_ok(), "Block 0 should be available");
+
+        // Get another provider and request state for block 100 (not executed)
+        let provider = factory.provider().unwrap();
+        let result = provider.try_into_history_at_block(100);
+
+        // Should fail with BlockNotExecuted error
+        match result {
+            Err(ProviderError::BlockNotExecuted { requested: 100, .. }) => {}
+            Err(e) => panic!("Expected BlockNotExecuted error, got: {e:?}"),
+            Ok(_) => panic!("Expected error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn test_unwind_storage_hashing_with_hashed_state() {
+        let factory = create_test_provider_factory();
+        let storage_settings = StorageSettings::v2();
+        factory.set_storage_settings_cache(storage_settings);
+
+        let address = Address::random();
+        let hashed_address = keccak256(address);
+
+        let plain_slot = B256::random();
+        let hashed_slot = keccak256(plain_slot);
+
+        let current_value = U256::from(100);
+        let old_value = U256::from(42);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw
+            .tx
+            .cursor_dup_write::<tables::HashedStorages>()
+            .unwrap()
+            .upsert(hashed_address, &StorageEntry { key: hashed_slot, value: current_value })
+            .unwrap();
+
+        let changesets = vec![(
+            BlockNumberAddress((1, address)),
+            StorageEntry { key: plain_slot, value: old_value },
+        )];
+
+        let result = provider_rw.unwind_storage_hashing(changesets.into_iter()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&hashed_address));
+        assert!(result[&hashed_address].contains(&hashed_slot));
+
+        let mut cursor = provider_rw.tx.cursor_dup_read::<tables::HashedStorages>().unwrap();
+        let entry = cursor
+            .seek_by_key_subkey(hashed_address, hashed_slot)
+            .unwrap()
+            .expect("entry should exist");
+        assert_eq!(entry.key, hashed_slot);
+        assert_eq!(entry.value, old_value);
+    }
+
+    #[test]
+    fn test_write_and_remove_state_roundtrip_legacy() {
+        let factory = create_test_provider_factory();
+        let storage_settings = StorageSettings::v1();
+        assert!(!storage_settings.use_hashed_state());
+        factory.set_storage_settings_cache(storage_settings);
+
+        let address = Address::with_last_byte(1);
+        let hashed_address = keccak256(address);
+        let slot = U256::from(5);
+        let slot_key = B256::from(slot);
+        let hashed_slot = keccak256(slot_key);
+
+        let mut rng = generators::rng();
+        let block0 =
+            random_block(&mut rng, 0, BlockParams { tx_count: Some(0), ..Default::default() });
+        let block1 =
+            random_block(&mut rng, 1, BlockParams { tx_count: Some(0), ..Default::default() });
+
+        {
+            let provider_rw = factory.provider_rw().unwrap();
+            provider_rw.insert_block(&block0.try_recover().unwrap()).unwrap();
+            provider_rw.insert_block(&block1.try_recover().unwrap()).unwrap();
+            provider_rw
+                .tx
+                .cursor_write::<tables::PlainAccountState>()
+                .unwrap()
+                .upsert(address, &Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None })
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        let provider_rw = factory.provider_rw().unwrap();
+
+        let mut state_init: BundleStateInit = AddressMap::default();
+        let mut storage_map: B256Map<(U256, U256)> = B256Map::default();
+        storage_map.insert(slot_key, (U256::ZERO, U256::from(10)));
+        state_init.insert(
+            address,
+            (
+                Some(Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None }),
+                Some(Account { nonce: 1, balance: U256::ZERO, bytecode_hash: None }),
+                storage_map,
+            ),
+        );
+
+        let mut reverts_init: RevertsInit = HashMap::default();
+        let mut block_reverts: AddressMap<AccountRevertInit> = AddressMap::default();
+        block_reverts.insert(
+            address,
+            (
+                Some(Some(Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None })),
+                vec![StorageEntry { key: slot_key, value: U256::ZERO }],
+            ),
+        );
+        reverts_init.insert(1, block_reverts);
+
+        let execution_outcome =
+            ExecutionOutcome::new_init(state_init, reverts_init, [], vec![vec![]], 1, vec![]);
+
+        provider_rw
+            .write_state(
+                &execution_outcome,
+                OriginalValuesKnown::Yes,
+                StateWriteConfig {
+                    write_receipts: false,
+                    write_account_changesets: true,
+                    write_storage_changesets: true,
+                },
+            )
+            .unwrap();
+
+        let hashed_state =
+            execution_outcome.hash_state_slow::<reth_trie::KeccakKeyHasher>().into_sorted();
+        provider_rw.write_hashed_state(&hashed_state).unwrap();
+
+        let account = provider_rw
+            .tx
+            .cursor_read::<tables::PlainAccountState>()
+            .unwrap()
+            .seek_exact(address)
+            .unwrap()
+            .unwrap()
+            .1;
+        assert_eq!(account.nonce, 1);
+
+        let storage_entry = provider_rw
+            .tx
+            .cursor_dup_read::<tables::PlainStorageState>()
+            .unwrap()
+            .seek_by_key_subkey(address, slot_key)
+            .unwrap()
+            .unwrap();
+        assert_eq!(storage_entry.key, slot_key);
+        assert_eq!(storage_entry.value, U256::from(10));
+
+        let hashed_entry = provider_rw
+            .tx
+            .cursor_dup_read::<tables::HashedStorages>()
+            .unwrap()
+            .seek_by_key_subkey(hashed_address, hashed_slot)
+            .unwrap()
+            .unwrap();
+        assert_eq!(hashed_entry.key, hashed_slot);
+        assert_eq!(hashed_entry.value, U256::from(10));
+
+        let account_cs_entries = provider_rw
+            .tx
+            .cursor_dup_read::<tables::AccountChangeSets>()
+            .unwrap()
+            .walk(Some(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(!account_cs_entries.is_empty());
+
+        let storage_cs_entries = provider_rw
+            .tx
+            .cursor_read::<tables::StorageChangeSets>()
+            .unwrap()
+            .walk(Some(BlockNumberAddress((1, address))))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(!storage_cs_entries.is_empty());
+        assert_eq!(storage_cs_entries[0].1.key, slot_key);
+
+        provider_rw.remove_state_above(0).unwrap();
+
+        let restored_account = provider_rw
+            .tx
+            .cursor_read::<tables::PlainAccountState>()
+            .unwrap()
+            .seek_exact(address)
+            .unwrap()
+            .unwrap()
+            .1;
+        assert_eq!(restored_account.nonce, 0);
+
+        let storage_gone = provider_rw
+            .tx
+            .cursor_dup_read::<tables::PlainStorageState>()
+            .unwrap()
+            .seek_by_key_subkey(address, slot_key)
+            .unwrap();
+        assert!(storage_gone.is_none() || storage_gone.unwrap().key != slot_key);
+
+        let account_cs_after = provider_rw
+            .tx
+            .cursor_dup_read::<tables::AccountChangeSets>()
+            .unwrap()
+            .walk(Some(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(account_cs_after.is_empty());
+
+        let storage_cs_after = provider_rw
+            .tx
+            .cursor_read::<tables::StorageChangeSets>()
+            .unwrap()
+            .walk(Some(BlockNumberAddress((1, address))))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(storage_cs_after.is_empty());
+    }
+
+    #[test]
+    fn test_unwind_storage_hashing_legacy() {
+        let factory = create_test_provider_factory();
+        let storage_settings = StorageSettings::v1();
+        assert!(!storage_settings.use_hashed_state());
+        factory.set_storage_settings_cache(storage_settings);
+
+        let address = Address::random();
+        let hashed_address = keccak256(address);
+
+        let plain_slot = B256::random();
+        let hashed_slot = keccak256(plain_slot);
+
+        let current_value = U256::from(100);
+        let old_value = U256::from(42);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw
+            .tx
+            .cursor_dup_write::<tables::HashedStorages>()
+            .unwrap()
+            .upsert(hashed_address, &StorageEntry { key: hashed_slot, value: current_value })
+            .unwrap();
+
+        let changesets = vec![(
+            BlockNumberAddress((1, address)),
+            StorageEntry { key: plain_slot, value: old_value },
+        )];
+
+        let result = provider_rw.unwind_storage_hashing(changesets.into_iter()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&hashed_address));
+        assert!(result[&hashed_address].contains(&hashed_slot));
+
+        let mut cursor = provider_rw.tx.cursor_dup_read::<tables::HashedStorages>().unwrap();
+        let entry = cursor
+            .seek_by_key_subkey(hashed_address, hashed_slot)
+            .unwrap()
+            .expect("entry should exist");
+        assert_eq!(entry.key, hashed_slot);
+        assert_eq!(entry.value, old_value);
+    }
+
+    #[test]
+    fn test_write_state_and_historical_read_hashed() {
+        use reth_storage_api::StateProvider;
+        use reth_trie::{HashedPostState, KeccakKeyHasher};
+        use revm_database::BundleState;
+        use revm_state::AccountInfo;
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let address = Address::with_last_byte(1);
+        let slot = U256::from(5);
+        let slot_key = B256::from(slot);
+        let hashed_address = keccak256(address);
+        let hashed_slot = keccak256(slot_key);
+
+        {
+            let sf = factory.static_file_provider();
+            let mut hw = sf.latest_writer(StaticFileSegment::Headers).unwrap();
+            let h0 = alloy_consensus::Header { number: 0, ..Default::default() };
+            hw.append_header(&h0, &B256::ZERO).unwrap();
+            let h1 = alloy_consensus::Header { number: 1, ..Default::default() };
+            hw.append_header(&h1, &B256::ZERO).unwrap();
+            hw.commit().unwrap();
+
+            let mut aw = sf.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            aw.append_account_changeset(vec![], 0).unwrap();
+            aw.commit().unwrap();
+
+            let mut sw = sf.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+            sw.append_storage_changeset(vec![], 0).unwrap();
+            sw.commit().unwrap();
+        }
+
+        let provider_rw = factory.provider_rw().unwrap();
+
+        let bundle = BundleState::builder(1..=1)
+            .state_present_account_info(
+                address,
+                AccountInfo { nonce: 1, balance: U256::from(10), ..Default::default() },
+            )
+            .state_storage(address, HashMap::from_iter([(slot, (U256::ZERO, U256::from(10)))]))
+            .revert_account_info(1, address, Some(None))
+            .revert_storage(1, address, vec![(slot, U256::ZERO)])
+            .build();
+
+        let execution_outcome = ExecutionOutcome::new(bundle.clone(), vec![vec![]], 1, Vec::new());
+
+        provider_rw
+            .tx
+            .put::<tables::BlockBodyIndices>(
+                1,
+                StoredBlockBodyIndices { first_tx_num: 0, tx_count: 0 },
+            )
+            .unwrap();
+
+        provider_rw
+            .write_state(
+                &execution_outcome,
+                OriginalValuesKnown::Yes,
+                StateWriteConfig {
+                    write_receipts: false,
+                    write_account_changesets: true,
+                    write_storage_changesets: true,
+                },
+            )
+            .unwrap();
+
+        let hashed_state =
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle.state()).into_sorted();
+        provider_rw.write_hashed_state(&hashed_state).unwrap();
+
+        let plain_storage_entries = provider_rw
+            .tx
+            .cursor_dup_read::<tables::PlainStorageState>()
+            .unwrap()
+            .walk(None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(plain_storage_entries.is_empty());
+
+        let hashed_entry = provider_rw
+            .tx
+            .cursor_dup_read::<tables::HashedStorages>()
+            .unwrap()
+            .seek_by_key_subkey(hashed_address, hashed_slot)
+            .unwrap()
+            .unwrap();
+        assert_eq!(hashed_entry.key, hashed_slot);
+        assert_eq!(hashed_entry.value, U256::from(10));
+
+        provider_rw.static_file_provider().commit().unwrap();
+
+        let sf = factory.static_file_provider();
+        let storage_cs = sf.storage_changeset(1).unwrap();
+        assert!(!storage_cs.is_empty());
+        assert_eq!(storage_cs[0].1.key, slot_key);
+
+        let account_cs = sf.account_block_changeset(1).unwrap();
+        assert!(!account_cs.is_empty());
+        assert_eq!(account_cs[0].address, address);
+
+        let historical_value =
+            HistoricalStateProviderRef::new(&*provider_rw, 0, ChangesetCache::new())
+                .storage(address, slot_key)
+                .unwrap();
+        assert_eq!(historical_value, None);
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum StorageMode {
+        V1,
+        V2,
+    }
+
+    fn run_save_blocks_and_verify(mode: StorageMode) {
+        use alloy_primitives::map::{FbBuildHasher, HashMap};
+
+        let factory = create_test_provider_factory();
+
+        match mode {
+            StorageMode::V1 => factory.set_storage_settings_cache(StorageSettings::v1()),
+            StorageMode::V2 => factory.set_storage_settings_cache(StorageSettings::v2()),
+        }
+
+        let num_blocks = 3u64;
+        let accounts_per_block = 5usize;
+        let slots_per_account = 3usize;
+
+        let genesis = SealedBlock::<reth_ethereum_primitives::Block>::from_sealed_parts(
+            SealedHeader::new(
+                Header { number: 0, difficulty: U256::from(1), ..Default::default() },
+                B256::ZERO,
+            ),
+            Default::default(),
+        );
+
+        let genesis_executed = ExecutedBlock::new(
+            Arc::new(genesis.try_recover().unwrap()),
+            Arc::new(BlockExecutionOutput {
+                result: BlockExecutionResult {
+                    receipts: vec![],
+                    requests: Default::default(),
+                    gas_used: 0,
+                    blob_gas_used: 0,
+                },
+                state: Default::default(),
+            }),
+            ComputedTrieData::default(),
+        );
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.save_blocks(vec![genesis_executed], SaveBlocksMode::Full).unwrap();
+        provider_rw.commit().unwrap();
+
+        let mut blocks: Vec<ExecutedBlock> = Vec::new();
+        let mut parent_hash = B256::ZERO;
+
+        for block_num in 1..=num_blocks {
+            let mut builder = BundleState::builder(block_num..=block_num);
+
+            for acct_idx in 0..accounts_per_block {
+                let address = Address::with_last_byte((block_num * 10 + acct_idx as u64) as u8);
+                let info = AccountInfo {
+                    nonce: block_num,
+                    balance: U256::from(block_num * 100 + acct_idx as u64),
+                    ..Default::default()
+                };
+
+                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1..=
+                    slots_per_account as u64)
+                    .map(|s| {
+                        (
+                            U256::from(s + acct_idx as u64 * 100),
+                            (U256::ZERO, U256::from(block_num * 1000 + s)),
+                        )
+                    })
+                    .collect();
+
+                let revert_storage: Vec<(U256, U256)> = (1..=slots_per_account as u64)
+                    .map(|s| (U256::from(s + acct_idx as u64 * 100), U256::ZERO))
+                    .collect();
+
+                builder = builder
+                    .state_present_account_info(address, info)
+                    .revert_account_info(block_num, address, Some(None))
+                    .state_storage(address, storage)
+                    .revert_storage(block_num, address, revert_storage);
+            }
+
+            let bundle = builder.build();
+
+            let hashed_state =
+                HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle.state()).into_sorted();
+
+            let header = Header {
+                number: block_num,
+                parent_hash,
+                difficulty: U256::from(1),
+                ..Default::default()
+            };
+            let block = SealedBlock::<reth_ethereum_primitives::Block>::seal_parts(
+                header,
+                Default::default(),
+            );
+            parent_hash = block.hash();
+
+            let executed = ExecutedBlock::new(
+                Arc::new(block.try_recover().unwrap()),
+                Arc::new(BlockExecutionOutput {
+                    result: BlockExecutionResult {
+                        receipts: vec![],
+                        requests: Default::default(),
+                        gas_used: 0,
+                        blob_gas_used: 0,
+                    },
+                    state: bundle,
+                }),
+                ComputedTrieData { hashed_state: Arc::new(hashed_state), ..Default::default() },
+            );
+            blocks.push(executed);
+        }
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.save_blocks(blocks, SaveBlocksMode::Full).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+
+        for block_num in 1..=num_blocks {
+            for acct_idx in 0..accounts_per_block {
+                let address = Address::with_last_byte((block_num * 10 + acct_idx as u64) as u8);
+                let hashed_address = keccak256(address);
+
+                let ha_entry = provider
+                    .tx_ref()
+                    .cursor_read::<tables::HashedAccounts>()
+                    .unwrap()
+                    .seek_exact(hashed_address)
+                    .unwrap();
+                assert!(
+                    ha_entry.is_some(),
+                    "HashedAccounts missing for block {block_num} acct {acct_idx}"
+                );
+
+                for s in 1..=slots_per_account as u64 {
+                    let slot = U256::from(s + acct_idx as u64 * 100);
+                    let slot_key = B256::from(slot);
+                    let hashed_slot = keccak256(slot_key);
+
+                    let hs_entry = provider
+                        .tx_ref()
+                        .cursor_dup_read::<tables::HashedStorages>()
+                        .unwrap()
+                        .seek_by_key_subkey(hashed_address, hashed_slot)
+                        .unwrap();
+                    assert!(
+                        hs_entry.is_some(),
+                        "HashedStorages missing for block {block_num} acct {acct_idx} slot {s}"
+                    );
+                    let entry = hs_entry.unwrap();
+                    assert_eq!(entry.key, hashed_slot);
+                    assert_eq!(entry.value, U256::from(block_num * 1000 + s));
+                }
+            }
+        }
+
+        for block_num in 1..=num_blocks {
+            let header = provider.header_by_number(block_num).unwrap();
+            assert!(header.is_some(), "Header missing for block {block_num}");
+
+            let indices = provider.block_body_indices(block_num).unwrap();
+            assert!(indices.is_some(), "BlockBodyIndices missing for block {block_num}");
+        }
+
+        let plain_accounts = provider.tx_ref().entries::<tables::PlainAccountState>().unwrap();
+        let plain_storage = provider.tx_ref().entries::<tables::PlainStorageState>().unwrap();
+
+        if mode == StorageMode::V2 {
+            assert_eq!(plain_accounts, 0, "v2: PlainAccountState should be empty");
+            assert_eq!(plain_storage, 0, "v2: PlainStorageState should be empty");
+
+            let mdbx_account_cs = provider.tx_ref().entries::<tables::AccountChangeSets>().unwrap();
+            assert_eq!(mdbx_account_cs, 0, "v2: AccountChangeSets in MDBX should be empty");
+
+            let mdbx_storage_cs = provider.tx_ref().entries::<tables::StorageChangeSets>().unwrap();
+            assert_eq!(mdbx_storage_cs, 0, "v2: StorageChangeSets in MDBX should be empty");
+
+            provider.static_file_provider().commit().unwrap();
+            let sf = factory.static_file_provider();
+
+            for block_num in 1..=num_blocks {
+                let account_cs = sf.account_block_changeset(block_num).unwrap();
+                assert!(
+                    !account_cs.is_empty(),
+                    "v2: static file AccountChangeSets should exist for block {block_num}"
+                );
+
+                let storage_cs = sf.storage_changeset(block_num).unwrap();
+                assert!(
+                    !storage_cs.is_empty(),
+                    "v2: static file StorageChangeSets should exist for block {block_num}"
+                );
+
+                for (_, entry) in &storage_cs {
+                    assert!(
+                        entry.key != keccak256(entry.key),
+                        "v2: static file storage changeset should have plain slot keys"
+                    );
+                }
+            }
+
+            let rocksdb = factory.rocksdb_provider();
+            for block_num in 1..=num_blocks {
+                for acct_idx in 0..accounts_per_block {
+                    let address = Address::with_last_byte((block_num * 10 + acct_idx as u64) as u8);
+                    let shards = rocksdb.account_history_shards(address).unwrap();
+                    assert!(
+                        !shards.is_empty(),
+                        "v2: RocksDB AccountsHistory missing for block {block_num} acct {acct_idx}"
+                    );
+
+                    for s in 1..=slots_per_account as u64 {
+                        let slot = U256::from(s + acct_idx as u64 * 100);
+                        let slot_key = B256::from(slot);
+                        let shards = rocksdb.storage_history_shards(address, slot_key).unwrap();
+                        assert!(
+                            !shards.is_empty(),
+                            "v2: RocksDB StoragesHistory missing for block {block_num} acct {acct_idx} slot {s}"
+                        );
+                    }
+                }
+            }
+        } else {
+            assert!(plain_accounts > 0, "v1: PlainAccountState should not be empty");
+            assert!(plain_storage > 0, "v1: PlainStorageState should not be empty");
+
+            let mdbx_account_cs = provider.tx_ref().entries::<tables::AccountChangeSets>().unwrap();
+            assert!(mdbx_account_cs > 0, "v1: AccountChangeSets in MDBX should not be empty");
+
+            let mdbx_storage_cs = provider.tx_ref().entries::<tables::StorageChangeSets>().unwrap();
+            assert!(mdbx_storage_cs > 0, "v1: StorageChangeSets in MDBX should not be empty");
+
+            for block_num in 1..=num_blocks {
+                let storage_entries: Vec<_> = provider
+                    .tx_ref()
+                    .cursor_dup_read::<tables::StorageChangeSets>()
+                    .unwrap()
+                    .walk_range(BlockNumberAddress::range(block_num..=block_num))
+                    .unwrap()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+                assert!(
+                    !storage_entries.is_empty(),
+                    "v1: MDBX StorageChangeSets should have entries for block {block_num}"
+                );
+
+                for (_, entry) in &storage_entries {
+                    let slot_key = B256::from(entry.key);
+                    assert!(
+                        slot_key != keccak256(slot_key),
+                        "v1: storage changeset keys should be plain (not hashed)"
+                    );
+                }
+            }
+
+            let mdbx_account_history =
+                provider.tx_ref().entries::<tables::AccountsHistory>().unwrap();
+            assert!(mdbx_account_history > 0, "v1: AccountsHistory in MDBX should not be empty");
+
+            let mdbx_storage_history =
+                provider.tx_ref().entries::<tables::StoragesHistory>().unwrap();
+            assert!(mdbx_storage_history > 0, "v1: StoragesHistory in MDBX should not be empty");
+        }
+    }
+
+    #[test]
+    fn test_save_blocks_v1_table_assertions() {
+        run_save_blocks_and_verify(StorageMode::V1);
+    }
+
+    #[test]
+    fn test_save_blocks_v2_table_assertions() {
+        run_save_blocks_and_verify(StorageMode::V2);
+    }
+
+    #[test]
+    fn test_write_and_remove_state_roundtrip_v2() {
+        let factory = create_test_provider_factory();
+        let storage_settings = StorageSettings::v2();
+        assert!(storage_settings.use_hashed_state());
+        factory.set_storage_settings_cache(storage_settings);
+
+        let address = Address::with_last_byte(1);
+        let hashed_address = keccak256(address);
+        let slot = U256::from(5);
+        let slot_key = B256::from(slot);
+        let hashed_slot = keccak256(slot_key);
+
+        {
+            let sf = factory.static_file_provider();
+            let mut hw = sf.latest_writer(StaticFileSegment::Headers).unwrap();
+            let h0 = alloy_consensus::Header { number: 0, ..Default::default() };
+            hw.append_header(&h0, &B256::ZERO).unwrap();
+            let h1 = alloy_consensus::Header { number: 1, ..Default::default() };
+            hw.append_header(&h1, &B256::ZERO).unwrap();
+            hw.commit().unwrap();
+
+            let mut aw = sf.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            aw.append_account_changeset(vec![], 0).unwrap();
+            aw.commit().unwrap();
+
+            let mut sw = sf.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+            sw.append_storage_changeset(vec![], 0).unwrap();
+            sw.commit().unwrap();
+        }
+
+        {
+            let provider_rw = factory.provider_rw().unwrap();
+            provider_rw
+                .tx
+                .put::<tables::BlockBodyIndices>(
+                    0,
+                    StoredBlockBodyIndices { first_tx_num: 0, tx_count: 0 },
+                )
+                .unwrap();
+            provider_rw
+                .tx
+                .put::<tables::BlockBodyIndices>(
+                    1,
+                    StoredBlockBodyIndices { first_tx_num: 0, tx_count: 0 },
+                )
+                .unwrap();
+            provider_rw
+                .tx
+                .cursor_write::<tables::HashedAccounts>()
+                .unwrap()
+                .upsert(
+                    hashed_address,
+                    &Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None },
+                )
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        let provider_rw = factory.provider_rw().unwrap();
+
+        let bundle = BundleState::builder(1..=1)
+            .state_present_account_info(
+                address,
+                AccountInfo { nonce: 1, balance: U256::from(10), ..Default::default() },
+            )
+            .state_storage(address, HashMap::from_iter([(slot, (U256::ZERO, U256::from(10)))]))
+            .revert_account_info(1, address, Some(None))
+            .revert_storage(1, address, vec![(slot, U256::ZERO)])
+            .build();
+
+        let execution_outcome = ExecutionOutcome::new(bundle.clone(), vec![vec![]], 1, Vec::new());
+
+        provider_rw
+            .write_state(
+                &execution_outcome,
+                OriginalValuesKnown::Yes,
+                StateWriteConfig {
+                    write_receipts: false,
+                    write_account_changesets: true,
+                    write_storage_changesets: true,
+                },
+            )
+            .unwrap();
+
+        let hashed_state =
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle.state()).into_sorted();
+        provider_rw.write_hashed_state(&hashed_state).unwrap();
+
+        let hashed_account = provider_rw
+            .tx
+            .cursor_read::<tables::HashedAccounts>()
+            .unwrap()
+            .seek_exact(hashed_address)
+            .unwrap()
+            .unwrap()
+            .1;
+        assert_eq!(hashed_account.nonce, 1);
+
+        let hashed_entry = provider_rw
+            .tx
+            .cursor_dup_read::<tables::HashedStorages>()
+            .unwrap()
+            .seek_by_key_subkey(hashed_address, hashed_slot)
+            .unwrap()
+            .unwrap();
+        assert_eq!(hashed_entry.key, hashed_slot);
+        assert_eq!(hashed_entry.value, U256::from(10));
+
+        let plain_accounts = provider_rw.tx.entries::<tables::PlainAccountState>().unwrap();
+        assert_eq!(plain_accounts, 0, "v2: PlainAccountState should be empty");
+
+        let plain_storage = provider_rw.tx.entries::<tables::PlainStorageState>().unwrap();
+        assert_eq!(plain_storage, 0, "v2: PlainStorageState should be empty");
+
+        provider_rw.static_file_provider().commit().unwrap();
+
+        let sf = factory.static_file_provider();
+        let storage_cs = sf.storage_changeset(1).unwrap();
+        assert!(!storage_cs.is_empty(), "v2: storage changesets should be in static files");
+        assert_eq!(storage_cs[0].1.key, slot_key, "v2: changeset key should be plain");
+
+        provider_rw.remove_state_above(0).unwrap();
+
+        let restored_account = provider_rw
+            .tx
+            .cursor_read::<tables::HashedAccounts>()
+            .unwrap()
+            .seek_exact(hashed_address)
+            .unwrap();
+        assert!(
+            restored_account.is_none(),
+            "v2: account should be removed (didn't exist before block 1)"
+        );
+
+        let storage_gone = provider_rw
+            .tx
+            .cursor_dup_read::<tables::HashedStorages>()
+            .unwrap()
+            .seek_by_key_subkey(hashed_address, hashed_slot)
+            .unwrap();
+        assert!(
+            storage_gone.is_none() || storage_gone.unwrap().key != hashed_slot,
+            "v2: storage should be reverted (removed or different key)"
+        );
+
+        let mdbx_storage_cs = provider_rw.tx.entries::<tables::StorageChangeSets>().unwrap();
+        assert_eq!(mdbx_storage_cs, 0, "v2: MDBX StorageChangeSets should remain empty");
+
+        let mdbx_account_cs = provider_rw.tx.entries::<tables::AccountChangeSets>().unwrap();
+        assert_eq!(mdbx_account_cs, 0, "v2: MDBX AccountChangeSets should remain empty");
+    }
+
+    #[test]
+    fn test_unwind_storage_history_indices_v2() {
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let address = Address::with_last_byte(1);
+        let slot_key = B256::from(U256::from(42));
+
+        {
+            let rocksdb = factory.rocksdb_provider();
+            let mut batch = rocksdb.batch();
+            batch.append_storage_history_shard(address, slot_key, vec![3u64, 7, 10]).unwrap();
+            batch.commit().unwrap();
+
+            let shards = rocksdb.storage_history_shards(address, slot_key).unwrap();
+            assert!(!shards.is_empty(), "history should be written to rocksdb");
+        }
+
+        let provider_rw = factory.provider_rw().unwrap();
+
+        let changesets = vec![
+            (
+                BlockNumberAddress((7, address)),
+                StorageEntry { key: slot_key, value: U256::from(5) },
+            ),
+            (
+                BlockNumberAddress((10, address)),
+                StorageEntry { key: slot_key, value: U256::from(8) },
+            ),
+        ];
+
+        let count = provider_rw.unwind_storage_history_indices(changesets.into_iter()).unwrap();
+        assert_eq!(count, 2);
+
+        provider_rw.commit().unwrap();
+
+        let rocksdb = factory.rocksdb_provider();
+        let shards = rocksdb.storage_history_shards(address, slot_key).unwrap();
+
+        assert!(
+            !shards.is_empty(),
+            "history shards should still exist with block 3 after partial unwind"
+        );
+
+        let all_blocks: Vec<u64> = shards.iter().flat_map(|(_, list)| list.iter()).collect();
+        assert!(all_blocks.contains(&3), "block 3 should remain");
+        assert!(!all_blocks.contains(&7), "block 7 should be unwound");
+        assert!(!all_blocks.contains(&10), "block 10 should be unwound");
+    }
+}

--- a/patches/reth-provider/src/providers/mod.rs
+++ b/patches/reth-provider/src/providers/mod.rs
@@ -1,0 +1,69 @@
+//! Contains the main provider types and traits for interacting with the blockchain's storage.
+
+use reth_chainspec::EthereumHardforks;
+use reth_db_api::table::Value;
+use reth_node_types::{NodePrimitives, NodeTypes, NodeTypesWithDB};
+
+mod database;
+pub use database::*;
+
+mod static_file;
+pub use static_file::{
+    StaticFileAccess, StaticFileJarProvider, StaticFileProvider, StaticFileProviderBuilder,
+    StaticFileProviderRW, StaticFileProviderRWRefMut, StaticFileWriteCtx, StaticFileWriter,
+};
+
+mod state;
+pub use state::{
+    historical::{
+        compute_history_rank, history_info, needs_prev_shard_check, HistoricalStateProvider,
+        HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,
+    },
+    latest::{LatestStateProvider, LatestStateProviderRef},
+    overlay::{OverlayBuilder, OverlayStateProvider, OverlayStateProviderFactory},
+};
+
+mod consistent_view;
+pub use consistent_view::{ConsistentDbView, ConsistentViewError};
+
+mod blockchain_provider;
+pub use blockchain_provider::BlockchainProvider;
+
+mod consistent;
+pub use consistent::ConsistentProvider;
+
+pub(crate) mod rocksdb;
+
+pub use rocksdb::{
+    PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksReadSnapshot, RocksTx,
+};
+
+/// Helper trait to bound [`NodeTypes`] so that combined with database they satisfy
+/// [`ProviderNodeTypes`].
+pub trait NodeTypesForProvider
+where
+    Self: NodeTypes<
+        ChainSpec: EthereumHardforks,
+        Storage: ChainStorage<Self::Primitives>,
+        Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
+    >,
+{
+}
+
+impl<T> NodeTypesForProvider for T where
+    T: NodeTypes<
+        ChainSpec: EthereumHardforks,
+        Storage: ChainStorage<T::Primitives>,
+        Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
+    >
+{
+}
+
+/// Helper trait keeping common requirements of providers for [`NodeTypesWithDB`].
+pub trait ProviderNodeTypes
+where
+    Self: NodeTypesForProvider + NodeTypesWithDB,
+{
+}
+impl<T> ProviderNodeTypes for T where T: NodeTypesForProvider + NodeTypesWithDB {}

--- a/patches/reth-provider/src/providers/rocksdb/invariants.rs
+++ b/patches/reth-provider/src/providers/rocksdb/invariants.rs
@@ -1,0 +1,1723 @@
+//! Invariant checking for `RocksDB` tables.
+//!
+//! This module provides consistency checks for tables stored in `RocksDB`, similar to the
+//! consistency checks for static files. The goal is to detect and potentially heal
+//! inconsistencies between `RocksDB` data and MDBX checkpoints.
+
+use super::RocksDBProvider;
+use crate::StaticFileProviderFactory;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::BlockNumber;
+use rayon::prelude::*;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
+use reth_db::models::{storage_sharded_key::StorageShardedKey, ShardedKey};
+use reth_db_api::tables;
+use reth_stages_types::StageId;
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{
+    BlockBodyIndicesProvider, ChangeSetReader, DBProvider, StageCheckpointReader,
+    StorageChangeSetReader, StorageSettingsCache, TransactionsProvider,
+};
+use reth_storage_errors::provider::ProviderResult;
+use std::collections::HashSet;
+
+/// Batch size for changeset iteration during history healing.
+/// Balances memory usage against iteration overhead.
+const HEAL_HISTORY_BATCH_SIZE: u64 = 10_000;
+
+impl RocksDBProvider {
+    /// Checks consistency of `RocksDB` tables against MDBX stage checkpoints.
+    ///
+    /// Returns an unwind target block number if the pipeline needs to unwind to rebuild
+    /// `RocksDB` data. Returns `None` if all invariants pass or if inconsistencies were healed.
+    ///
+    /// # Invariants checked
+    ///
+    /// For `TransactionHashNumbers`:
+    /// - The maximum `TxNumber` value should not exceed what the `TransactionLookup` stage
+    ///   checkpoint indicates has been processed.
+    /// - If `RocksDB` is ahead, excess entries are pruned (healed).
+    /// - If `RocksDB` is behind, an unwind is required.
+    ///
+    /// For `StoragesHistory` and `AccountsHistory`:
+    /// - Uses changesets to heal stale entries when static file tip > checkpoint.
+    ///
+    /// # Requirements
+    ///
+    /// For pruning `TransactionHashNumbers`, the provider must be able to supply transaction
+    /// data (typically from static files) so that transaction hashes can be computed. This
+    /// implies that static files should be ahead of or in sync with `RocksDB`.
+    pub fn check_consistency<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider
+            + StageCheckpointReader
+            + StorageSettingsCache
+            + StaticFileProviderFactory
+            + BlockBodyIndicesProvider
+            + StorageChangeSetReader
+            + ChangeSetReader
+            + TransactionsProvider<Transaction: Encodable2718>
+            + ChainSpecProvider,
+    {
+        let mut unwind_target: Option<BlockNumber> = None;
+
+        // Heal TransactionHashNumbers if stored in RocksDB
+        if provider.cached_storage_settings().storage_v2 &&
+            let Some(target) = self.heal_transaction_hash_numbers(provider)?
+        {
+            unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
+        }
+
+        // Heal StoragesHistory if stored in RocksDB
+        if provider.cached_storage_settings().storage_v2 &&
+            let Some(target) = self.heal_storages_history(provider)?
+        {
+            unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
+        }
+
+        // Heal AccountsHistory if stored in RocksDB
+        if provider.cached_storage_settings().storage_v2 &&
+            let Some(target) = self.heal_accounts_history(provider)?
+        {
+            unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
+        }
+
+        Ok(unwind_target)
+    }
+
+    /// Heals the `TransactionHashNumbers` table.
+    ///
+    /// - Fast path: if checkpoint == 0, clear any stale data and return
+    /// - If `sf_tip` < checkpoint, return unwind target (static files behind)
+    /// - If `sf_tip` == checkpoint, nothing to do
+    /// - If `sf_tip` > checkpoint, heal via transaction ranges in batches
+    fn heal_transaction_hash_numbers<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider
+            + StageCheckpointReader
+            + StaticFileProviderFactory
+            + BlockBodyIndicesProvider
+            + TransactionsProvider<Transaction: Encodable2718>,
+    {
+        let checkpoint = provider
+            .get_stage_checkpoint(StageId::TransactionLookup)?
+            .map(|cp| cp.block_number)
+            .unwrap_or(0);
+
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::Transactions)
+            .unwrap_or(0);
+
+        // Fast path: clear any stale data and return.
+        if checkpoint == 0 {
+            if self.first::<tables::TransactionHashNumbers>()?.is_some() {
+                tracing::info!(
+                    target: "reth::providers::rocksdb",
+                    "TransactionHashNumbers: checkpoint is 0, clearing stale data"
+                );
+                self.clear::<tables::TransactionHashNumbers>()?;
+            }
+
+            return Ok(None);
+        }
+
+        if sf_tip < checkpoint {
+            // This should never happen in normal operation - static files are always committed
+            // before RocksDB. If we get here, something is seriously wrong. The unwind is a
+            // best-effort attempt but is probably futile.
+            tracing::warn!(
+                target: "reth::providers::rocksdb",
+                sf_tip,
+                checkpoint,
+                "TransactionHashNumbers: static file tip behind checkpoint, unwind needed"
+            );
+            return Ok(Some(sf_tip));
+        }
+
+        // sf_tip == checkpoint - nothing to do
+        if sf_tip == checkpoint {
+            return Ok(None);
+        }
+
+        // Get end tx from static files (authoritative for sf_tip)
+        let sf_tip_end_tx = provider
+            .static_file_provider()
+            .get_highest_static_file_tx(StaticFileSegment::Transactions)
+            .unwrap_or(0);
+
+        // Get the first tx after the checkpoint block from MDBX (authoritative up to checkpoint)
+        let checkpoint_next_tx = provider
+            .block_body_indices(checkpoint)?
+            .map(|indices| indices.next_tx_num())
+            .unwrap_or(0);
+
+        if sf_tip_end_tx < checkpoint_next_tx {
+            // This should never happen in normal operation - static files should have all
+            // transactions up to sf_tip. If we get here, something is seriously wrong.
+            // The unwind is a best-effort attempt but is probably futile.
+            tracing::warn!(
+                target: "reth::providers::rocksdb",
+                sf_tip_end_tx,
+                checkpoint_next_tx,
+                checkpoint,
+                sf_tip,
+                "TransactionHashNumbers: static file tx tip behind checkpoint, unwind needed"
+            );
+            return Ok(Some(sf_tip));
+        }
+
+        tracing::info!(
+            target: "reth::providers::rocksdb",
+            checkpoint,
+            sf_tip,
+            checkpoint_next_tx,
+            sf_tip_end_tx,
+            "TransactionHashNumbers: healing via transaction ranges"
+        );
+
+        const BATCH_SIZE: u64 = 10_000;
+        let mut batch_start = checkpoint_next_tx;
+
+        while batch_start <= sf_tip_end_tx {
+            let batch_end = batch_start.saturating_add(BATCH_SIZE - 1).min(sf_tip_end_tx);
+
+            tracing::debug!(
+                target: "reth::providers::rocksdb",
+                batch_start,
+                batch_end,
+                "Pruning TransactionHashNumbers batch"
+            );
+
+            self.prune_transaction_hash_numbers_in_range(provider, batch_start..=batch_end)?;
+
+            batch_start = batch_end.saturating_add(1);
+        }
+
+        Ok(None)
+    }
+
+    /// Prunes `TransactionHashNumbers` entries for transactions in the given range.
+    ///
+    /// This fetches transactions from the provider, computes their hashes in parallel,
+    /// and deletes the corresponding entries from `RocksDB` by key. This approach is more
+    /// scalable than iterating all rows because it only processes the transactions that
+    /// need to be pruned.
+    ///
+    /// # Requirements
+    ///
+    /// The provider must be able to supply transaction data (typically from static files)
+    /// so that transaction hashes can be computed. This implies that static files should
+    /// be ahead of or in sync with `RocksDB`.
+    fn prune_transaction_hash_numbers_in_range<Provider>(
+        &self,
+        provider: &Provider,
+        tx_range: std::ops::RangeInclusive<u64>,
+    ) -> ProviderResult<()>
+    where
+        Provider: TransactionsProvider<Transaction: Encodable2718>,
+    {
+        if tx_range.is_empty() {
+            return Ok(());
+        }
+
+        // Fetch transactions in the range and compute their hashes in parallel
+        let hashes: Vec<_> = provider
+            .transactions_by_tx_range(tx_range.clone())?
+            .into_par_iter()
+            .map(|tx| tx.trie_hash())
+            .collect();
+
+        if !hashes.is_empty() {
+            tracing::info!(
+                target: "reth::providers::rocksdb",
+                deleted_count = hashes.len(),
+                tx_range_start = *tx_range.start(),
+                tx_range_end = *tx_range.end(),
+                "Pruning TransactionHashNumbers entries by tx range"
+            );
+
+            let mut batch = self.batch();
+            for hash in hashes {
+                batch.delete::<tables::TransactionHashNumbers>(hash)?;
+            }
+            batch.commit()?;
+        }
+
+        Ok(())
+    }
+
+    /// Heals the `StoragesHistory` table by removing stale entries.
+    ///
+    /// Returns an unwind target if static file tip is behind checkpoint (cannot heal).
+    /// Otherwise iterates changesets in batches to identify and unwind affected keys.
+    fn heal_storages_history<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider
+            + StageCheckpointReader
+            + StaticFileProviderFactory
+            + StorageChangeSetReader
+            + ChainSpecProvider,
+    {
+        let checkpoint = provider
+            .get_stage_checkpoint(StageId::IndexStorageHistory)?
+            .map(|cp| cp.block_number)
+            .unwrap_or(0);
+
+        // Fast path: clear and re-insert genesis history.
+        if checkpoint == 0 {
+            tracing::info!(
+                target: "reth::providers::rocksdb",
+                "StoragesHistory: checkpoint is 0, clearing stale data"
+            );
+            self.clear::<tables::StoragesHistory>()?;
+
+            let chain_spec = provider.chain_spec();
+            let genesis = chain_spec.genesis();
+            let list = tables::BlockNumberList::new([0]).expect("single block always fits");
+            for (addr, account) in &genesis.alloc {
+                if let Some(storage) = &account.storage {
+                    for key in storage.keys() {
+                        self.put::<tables::StoragesHistory>(
+                            StorageShardedKey::last(*addr, *key),
+                            &list,
+                        )?;
+                    }
+                }
+            }
+
+            return Ok(None);
+        }
+
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
+            .unwrap_or(0);
+
+        if sf_tip < checkpoint {
+            // This should never happen in normal operation - static files are always
+            // committed before RocksDB. If we get here, something is seriously wrong.
+            // The unwind is a best-effort attempt but is probably futile.
+            tracing::warn!(
+                target: "reth::providers::rocksdb",
+                sf_tip,
+                checkpoint,
+                "StoragesHistory: static file tip behind checkpoint, unwind needed"
+            );
+            return Ok(Some(sf_tip));
+        }
+
+        if sf_tip == checkpoint {
+            return Ok(None);
+        }
+
+        let total_blocks = sf_tip - checkpoint;
+        tracing::info!(
+            target: "reth::providers::rocksdb",
+            checkpoint,
+            sf_tip,
+            total_blocks,
+            "StoragesHistory: healing via changesets"
+        );
+
+        let mut batch_start = checkpoint + 1;
+        let mut batch_num = 0u64;
+        let total_batches = total_blocks.div_ceil(HEAL_HISTORY_BATCH_SIZE);
+
+        while batch_start <= sf_tip {
+            let batch_end = (batch_start + HEAL_HISTORY_BATCH_SIZE - 1).min(sf_tip);
+            batch_num += 1;
+
+            let changesets = provider.storage_changesets_range(batch_start..=batch_end)?;
+
+            let unique_keys: HashSet<_> = changesets
+                .into_iter()
+                .map(|(block_addr, entry)| (block_addr.address(), entry.key, checkpoint + 1))
+                .collect();
+            let indices: Vec<_> = unique_keys.into_iter().collect();
+
+            if !indices.is_empty() {
+                tracing::info!(
+                    target: "reth::providers::rocksdb",
+                    batch_num,
+                    total_batches,
+                    batch_start,
+                    batch_end,
+                    indices_count = indices.len(),
+                    "StoragesHistory: unwinding batch"
+                );
+
+                let batch = self.unwind_storage_history_indices(&indices)?;
+                self.commit_batch(batch)?;
+            }
+
+            batch_start = batch_end + 1;
+        }
+
+        Ok(None)
+    }
+
+    /// Heals the `AccountsHistory` table by removing stale entries.
+    ///
+    /// Returns an unwind target if static file tip is behind checkpoint (cannot heal).
+    /// Otherwise iterates changesets in batches to identify and unwind affected keys.
+    fn heal_accounts_history<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider
+            + StageCheckpointReader
+            + StaticFileProviderFactory
+            + ChangeSetReader
+            + ChainSpecProvider,
+    {
+        let checkpoint = provider
+            .get_stage_checkpoint(StageId::IndexAccountHistory)?
+            .map(|cp| cp.block_number)
+            .unwrap_or(0);
+
+        // Fast path: clear and re-insert genesis history.
+        if checkpoint == 0 {
+            tracing::info!(
+                target: "reth::providers::rocksdb",
+                "AccountsHistory: checkpoint is 0, clearing stale data"
+            );
+            self.clear::<tables::AccountsHistory>()?;
+
+            let chain_spec = provider.chain_spec();
+            let genesis = chain_spec.genesis();
+            let list = tables::BlockNumberList::new([0]).expect("single block always fits");
+            for addr in genesis.alloc.keys() {
+                self.put::<tables::AccountsHistory>(ShardedKey::last(*addr), &list)?;
+            }
+
+            return Ok(None);
+        }
+
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets)
+            .unwrap_or(0);
+
+        if sf_tip < checkpoint {
+            // This should never happen in normal operation - static files are always
+            // committed before RocksDB. If we get here, something is seriously wrong.
+            // The unwind is a best-effort attempt but is probably futile.
+            tracing::warn!(
+                target: "reth::providers::rocksdb",
+                sf_tip,
+                checkpoint,
+                "AccountsHistory: static file tip behind checkpoint, unwind needed"
+            );
+            return Ok(Some(sf_tip));
+        }
+
+        if sf_tip == checkpoint {
+            return Ok(None);
+        }
+
+        let total_blocks = sf_tip - checkpoint;
+        tracing::info!(
+            target: "reth::providers::rocksdb",
+            checkpoint,
+            sf_tip,
+            total_blocks,
+            "AccountsHistory: healing via changesets"
+        );
+
+        let mut batch_start = checkpoint + 1;
+        let mut batch_num = 0u64;
+        let total_batches = total_blocks.div_ceil(HEAL_HISTORY_BATCH_SIZE);
+
+        while batch_start <= sf_tip {
+            let batch_end = (batch_start + HEAL_HISTORY_BATCH_SIZE - 1).min(sf_tip);
+            batch_num += 1;
+
+            let changesets = provider.account_changesets_range(batch_start..=batch_end)?;
+
+            let mut addresses = HashSet::with_capacity(changesets.len());
+            addresses.extend(changesets.iter().map(|(_, cs)| cs.address));
+            let unwind_from = checkpoint + 1;
+            let indices: Vec<_> = addresses.into_iter().map(|addr| (addr, unwind_from)).collect();
+
+            if !indices.is_empty() {
+                tracing::info!(
+                    target: "reth::providers::rocksdb",
+                    batch_num,
+                    total_batches,
+                    batch_start,
+                    batch_end,
+                    indices_count = indices.len(),
+                    "AccountsHistory: unwinding batch"
+                );
+
+                let batch = self.unwind_account_history_indices(&indices)?;
+                self.commit_batch(batch)?;
+            }
+
+            batch_start = batch_end + 1;
+        }
+
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        init::insert_genesis_history,
+        providers::{rocksdb::RocksDBBuilder, static_file::StaticFileWriter},
+        test_utils::{create_test_provider_factory, create_test_provider_factory_with_chain_spec},
+        BlockWriter, DatabaseProviderFactory, RocksDBProviderFactory, StageCheckpointWriter,
+        TransactionsProvider,
+    };
+    use alloy_primitives::{Address, B256};
+    use reth_chainspec::MAINNET;
+    use reth_db::cursor::{DbCursorRO, DbCursorRW};
+    use reth_db_api::{
+        models::{storage_sharded_key::StorageShardedKey, StorageSettings},
+        tables::{self, BlockNumberList},
+        transaction::DbTxMut,
+    };
+    use reth_stages_types::StageCheckpoint;
+    use reth_testing_utils::generators::{self, BlockRangeParams};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_first_last_empty_rocksdb() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Empty RocksDB, no checkpoints - should be consistent
+        let first = provider.first::<tables::TransactionHashNumbers>().unwrap();
+        let last = provider.last::<tables::TransactionHashNumbers>().unwrap();
+
+        assert!(first.is_none());
+        assert!(last.is_none());
+    }
+
+    #[test]
+    fn test_first_last_with_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .build()
+            .unwrap();
+
+        // Insert some data
+        let tx_hash = B256::from([1u8; 32]);
+        provider.put::<tables::TransactionHashNumbers>(tx_hash, &100).unwrap();
+
+        // RocksDB has data
+        let last = provider.last::<tables::TransactionHashNumbers>().unwrap();
+        assert!(last.is_some());
+        assert_eq!(last.unwrap().1, 100);
+    }
+
+    #[test]
+    fn test_check_consistency_empty_rocksdb_no_checkpoint_is_ok() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Empty RocksDB and no checkpoints - should be consistent (None = no unwind needed)
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None);
+    }
+
+    /// Tests that `checkpoint=0` with empty `RocksDB` returns early without attempting
+    /// an expensive healing loop. Previously, when `sf_tip` > `checkpoint=0`, the healer
+    /// would iterate billions of transactions from static files for no effect, causing
+    /// the node to hang on startup with MDBX read transaction timeouts.
+    #[test]
+    fn test_check_consistency_checkpoint_zero_empty_rocksdb_returns_early() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // No checkpoints set — all default to 0 via unwrap_or(0).
+        // RocksDB tables are empty.
+        let provider = factory.database_provider_ro().unwrap();
+
+        let result = rocksdb.heal_transaction_hash_numbers(&provider).unwrap();
+        assert_eq!(result, None, "TransactionHashNumbers should return early at checkpoint 0");
+        assert!(rocksdb.first::<tables::TransactionHashNumbers>().unwrap().is_none());
+
+        let result = rocksdb.heal_storages_history(&provider).unwrap();
+        assert_eq!(result, None, "StoragesHistory should return early at checkpoint 0");
+
+        let result = rocksdb.heal_accounts_history(&provider).unwrap();
+        assert_eq!(result, None, "AccountsHistory should return early at checkpoint 0");
+        // Genesis account history entries are re-inserted
+        assert_eq!(
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().count(),
+            factory.chain_spec().genesis().alloc.len()
+        );
+    }
+
+    #[test]
+    fn test_check_consistency_empty_rocksdb_with_checkpoint_is_first_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::TransactionLookup, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB is empty but checkpoint says block 100 was processed.
+        // Since static file tip defaults to 0 when None, and 0 < 100, an unwind is triggered.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "Static file tip (0) behind checkpoint (100) triggers unwind");
+    }
+
+    /// Tests that when checkpoint=0 and `RocksDB` has data, all entries are pruned.
+    /// This simulates a crash recovery scenario where the checkpoint was lost.
+    #[test]
+    fn test_check_consistency_checkpoint_zero_with_rocksdb_data_prunes_all() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Generate blocks with real transactions and insert them
+        let mut rng = generators::rng();
+        let blocks = generators::random_block_range(
+            &mut rng,
+            0..=2,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
+
+        let mut tx_hashes = Vec::new();
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            let mut tx_count = 0u64;
+            for block in &blocks {
+                provider
+                    .insert_block(&block.clone().try_recover().expect("recover block"))
+                    .unwrap();
+                for tx in &block.body().transactions {
+                    let hash = tx.trie_hash();
+                    tx_hashes.push(hash);
+                    rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
+                    tx_count += 1;
+                }
+            }
+            provider.commit().unwrap();
+        }
+
+        // Explicitly clear the checkpoints to simulate crash recovery
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::TransactionLookup, StageCheckpoint::new(0))
+                .unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(0))
+                .unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(0))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        // Verify RocksDB data exists
+        assert!(rocksdb.last::<tables::TransactionHashNumbers>().unwrap().is_some());
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // checkpoint = 0 but RocksDB has data.
+        // This means RocksDB has stale data that should be cleared.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Should heal by clearing, no unwind needed");
+
+        // Verify data was cleared
+        for hash in &tx_hashes {
+            assert!(
+                rocksdb.get::<tables::TransactionHashNumbers>(*hash).unwrap().is_none(),
+                "RocksDB should be empty after pruning"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_empty_with_checkpoint_is_first_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB is empty but checkpoint says block 100 was processed.
+        // Since sf_tip=0 < checkpoint=100, we return unwind target of 0.
+        // This should never happen in normal operation.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "sf_tip=0 < checkpoint=100 returns unwind target");
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_preserves_genesis_entries_at_checkpoint_zero(
+    ) -> eyre::Result<()> {
+        // Modify mainnet chainspec to include a single genesis storage slot
+        let mut chain_spec = MAINNET.clone();
+        Arc::make_mut(&mut chain_spec).genesis.alloc.first_entry().unwrap().get_mut().storage =
+            Some(From::from([(B256::random(), B256::random())]));
+
+        // Create a test provider factory for MDBX with NO checkpoint
+        let factory = create_test_provider_factory_with_chain_spec(chain_spec);
+        let rocksdb = factory.rocksdb_provider();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Insert genesis history into RocksDB
+        let provider_rw = factory.database_provider_rw().unwrap();
+        insert_genesis_history(&provider_rw, factory.chain_spec().genesis.alloc.iter())?;
+        provider_rw.commit()?;
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // This should not prune anything because only genesis entries are present
+        let result = rocksdb.heal_storages_history(&provider).unwrap();
+        assert_eq!(result, None, "Should skip healing when only genesis entries present");
+
+        // Verify data was NOT deleted
+        assert!(
+            rocksdb.iter::<tables::StoragesHistory>().unwrap().count() > 0,
+            "Genesis entries should be preserved"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_check_consistency_mdbx_behind_checkpoint_needs_unwind() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Generate blocks with real transactions (blocks 0-2, 6 transactions total)
+        let mut rng = generators::rng();
+        let blocks = generators::random_block_range(
+            &mut rng,
+            0..=2,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
+
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            let mut tx_count = 0u64;
+            for block in &blocks {
+                provider
+                    .insert_block(&block.clone().try_recover().expect("recover block"))
+                    .unwrap();
+                for tx in &block.body().transactions {
+                    let hash = tx.trie_hash();
+                    rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
+                    tx_count += 1;
+                }
+            }
+            provider.commit().unwrap();
+        }
+
+        // Set checkpoint to block 10 (beyond our actual data at block 2)
+        // sf_tip is at block 2, checkpoint is at block 10
+        // Since sf_tip < checkpoint, we need to unwind to sf_tip
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::TransactionLookup, StageCheckpoint::new(10))
+                .unwrap();
+            // Reset history checkpoints so they don't interfere
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(0))
+                .unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(0))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // sf_tip (2) < checkpoint (10), so unwind to sf_tip is needed
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(2), "sf_tip < checkpoint requires unwind to sf_tip");
+    }
+
+    #[test]
+    fn test_check_consistency_rocksdb_ahead_of_checkpoint_prunes_excess() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Generate blocks with real transactions:
+        // Blocks 0-5, each with 2 transactions = 12 total transactions (0-11)
+        let mut rng = generators::rng();
+        let blocks = generators::random_block_range(
+            &mut rng,
+            0..=5,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
+
+        // Track which hashes belong to which blocks
+        let mut tx_hashes = Vec::new();
+        let mut tx_count = 0u64;
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            // Insert ALL blocks (0-5) to write transactions to static files
+            for block in &blocks {
+                provider
+                    .insert_block(&block.clone().try_recover().expect("recover block"))
+                    .unwrap();
+                for tx in &block.body().transactions {
+                    let hash = tx.trie_hash();
+                    tx_hashes.push(hash);
+                    rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
+                    tx_count += 1;
+                }
+            }
+            provider.commit().unwrap();
+        }
+
+        // Simulate crash recovery scenario:
+        // MDBX was unwound to block 2, but RocksDB and static files still have more data.
+        // Remove TransactionBlocks entries for blocks 3-5 to simulate MDBX unwind.
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            // Delete TransactionBlocks entries for tx > 5 (i.e., for blocks 3-5)
+            // TransactionBlocks maps last_tx_in_block -> block_number
+            // After unwind, only entries for blocks 0-2 should remain (tx 5 -> block 2)
+            let mut cursor = provider.tx_ref().cursor_write::<tables::TransactionBlocks>().unwrap();
+            // Walk and delete entries where block > 2
+            let mut to_delete = Vec::new();
+            let mut walker = cursor.walk(Some(0)).unwrap();
+            while let Some((tx_num, block_num)) = walker.next().transpose().unwrap() {
+                if block_num > 2 {
+                    to_delete.push(tx_num);
+                }
+            }
+            drop(walker);
+            for tx_num in to_delete {
+                cursor.seek_exact(tx_num).unwrap();
+                cursor.delete_current().unwrap();
+            }
+
+            // Set checkpoint to block 2
+            provider
+                .save_stage_checkpoint(StageId::TransactionLookup, StageCheckpoint::new(2))
+                .unwrap();
+            // Reset history checkpoints so they don't interfere
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(0))
+                .unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(0))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has tx hashes for all blocks (0-5)
+        // MDBX TransactionBlocks only goes up to tx 5 (block 2)
+        // Static files have data for all txs (0-11)
+        // This means RocksDB is ahead and should prune entries for tx 6-11
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Should heal by pruning, no unwind needed");
+
+        // Verify: hashes for blocks 0-2 (tx 0-5) should remain, blocks 3-5 (tx 6-11) should be
+        // pruned First 6 hashes should remain
+        for (i, hash) in tx_hashes.iter().take(6).enumerate() {
+            assert!(
+                rocksdb.get::<tables::TransactionHashNumbers>(*hash).unwrap().is_some(),
+                "tx {} should remain",
+                i
+            );
+        }
+        // Last 6 hashes should be pruned
+        for (i, hash) in tx_hashes.iter().skip(6).enumerate() {
+            assert!(
+                rocksdb.get::<tables::TransactionHashNumbers>(*hash).unwrap().is_none(),
+                "tx {} should be pruned",
+                i + 6
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_sentinel_only_with_checkpoint_is_first_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Insert ONLY sentinel entries (highest_block_number = u64::MAX)
+        // This simulates a scenario where history tracking started but no shards were completed
+        let key_sentinel_1 = StorageShardedKey::new(Address::ZERO, B256::ZERO, u64::MAX);
+        let key_sentinel_2 = StorageShardedKey::new(Address::random(), B256::random(), u64::MAX);
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
+        rocksdb.put::<tables::StoragesHistory>(key_sentinel_1, &block_list).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key_sentinel_2, &block_list).unwrap();
+
+        // Verify entries exist (not empty table)
+        assert!(rocksdb.first::<tables::StoragesHistory>().unwrap().is_some());
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has only sentinel entries but checkpoint is set.
+        // Since sf_tip=0 < checkpoint=100, we return unwind target of 0.
+        // This should never happen in normal operation.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "sf_tip=0 < checkpoint=100 returns unwind target");
+    }
+
+    #[test]
+    fn test_check_consistency_accounts_history_sentinel_only_with_checkpoint_is_first_run() {
+        use reth_db_api::models::ShardedKey;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Insert ONLY sentinel entries (highest_block_number = u64::MAX)
+        let key_sentinel_1 = ShardedKey::new(Address::ZERO, u64::MAX);
+        let key_sentinel_2 = ShardedKey::new(Address::random(), u64::MAX);
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
+        rocksdb.put::<tables::AccountsHistory>(key_sentinel_1, &block_list).unwrap();
+        rocksdb.put::<tables::AccountsHistory>(key_sentinel_2, &block_list).unwrap();
+
+        // Verify entries exist (not empty table)
+        assert!(rocksdb.first::<tables::AccountsHistory>().unwrap().is_some());
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has only sentinel entries but checkpoint is set.
+        // Since sf_tip=0 < checkpoint=100, we return unwind target of 0.
+        // This should never happen in normal operation.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "sf_tip=0 < checkpoint=100 returns unwind target");
+    }
+
+    /// Test that pruning works by fetching transactions and computing their hashes,
+    /// rather than iterating all rows. This test uses random blocks with unique
+    /// transactions so we can verify the correct entries are pruned.
+    #[test]
+    fn test_prune_transaction_hash_numbers_by_range() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .build()
+            .unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Generate random blocks with unique transactions
+        // Block 0 (genesis) has no transactions
+        // Blocks 1-5 each have 2 transactions = 10 transactions total
+        let mut rng = generators::rng();
+        let blocks = generators::random_block_range(
+            &mut rng,
+            0..=5,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
+
+        // Insert blocks into the database
+        let mut tx_count = 0u64;
+        let mut tx_hashes = Vec::new();
+        {
+            let provider = factory.database_provider_rw().unwrap();
+
+            for block in &blocks {
+                provider
+                    .insert_block(&block.clone().try_recover().expect("recover block"))
+                    .unwrap();
+
+                // Store transaction hash -> tx_number mappings in RocksDB
+                for tx in &block.body().transactions {
+                    let hash = tx.trie_hash();
+                    tx_hashes.push(hash);
+                    rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
+                    tx_count += 1;
+                }
+            }
+
+            // Set checkpoint to block 2 (meaning we should only have tx hashes for blocks 0-2)
+            // Blocks 0, 1, 2 have 6 transactions (2 each), so tx 0-5 should remain
+            provider
+                .save_stage_checkpoint(StageId::TransactionLookup, StageCheckpoint::new(2))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        // At this point:
+        // - RocksDB has tx hashes for blocks 0-5 (10 total: 2 per block)
+        // - Checkpoint says we only processed up to block 2
+        // - We need to prune tx hashes for blocks 3, 4, 5 (tx 6-9)
+
+        // Verify RocksDB has the expected number of entries before pruning
+        let rocksdb_count_before: usize =
+            rocksdb.iter::<tables::TransactionHashNumbers>().unwrap().count();
+        assert_eq!(
+            rocksdb_count_before, tx_count as usize,
+            "RocksDB should have all {} transaction hashes before pruning",
+            tx_count
+        );
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Verify we can fetch transactions by tx range
+        let all_txs = provider.transactions_by_tx_range(0..tx_count).unwrap();
+        assert_eq!(all_txs.len(), tx_count as usize, "Should be able to fetch all transactions");
+
+        // Verify the hashes match between what we stored and what we compute from fetched txs
+        for (i, tx) in all_txs.iter().enumerate() {
+            let computed_hash = tx.trie_hash();
+            assert_eq!(
+                computed_hash, tx_hashes[i],
+                "Hash mismatch for tx {}: stored {:?} vs computed {:?}",
+                i, tx_hashes[i], computed_hash
+            );
+        }
+
+        // Blocks 0, 1, 2 have 2 tx each = 6 tx total (indices 0-5)
+        // We want to keep tx 0-5, prune tx 6-9
+        let max_tx_to_keep = 5u64;
+        let tx_to_prune_start = max_tx_to_keep + 1;
+
+        // Prune transactions 6-9 (blocks 3-5)
+        rocksdb
+            .prune_transaction_hash_numbers_in_range(&provider, tx_to_prune_start..=(tx_count - 1))
+            .expect("prune should succeed");
+
+        // Verify: transactions 0-5 should remain, 6-9 should be pruned
+        let mut remaining_count = 0;
+        for result in rocksdb.iter::<tables::TransactionHashNumbers>().unwrap() {
+            let (_hash, tx_num) = result.unwrap();
+            assert!(
+                tx_num <= max_tx_to_keep,
+                "Transaction {} should have been pruned (> {})",
+                tx_num,
+                max_tx_to_keep
+            );
+            remaining_count += 1;
+        }
+        assert_eq!(
+            remaining_count,
+            (max_tx_to_keep + 1) as usize,
+            "Should have {} transactions (0-{})",
+            max_tx_to_keep + 1,
+            max_tx_to_keep
+        );
+    }
+
+    #[test]
+    fn test_check_consistency_accounts_history_empty_with_checkpoint_is_first_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB is empty but checkpoint says block 100 was processed.
+        // Since sf_tip=0 < checkpoint=100, we return unwind target of 0.
+        // This should never happen in normal operation.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "sf_tip=0 < checkpoint=100 returns unwind target");
+    }
+
+    #[test]
+    fn test_check_consistency_accounts_history_preserves_genesis_entries_at_checkpoint_zero(
+    ) -> eyre::Result<()> {
+        // Create a test provider factory for MDBX with NO checkpoint
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+        let rocksdb = factory.rocksdb_provider();
+
+        // Insert genesis history into RocksDB
+        let provider_rw = factory.database_provider_rw().unwrap();
+        insert_genesis_history(&provider_rw, factory.chain_spec().genesis.alloc.iter())?;
+        provider_rw.commit()?;
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // This should not prune anything because only genesis entries are present
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Should heal by pruning, no unwind needed");
+
+        // Verify data was NOT deleted
+        assert!(
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().count() > 0,
+            "Genesis entries should be preserved"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_check_consistency_accounts_history_sf_tip_equals_checkpoint_no_action() {
+        use reth_db::models::AccountBeforeTx;
+        use reth_db_api::models::ShardedKey;
+        use reth_static_file_types::StaticFileSegment;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Insert some AccountsHistory entries with various highest_block_numbers
+        let key1 = ShardedKey::new(Address::ZERO, 50);
+        let key2 = ShardedKey::new(Address::random(), 75);
+        let key3 = ShardedKey::new(Address::random(), u64::MAX); // sentinel
+        let block_list1 = BlockNumberList::new_pre_sorted([10, 20, 30, 50]);
+        let block_list2 = BlockNumberList::new_pre_sorted([40, 60, 75]);
+        let block_list3 = BlockNumberList::new_pre_sorted([80, 90, 100]);
+        rocksdb.put::<tables::AccountsHistory>(key1, &block_list1).unwrap();
+        rocksdb.put::<tables::AccountsHistory>(key2, &block_list2).unwrap();
+        rocksdb.put::<tables::AccountsHistory>(key3, &block_list3).unwrap();
+
+        // Capture RocksDB state before consistency check
+        let entries_before: Vec<_> =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().map(|r| r.unwrap()).collect();
+        assert_eq!(entries_before.len(), 3, "Should have 3 entries before check");
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Write account changesets to static files for blocks 0-100
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            for block_num in 0..=100 {
+                let changeset = vec![AccountBeforeTx { address: Address::random(), info: None }];
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Set IndexAccountHistory checkpoint to block 100 (same as sf_tip)
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Verify sf_tip equals checkpoint (both at 100)
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets)
+            .unwrap();
+        assert_eq!(sf_tip, 100, "Static file tip should be 100");
+
+        // Run check_consistency - should return None (no unwind needed)
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "sf_tip == checkpoint should not require unwind");
+
+        // Verify NO entries are deleted - RocksDB state unchanged
+        let entries_after: Vec<_> =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(
+            entries_after.len(),
+            entries_before.len(),
+            "RocksDB entry count should be unchanged when sf_tip == checkpoint"
+        );
+
+        // Verify exact entries are preserved
+        for (before, after) in entries_before.iter().zip(entries_after.iter()) {
+            assert_eq!(before.0.key, after.0.key, "Entry key should be unchanged");
+            assert_eq!(
+                before.0.highest_block_number, after.0.highest_block_number,
+                "Entry highest_block_number should be unchanged"
+            );
+            assert_eq!(before.1, after.1, "Entry block list should be unchanged");
+        }
+    }
+
+    /// Tests `StoragesHistory` changeset-based healing with enough blocks to trigger batching.
+    ///
+    /// Scenario:
+    /// 1. Generate 15,000 blocks worth of storage changeset data (to exceed the 10k batch size)
+    /// 2. Each block has 1 storage change (address + slot + value)
+    /// 3. Write storage changesets to static files for all 15k blocks
+    /// 4. Set `IndexStorageHistory` checkpoint to block 5000
+    /// 5. Insert stale `StoragesHistory` entries in `RocksDB` for (address, slot) pairs that
+    ///    changed in blocks 5001-15000
+    /// 6. Run `check_consistency`
+    /// 7. Verify stale entries for blocks > 5000 are pruned and batching worked
+    #[test]
+    fn test_check_consistency_storages_history_heals_via_changesets_large_range() {
+        use alloy_primitives::U256;
+        use reth_db_api::models::StorageBeforeTx;
+
+        const TOTAL_BLOCKS: u64 = 15_000;
+        const CHECKPOINT_BLOCK: u64 = 5_000;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Helper to generate address from block number (reuses stack arrays)
+        #[inline]
+        fn make_address(block_num: u64) -> Address {
+            let mut addr_bytes = [0u8; 20];
+            addr_bytes[0..8].copy_from_slice(&block_num.to_le_bytes());
+            Address::from(addr_bytes)
+        }
+
+        // Helper to generate slot from block number (reuses stack arrays)
+        #[inline]
+        fn make_slot(block_num: u64) -> B256 {
+            let mut slot_bytes = [0u8; 32];
+            slot_bytes[0..8].copy_from_slice(&block_num.to_le_bytes());
+            B256::from(slot_bytes)
+        }
+
+        // Write storage changesets to static files for 15k blocks.
+        // Each block has 1 storage change with a unique (address, slot) pair.
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            // Reuse changeset vec to avoid repeated allocations
+            let mut changeset = Vec::with_capacity(1);
+
+            for block_num in 0..TOTAL_BLOCKS {
+                changeset.clear();
+                changeset.push(StorageBeforeTx {
+                    address: make_address(block_num),
+                    key: make_slot(block_num),
+                    value: U256::from(block_num),
+                });
+
+                writer.append_storage_changeset(changeset.clone(), block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Verify static files have data up to block 14999
+        {
+            let sf_provider = factory.static_file_provider();
+            let highest = sf_provider
+                .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
+                .unwrap();
+            assert_eq!(highest, TOTAL_BLOCKS - 1, "Static files should have blocks 0..14999");
+        }
+
+        // Set IndexStorageHistory checkpoint to block 5000
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(
+                    StageId::IndexStorageHistory,
+                    StageCheckpoint::new(CHECKPOINT_BLOCK),
+                )
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        // Insert stale StoragesHistory entries for blocks 5001-14999
+        // These are (address, slot) pairs that changed after the checkpoint
+        for block_num in (CHECKPOINT_BLOCK + 1)..TOTAL_BLOCKS {
+            let key =
+                StorageShardedKey::new(make_address(block_num), make_slot(block_num), block_num);
+            let block_list = BlockNumberList::new_pre_sorted([block_num]);
+            rocksdb.put::<tables::StoragesHistory>(key, &block_list).unwrap();
+        }
+
+        // Verify RocksDB has stale entries before healing
+        let count_before: usize = rocksdb.iter::<tables::StoragesHistory>().unwrap().count();
+        assert_eq!(
+            count_before,
+            (TOTAL_BLOCKS - CHECKPOINT_BLOCK - 1) as usize,
+            "Should have {} stale entries before healing",
+            TOTAL_BLOCKS - CHECKPOINT_BLOCK - 1
+        );
+
+        // Run check_consistency - this should heal by pruning stale entries
+        let provider = factory.database_provider_ro().unwrap();
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Should heal via changesets, no unwind needed");
+
+        // Verify all stale entries were pruned
+        // After healing, entries with highest_block_number > checkpoint should be gone
+        let mut remaining_stale = 0;
+        for result in rocksdb.iter::<tables::StoragesHistory>().unwrap() {
+            let (key, _) = result.unwrap();
+            if key.sharded_key.highest_block_number > CHECKPOINT_BLOCK {
+                remaining_stale += 1;
+            }
+        }
+        assert_eq!(
+            remaining_stale, 0,
+            "All stale entries (block > {}) should be pruned",
+            CHECKPOINT_BLOCK
+        );
+    }
+
+    /// Tests that healing preserves entries at exactly the checkpoint block.
+    ///
+    /// This catches off-by-one bugs where checkpoint block data is incorrectly deleted.
+    #[test]
+    fn test_check_consistency_storages_history_preserves_checkpoint_block() {
+        use alloy_primitives::U256;
+        use reth_db_api::models::StorageBeforeTx;
+
+        const CHECKPOINT_BLOCK: u64 = 100;
+        const SF_TIP: u64 = 200;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let checkpoint_addr = Address::repeat_byte(0xAA);
+        let checkpoint_slot = B256::repeat_byte(0xBB);
+        let stale_addr = Address::repeat_byte(0xCC);
+        let stale_slot = B256::repeat_byte(0xDD);
+
+        // Write storage changesets to static files
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            for block_num in 0..=SF_TIP {
+                let changeset = if block_num == CHECKPOINT_BLOCK {
+                    vec![StorageBeforeTx {
+                        address: checkpoint_addr,
+                        key: checkpoint_slot,
+                        value: U256::from(block_num),
+                    }]
+                } else if block_num > CHECKPOINT_BLOCK {
+                    vec![StorageBeforeTx {
+                        address: stale_addr,
+                        key: stale_slot,
+                        value: U256::from(block_num),
+                    }]
+                } else {
+                    vec![StorageBeforeTx {
+                        address: Address::ZERO,
+                        key: B256::ZERO,
+                        value: U256::ZERO,
+                    }]
+                };
+                writer.append_storage_changeset(changeset, block_num).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        // Set checkpoint
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(
+                    StageId::IndexStorageHistory,
+                    StageCheckpoint::new(CHECKPOINT_BLOCK),
+                )
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        // Insert entry AT the checkpoint block (should be preserved)
+        let checkpoint_key =
+            StorageShardedKey::new(checkpoint_addr, checkpoint_slot, CHECKPOINT_BLOCK);
+        let checkpoint_list = BlockNumberList::new_pre_sorted([CHECKPOINT_BLOCK]);
+        rocksdb.put::<tables::StoragesHistory>(checkpoint_key.clone(), &checkpoint_list).unwrap();
+
+        // Insert stale entry AFTER the checkpoint (should be removed)
+        let stale_key = StorageShardedKey::new(stale_addr, stale_slot, SF_TIP);
+        let stale_list = BlockNumberList::new_pre_sorted([CHECKPOINT_BLOCK + 1, SF_TIP]);
+        rocksdb.put::<tables::StoragesHistory>(stale_key.clone(), &stale_list).unwrap();
+
+        // Run healing
+        let provider = factory.database_provider_ro().unwrap();
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Should heal without unwind");
+
+        // Verify checkpoint block entry is PRESERVED
+        let preserved = rocksdb.get::<tables::StoragesHistory>(checkpoint_key).unwrap();
+        assert!(preserved.is_some(), "Entry at checkpoint block should be preserved, not deleted");
+
+        // Verify stale entry is removed or unwound
+        let stale = rocksdb.get::<tables::StoragesHistory>(stale_key).unwrap();
+        assert!(stale.is_none(), "Stale entry after checkpoint should be removed");
+    }
+
+    /// Tests `AccountsHistory` changeset-based healing with enough blocks to trigger batching.
+    ///
+    /// Scenario:
+    /// 1. Generate 15,000 blocks worth of account changeset data (to exceed the 10k batch size)
+    /// 2. Each block has 1 account change (simple - just random addresses)
+    /// 3. Write account changesets to static files for all 15k blocks
+    /// 4. Set `IndexAccountHistory` checkpoint to block 5000
+    /// 5. Insert stale `AccountsHistory` entries in `RocksDB` for addresses that changed in blocks
+    ///    5001-15000
+    /// 6. Run `check_consistency`
+    /// 7. Verify:
+    ///    - Stale entries for blocks > 5000 are pruned
+    ///    - The batching worked (no OOM, completed successfully)
+    #[test]
+    fn test_check_consistency_accounts_history_heals_via_changesets_large_range() {
+        use reth_db::models::AccountBeforeTx;
+        use reth_db_api::models::ShardedKey;
+        use reth_static_file_types::StaticFileSegment;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Create test provider factory
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        const TOTAL_BLOCKS: u64 = 15_000;
+        const CHECKPOINT_BLOCK: u64 = 5_000;
+
+        // Helper to generate address from block number (avoids pre-allocating 15k addresses)
+        #[inline]
+        fn make_address(block_num: u64) -> Address {
+            let mut addr = Address::ZERO;
+            addr.0[0..8].copy_from_slice(&block_num.to_le_bytes());
+            addr
+        }
+
+        // Write account changesets to static files for all 15k blocks
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            // Reuse changeset vec to avoid repeated allocations
+            let mut changeset = Vec::with_capacity(1);
+
+            for block_num in 0..TOTAL_BLOCKS {
+                changeset.clear();
+                changeset.push(AccountBeforeTx { address: make_address(block_num), info: None });
+                writer.append_account_changeset(changeset.clone(), block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Insert stale AccountsHistory entries in RocksDB for addresses that changed
+        // in blocks 5001-15000 (i.e., blocks after the checkpoint)
+        // These should be pruned by check_consistency
+        for block_num in (CHECKPOINT_BLOCK + 1)..TOTAL_BLOCKS {
+            let key = ShardedKey::new(make_address(block_num), block_num);
+            let block_list = BlockNumberList::new_pre_sorted([block_num]);
+            rocksdb.put::<tables::AccountsHistory>(key, &block_list).unwrap();
+        }
+
+        // Also insert some valid entries for blocks <= 5000 that should NOT be pruned
+        for block_num in [100u64, 500, 1000, 2500, 5000] {
+            let key = ShardedKey::new(make_address(block_num), block_num);
+            let block_list = BlockNumberList::new_pre_sorted([block_num]);
+            rocksdb.put::<tables::AccountsHistory>(key, &block_list).unwrap();
+        }
+
+        // Verify we have entries before healing
+        let entries_before: usize = rocksdb.iter::<tables::AccountsHistory>().unwrap().count();
+        let stale_count = (TOTAL_BLOCKS - CHECKPOINT_BLOCK - 1) as usize;
+        let valid_count = 5usize;
+        assert_eq!(
+            entries_before,
+            stale_count + valid_count,
+            "Should have {} stale + {} valid entries before healing",
+            stale_count,
+            valid_count
+        );
+
+        // Set IndexAccountHistory checkpoint to block 5000
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(
+                    StageId::IndexAccountHistory,
+                    StageCheckpoint::new(CHECKPOINT_BLOCK),
+                )
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Verify sf_tip > checkpoint
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets)
+            .unwrap();
+        assert_eq!(sf_tip, TOTAL_BLOCKS - 1, "Static file tip should be 14999");
+        assert!(sf_tip > CHECKPOINT_BLOCK, "sf_tip should be > checkpoint to trigger healing");
+
+        // Run check_consistency - this should trigger batched changeset-based healing
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Healing should succeed without requiring unwind");
+
+        // Verify: all stale entries for blocks > 5000 should be pruned
+        // Count remaining entries with highest_block_number > checkpoint
+        let mut remaining_stale = 0;
+        for result in rocksdb.iter::<tables::AccountsHistory>().unwrap() {
+            let (key, _) = result.unwrap();
+            if key.highest_block_number > CHECKPOINT_BLOCK && key.highest_block_number != u64::MAX {
+                remaining_stale += 1;
+            }
+        }
+        assert_eq!(
+            remaining_stale, 0,
+            "All stale entries (block > {}) should be pruned",
+            CHECKPOINT_BLOCK
+        );
+    }
+
+    /// Tests that accounts history healing preserves entries at exactly the checkpoint block.
+    #[test]
+    fn test_check_consistency_accounts_history_preserves_checkpoint_block() {
+        use reth_db::models::AccountBeforeTx;
+        use reth_db_api::models::ShardedKey;
+
+        const CHECKPOINT_BLOCK: u64 = 100;
+        const SF_TIP: u64 = 200;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let checkpoint_addr = Address::repeat_byte(0xAA);
+        let stale_addr = Address::repeat_byte(0xCC);
+
+        // Write account changesets to static files
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            for block_num in 0..=SF_TIP {
+                let changeset = if block_num == CHECKPOINT_BLOCK {
+                    vec![AccountBeforeTx { address: checkpoint_addr, info: None }]
+                } else if block_num > CHECKPOINT_BLOCK {
+                    vec![AccountBeforeTx { address: stale_addr, info: None }]
+                } else {
+                    vec![AccountBeforeTx { address: Address::ZERO, info: None }]
+                };
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        // Set checkpoint
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(
+                    StageId::IndexAccountHistory,
+                    StageCheckpoint::new(CHECKPOINT_BLOCK),
+                )
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        // Insert entry AT the checkpoint block (should be preserved)
+        let checkpoint_key = ShardedKey::new(checkpoint_addr, CHECKPOINT_BLOCK);
+        let checkpoint_list = BlockNumberList::new_pre_sorted([CHECKPOINT_BLOCK]);
+        rocksdb.put::<tables::AccountsHistory>(checkpoint_key.clone(), &checkpoint_list).unwrap();
+
+        // Insert stale entry AFTER the checkpoint (should be removed)
+        let stale_key = ShardedKey::new(stale_addr, SF_TIP);
+        let stale_list = BlockNumberList::new_pre_sorted([CHECKPOINT_BLOCK + 1, SF_TIP]);
+        rocksdb.put::<tables::AccountsHistory>(stale_key.clone(), &stale_list).unwrap();
+
+        // Run healing
+        let provider = factory.database_provider_ro().unwrap();
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Should heal without unwind");
+
+        // Verify checkpoint block entry is PRESERVED
+        let preserved = rocksdb.get::<tables::AccountsHistory>(checkpoint_key).unwrap();
+        assert!(preserved.is_some(), "Entry at checkpoint block should be preserved, not deleted");
+
+        // Verify stale entry is removed or unwound
+        let stale = rocksdb.get::<tables::AccountsHistory>(stale_key).unwrap();
+        assert!(stale.is_none(), "Stale entry after checkpoint should be removed");
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_sf_tip_equals_checkpoint_no_action() {
+        use alloy_primitives::U256;
+        use reth_db::models::StorageBeforeTx;
+        use reth_static_file_types::StaticFileSegment;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Insert StoragesHistory entries into RocksDB
+        let key1 = StorageShardedKey::new(Address::ZERO, B256::ZERO, 50);
+        let key2 = StorageShardedKey::new(Address::random(), B256::random(), 80);
+        let block_list1 = BlockNumberList::new_pre_sorted([10, 20, 30, 50]);
+        let block_list2 = BlockNumberList::new_pre_sorted([40, 60, 80]);
+        rocksdb.put::<tables::StoragesHistory>(key1, &block_list1).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key2, &block_list2).unwrap();
+
+        // Capture entries before consistency check
+        let entries_before: Vec<_> =
+            rocksdb.iter::<tables::StoragesHistory>().unwrap().map(|r| r.unwrap()).collect();
+
+        // Create a test provider factory
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // Write storage changesets to static files for blocks 0-100
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            for block_num in 0..=100u64 {
+                let changeset = vec![StorageBeforeTx {
+                    address: Address::ZERO,
+                    key: B256::with_last_byte(block_num as u8),
+                    value: U256::from(block_num),
+                }];
+                writer.append_storage_changeset(changeset, block_num).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        // Set IndexStorageHistory checkpoint to block 100 (same as sf_tip)
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Verify sf_tip equals checkpoint (both at 100)
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
+            .unwrap();
+        assert_eq!(sf_tip, 100, "Static file tip should be 100");
+
+        // Run check_consistency - should return None (no unwind needed)
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "sf_tip == checkpoint should not require unwind");
+
+        // Verify NO entries are deleted - RocksDB state unchanged
+        let entries_after: Vec<_> =
+            rocksdb.iter::<tables::StoragesHistory>().unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(
+            entries_after.len(),
+            entries_before.len(),
+            "RocksDB entry count should be unchanged when sf_tip == checkpoint"
+        );
+
+        // Verify exact entries are preserved
+        for (before, after) in entries_before.iter().zip(entries_after.iter()) {
+            assert_eq!(before.0, after.0, "Entry key should be unchanged");
+            assert_eq!(before.1, after.1, "Entry block list should be unchanged");
+        }
+    }
+}

--- a/patches/reth-provider/src/providers/rocksdb/metrics.rs
+++ b/patches/reth-provider/src/providers/rocksdb/metrics.rs
@@ -1,0 +1,95 @@
+use std::{collections::HashMap, time::Duration};
+
+use itertools::Itertools;
+use metrics::{Counter, Histogram};
+use reth_db::Tables;
+use reth_metrics::Metrics;
+use strum::{EnumIter, IntoEnumIterator};
+
+pub(super) const ROCKSDB_TABLES: &[&str] = &[
+    Tables::TransactionHashNumbers.name(),
+    Tables::StoragesHistory.name(),
+    Tables::AccountsHistory.name(),
+];
+
+/// Metrics for the `RocksDB` provider.
+#[derive(Debug)]
+pub(crate) struct RocksDBMetrics {
+    operations: HashMap<(&'static str, RocksDBOperation), RocksDBOperationMetrics>,
+}
+
+impl Default for RocksDBMetrics {
+    fn default() -> Self {
+        let mut operations = ROCKSDB_TABLES
+            .iter()
+            .copied()
+            .cartesian_product(RocksDBOperation::iter())
+            .map(|(table, operation)| {
+                (
+                    (table, operation),
+                    RocksDBOperationMetrics::new_with_labels(&[
+                        ("table", table),
+                        ("operation", operation.as_str()),
+                    ]),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        // Add special "Batch" entry for batch write operations
+        operations.insert(
+            ("Batch", RocksDBOperation::BatchWrite),
+            RocksDBOperationMetrics::new_with_labels(&[
+                ("table", "Batch"),
+                ("operation", RocksDBOperation::BatchWrite.as_str()),
+            ]),
+        );
+
+        Self { operations }
+    }
+}
+
+impl RocksDBMetrics {
+    /// Records operation metrics with the given operation label and table name.
+    pub(crate) fn record_operation(
+        &self,
+        operation: RocksDBOperation,
+        table: &'static str,
+        duration: Duration,
+    ) {
+        let metrics =
+            self.operations.get(&(table, operation)).expect("operation metrics should exist");
+
+        metrics.calls_total.increment(1);
+        metrics.duration_seconds.record(duration.as_secs_f64());
+    }
+}
+
+/// `RocksDB` operations that are tracked
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
+pub(crate) enum RocksDBOperation {
+    Get,
+    Put,
+    Delete,
+    BatchWrite,
+}
+
+impl RocksDBOperation {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "get",
+            Self::Put => "put",
+            Self::Delete => "delete",
+            Self::BatchWrite => "batch-write",
+        }
+    }
+}
+
+/// Metrics for a specific `RocksDB` operation on a table
+#[derive(Metrics, Clone)]
+#[metrics(scope = "rocksdb.provider")]
+pub(crate) struct RocksDBOperationMetrics {
+    /// Total number of calls
+    calls_total: Counter,
+    /// Duration of operations
+    duration_seconds: Histogram,
+}

--- a/patches/reth-provider/src/providers/rocksdb/mod.rs
+++ b/patches/reth-provider/src/providers/rocksdb/mod.rs
@@ -1,0 +1,11 @@
+//! [`RocksDBProvider`] implementation
+
+mod invariants;
+mod metrics;
+mod provider;
+
+pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
+pub use provider::{
+    PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksReadSnapshot, RocksTx,
+};

--- a/patches/reth-provider/src/providers/rocksdb/provider.rs
+++ b/patches/reth-provider/src/providers/rocksdb/provider.rs
@@ -1,0 +1,4335 @@
+use super::metrics::{RocksDBMetrics, RocksDBOperation, ROCKSDB_TABLES};
+use crate::providers::{compute_history_rank, needs_prev_shard_check, HistoryInfo};
+use alloy_consensus::transaction::TxHashRef;
+use alloy_primitives::{
+    map::{AddressMap, HashMap},
+    Address, BlockNumber, TxNumber, B256,
+};
+use itertools::Itertools;
+use metrics::Label;
+use parking_lot::Mutex;
+use reth_chain_state::ExecutedBlock;
+use reth_db_api::{
+    database_metrics::DatabaseMetrics,
+    models::{
+        sharded_key::NUM_OF_INDICES_IN_SHARD, storage_sharded_key::StorageShardedKey, ShardedKey,
+        StorageSettings,
+    },
+    table::{Compress, Decode, Decompress, Encode, Table},
+    tables, BlockNumberList, DatabaseError,
+};
+use reth_primitives_traits::{BlockBody as _, FastInstant as Instant};
+use reth_prune_types::PruneMode;
+use reth_storage_errors::{
+    db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation, LogLevel},
+    provider::{ProviderError, ProviderResult},
+};
+use rocksdb::{
+    BlockBasedOptions, Cache, ColumnFamilyDescriptor, CompactionPri, DBCompressionType,
+    DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
+    OptimisticTransactionOptions, Options, SnapshotWithThreadMode, Transaction,
+    WriteBatchWithTransaction, WriteOptions, DB,
+};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tracing::instrument;
+
+/// Returns [`WriteOptions`] with WAL sync enabled for crash durability.
+fn synced_write_options() -> WriteOptions {
+    let mut opts = WriteOptions::default();
+    opts.set_sync(true);
+    opts
+}
+
+/// Pending `RocksDB` batches type alias.
+pub(crate) type PendingRocksDBBatches = Arc<Mutex<Vec<WriteBatchWithTransaction<true>>>>;
+
+/// Raw key-value result from a `RocksDB` iterator.
+type RawKVResult = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
+
+/// Statistics for a single `RocksDB` table (column family).
+#[derive(Debug, Clone)]
+pub struct RocksDBTableStats {
+    /// Size of SST files on disk in bytes.
+    pub sst_size_bytes: u64,
+    /// Size of memtables in memory in bytes.
+    pub memtable_size_bytes: u64,
+    /// Name of the table/column family.
+    pub name: String,
+    /// Estimated number of keys in the table.
+    pub estimated_num_keys: u64,
+    /// Estimated size of live data in bytes (SST files + memtables).
+    pub estimated_size_bytes: u64,
+    /// Estimated bytes pending compaction (reclaimable space).
+    pub pending_compaction_bytes: u64,
+}
+
+/// Database-level statistics for `RocksDB`.
+///
+/// Contains both per-table statistics and DB-level metrics like WAL size.
+#[derive(Debug, Clone)]
+pub struct RocksDBStats {
+    /// Statistics for each table (column family).
+    pub tables: Vec<RocksDBTableStats>,
+    /// Total size of WAL (Write-Ahead Log) files in bytes.
+    ///
+    /// WAL is shared across all tables and not included in per-table metrics.
+    pub wal_size_bytes: u64,
+}
+
+/// Context for `RocksDB` block writes.
+#[derive(Clone)]
+pub(crate) struct RocksDBWriteCtx {
+    /// The first block number being written.
+    pub first_block_number: BlockNumber,
+    /// The prune mode for transaction lookup, if any.
+    pub prune_tx_lookup: Option<PruneMode>,
+    /// Storage settings determining what goes to `RocksDB`.
+    pub storage_settings: StorageSettings,
+    /// Pending batches to push to after writing.
+    pub pending_batches: PendingRocksDBBatches,
+}
+
+impl fmt::Debug for RocksDBWriteCtx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBWriteCtx")
+            .field("first_block_number", &self.first_block_number)
+            .field("prune_tx_lookup", &self.prune_tx_lookup)
+            .field("storage_settings", &self.storage_settings)
+            .field("pending_batches", &"<pending batches>")
+            .finish()
+    }
+}
+
+/// Default cache size for `RocksDB` block cache (128 MB).
+const DEFAULT_CACHE_SIZE: usize = 128 << 20;
+
+/// Default block size for `RocksDB` tables (16 KB).
+const DEFAULT_BLOCK_SIZE: usize = 16 * 1024;
+
+/// Default max background jobs for `RocksDB` compaction and flushing.
+const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 6;
+
+/// Default max open file descriptors for `RocksDB`.
+///
+/// Caps the number of SST file handles `RocksDB` keeps open simultaneously.
+/// Set to 512 to stay within the common default OS `ulimit -n` of 1024,
+/// leaving headroom for MDBX, static files, and other I/O.
+/// `RocksDB` uses an internal table cache and re-opens files on demand,
+/// so this has negligible performance impact on read-heavy workloads.
+const DEFAULT_MAX_OPEN_FILES: i32 = 512;
+
+/// Default bytes per sync for `RocksDB` WAL writes (1 MB).
+const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
+
+/// Default write buffer size for `RocksDB` memtables (128 MB).
+///
+/// Larger memtables reduce flush frequency during burst writes, providing more consistent
+/// tail latency. Benchmarks showed 128 MB reduces p99 latency variance by ~80% compared
+/// to 64 MB default, with negligible impact on mean throughput.
+const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 << 20;
+
+/// Default buffer capacity for compression in batches.
+/// 4 KiB matches common block/page sizes and comfortably holds typical history values,
+/// reducing the first few reallocations without over-allocating.
+const DEFAULT_COMPRESS_BUF_CAPACITY: usize = 4096;
+
+/// Default auto-commit threshold for batch writes (4 GiB).
+///
+/// When a batch exceeds this size, it is automatically committed to prevent OOM
+/// during large bulk writes. The consistency check on startup heals any crash
+/// that occurs between auto-commits.
+const DEFAULT_AUTO_COMMIT_THRESHOLD: usize = 4 * 1024 * 1024 * 1024;
+
+/// Builder for [`RocksDBProvider`].
+pub struct RocksDBBuilder {
+    path: PathBuf,
+    column_families: Vec<String>,
+    enable_metrics: bool,
+    enable_statistics: bool,
+    log_level: rocksdb::LogLevel,
+    block_cache: Cache,
+    read_only: bool,
+}
+
+impl fmt::Debug for RocksDBBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBBuilder")
+            .field("path", &self.path)
+            .field("column_families", &self.column_families)
+            .field("enable_metrics", &self.enable_metrics)
+            .finish()
+    }
+}
+
+impl RocksDBBuilder {
+    /// Creates a new builder with optimized default options.
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        let cache = Cache::new_lru_cache(DEFAULT_CACHE_SIZE);
+        Self {
+            path: path.as_ref().to_path_buf(),
+            column_families: Vec::new(),
+            enable_metrics: false,
+            enable_statistics: false,
+            log_level: rocksdb::LogLevel::Info,
+            block_cache: cache,
+            read_only: false,
+        }
+    }
+
+    /// Creates default table options with shared block cache.
+    fn default_table_options(cache: &Cache) -> BlockBasedOptions {
+        let mut table_options = BlockBasedOptions::default();
+        table_options.set_block_size(DEFAULT_BLOCK_SIZE);
+        table_options.set_cache_index_and_filter_blocks(true);
+        table_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        // Shared block cache for all column families.
+        table_options.set_block_cache(cache);
+        table_options
+    }
+
+    /// Creates optimized `RocksDB` options per `RocksDB` wiki recommendations.
+    fn default_options(
+        log_level: rocksdb::LogLevel,
+        cache: &Cache,
+        enable_statistics: bool,
+    ) -> Options {
+        // Follow recommend tuning guide from RocksDB wiki, see https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning
+        let table_options = Self::default_table_options(cache);
+
+        let mut options = Options::default();
+        options.set_block_based_table_factory(&table_options);
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+        options.set_max_background_jobs(DEFAULT_MAX_BACKGROUND_JOBS);
+        options.set_bytes_per_sync(DEFAULT_BYTES_PER_SYNC);
+
+        options.set_bottommost_compression_type(DBCompressionType::Zstd);
+        options.set_bottommost_zstd_max_train_bytes(0, true);
+        options.set_compression_type(DBCompressionType::Lz4);
+        options.set_compaction_pri(CompactionPri::MinOverlappingRatio);
+
+        options.set_log_level(log_level);
+
+        options.set_max_open_files(DEFAULT_MAX_OPEN_FILES);
+
+        // Delete obsolete WAL files immediately after all column families have flushed.
+        // Both set to 0 means "delete ASAP, no archival".
+        options.set_wal_ttl_seconds(0);
+        options.set_wal_size_limit_mb(0);
+
+        // Statistics can view from RocksDB log file
+        if enable_statistics {
+            options.enable_statistics();
+        }
+
+        options
+    }
+
+    /// Creates optimized column family options.
+    fn default_column_family_options(cache: &Cache) -> Options {
+        // Follow recommend tuning guide from RocksDB wiki, see https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning
+        let table_options = Self::default_table_options(cache);
+
+        let mut cf_options = Options::default();
+        cf_options.set_block_based_table_factory(&table_options);
+        cf_options.set_level_compaction_dynamic_level_bytes(true);
+        // Recommend to use Zstd for bottommost compression and Lz4 for other levels, see https://github.com/facebook/rocksdb/wiki/Compression#configuration
+        cf_options.set_compression_type(DBCompressionType::Lz4);
+        cf_options.set_bottommost_compression_type(DBCompressionType::Zstd);
+        // Only use Zstd compression, disable dictionary training
+        cf_options.set_bottommost_zstd_max_train_bytes(0, true);
+        cf_options.set_write_buffer_size(DEFAULT_WRITE_BUFFER_SIZE);
+
+        cf_options
+    }
+
+    /// Creates optimized column family options for `TransactionHashNumbers`.
+    ///
+    /// This table stores `B256 -> TxNumber` mappings where:
+    /// - Keys are incompressible 32-byte hashes (compression wastes CPU for zero benefit)
+    /// - Values are varint-encoded `u64` (a few bytes - too small to benefit from compression)
+    /// - Every lookup expects a hit (bloom filters only help when checking non-existent keys)
+    fn tx_hash_numbers_column_family_options(cache: &Cache) -> Options {
+        let mut table_options = BlockBasedOptions::default();
+        table_options.set_block_size(DEFAULT_BLOCK_SIZE);
+        table_options.set_cache_index_and_filter_blocks(true);
+        table_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        table_options.set_block_cache(cache);
+        // Disable bloom filter: every lookup expects a hit, so bloom filters provide no benefit
+        // and waste memory
+
+        let mut cf_options = Options::default();
+        cf_options.set_block_based_table_factory(&table_options);
+        cf_options.set_level_compaction_dynamic_level_bytes(true);
+        // Disable compression: B256 keys are incompressible hashes, TxNumber values are
+        // varint-encoded u64 (a few bytes). Compression wastes CPU cycles for zero space savings.
+        cf_options.set_compression_type(DBCompressionType::None);
+        cf_options.set_bottommost_compression_type(DBCompressionType::None);
+
+        cf_options
+    }
+
+    /// Adds a column family for a specific table type.
+    pub fn with_table<T: Table>(mut self) -> Self {
+        self.column_families.push(T::NAME.to_string());
+        self
+    }
+
+    /// Registers the default tables used by reth for `RocksDB` storage.
+    ///
+    /// This registers:
+    /// - [`tables::TransactionHashNumbers`] - Transaction hash to number mapping
+    /// - [`tables::AccountsHistory`] - Account history index
+    /// - [`tables::StoragesHistory`] - Storage history index
+    pub fn with_default_tables(self) -> Self {
+        self.with_table::<tables::TransactionHashNumbers>()
+            .with_table::<tables::AccountsHistory>()
+            .with_table::<tables::StoragesHistory>()
+    }
+
+    /// Enables metrics.
+    pub const fn with_metrics(mut self) -> Self {
+        self.enable_metrics = true;
+        self
+    }
+
+    /// Enables `RocksDB` internal statistics collection.
+    pub const fn with_statistics(mut self) -> Self {
+        self.enable_statistics = true;
+        self
+    }
+
+    /// Sets the log level from `DatabaseArgs` configuration.
+    pub const fn with_database_log_level(mut self, log_level: Option<LogLevel>) -> Self {
+        if let Some(level) = log_level {
+            self.log_level = convert_log_level(level);
+        }
+        self
+    }
+
+    /// Sets a custom block cache size.
+    pub fn with_block_cache_size(mut self, capacity_bytes: usize) -> Self {
+        self.block_cache = Cache::new_lru_cache(capacity_bytes);
+        self
+    }
+
+    /// Sets read-only mode.
+    ///
+    /// Opens the database as a secondary instance, which supports catching up
+    /// with the primary via [`RocksDBProvider::try_catch_up_with_primary`].
+    /// A temporary directory is created automatically for the secondary's LOG files.
+    ///
+    /// Note: Write operations on a read-only provider will panic at runtime.
+    pub const fn with_read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    /// Builds the [`RocksDBProvider`].
+    pub fn build(self) -> ProviderResult<RocksDBProvider> {
+        let options =
+            Self::default_options(self.log_level, &self.block_cache, self.enable_statistics);
+
+        let cf_descriptors: Vec<ColumnFamilyDescriptor> = self
+            .column_families
+            .iter()
+            .map(|name| {
+                let cf_options = if name == tables::TransactionHashNumbers::NAME {
+                    Self::tx_hash_numbers_column_family_options(&self.block_cache)
+                } else {
+                    Self::default_column_family_options(&self.block_cache)
+                };
+                ColumnFamilyDescriptor::new(name.clone(), cf_options)
+            })
+            .collect();
+
+        let metrics = self.enable_metrics.then(RocksDBMetrics::default);
+
+        if self.read_only {
+            // Open as secondary instance for catch-up capability.
+            // Secondary needs max_open_files = -1 to keep all FDs open.
+            let mut options = options;
+            options.set_max_open_files(-1);
+
+            let secondary_path = self
+                .path
+                .parent()
+                .unwrap_or(&self.path)
+                .join(format!("rocksdb-secondary-tmp-{}", std::process::id()));
+            reth_fs_util::create_dir_all(&secondary_path).map_err(ProviderError::other)?;
+
+            let db = DB::open_cf_descriptors_as_secondary(
+                &options,
+                &self.path,
+                &secondary_path,
+                cf_descriptors,
+            )
+            .map_err(|e| {
+                ProviderError::Database(DatabaseError::Open(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
+            Ok(RocksDBProvider(Arc::new(RocksDBProviderInner::Secondary {
+                db,
+                metrics,
+                secondary_path,
+            })))
+        } else {
+            // Use OptimisticTransactionDB for MDBX-like transaction semantics (read-your-writes,
+            // rollback) OptimisticTransactionDB uses optimistic concurrency control (conflict
+            // detection at commit) and is backed by DBCommon, giving us access to
+            // cancel_all_background_work for clean shutdown.
+            let db =
+                OptimisticTransactionDB::open_cf_descriptors(&options, &self.path, cf_descriptors)
+                    .map_err(|e| {
+                        ProviderError::Database(DatabaseError::Open(DatabaseErrorInfo {
+                            message: e.to_string().into(),
+                            code: -1,
+                        }))
+                    })?;
+            Ok(RocksDBProvider(Arc::new(RocksDBProviderInner::ReadWrite { db, metrics })))
+        }
+    }
+}
+
+/// Some types don't support compression (eg. B256), and we don't want to be copying them to the
+/// allocated buffer when we can just use their reference.
+macro_rules! compress_to_buf_or_ref {
+    ($buf:expr, $value:expr) => {
+        if let Some(value) = $value.uncompressable_ref() {
+            Some(value)
+        } else {
+            $buf.clear();
+            $value.compress_to_buf(&mut $buf);
+            None
+        }
+    };
+}
+
+/// `RocksDB` provider for auxiliary storage layer beside main database MDBX.
+#[derive(Debug)]
+pub struct RocksDBProvider(Arc<RocksDBProviderInner>);
+
+/// Inner state for `RocksDB` provider.
+enum RocksDBProviderInner {
+    /// Read-write mode using `OptimisticTransactionDB`.
+    ReadWrite {
+        /// `RocksDB` database instance with optimistic transaction support.
+        db: OptimisticTransactionDB,
+        /// Metrics latency & operations.
+        metrics: Option<RocksDBMetrics>,
+    },
+    /// Secondary mode using `DB` opened with `open_cf_descriptors_as_secondary`.
+    /// Supports catching up with the primary via `try_catch_up_with_primary`.
+    /// Does not support snapshots; consistency is guaranteed externally.
+    Secondary {
+        /// Secondary `RocksDB` database instance.
+        db: DB,
+        /// Metrics latency & operations.
+        metrics: Option<RocksDBMetrics>,
+        /// Temporary directory for secondary LOG files, removed on drop.
+        secondary_path: PathBuf,
+    },
+}
+
+impl RocksDBProviderInner {
+    /// Returns the metrics for this provider.
+    const fn metrics(&self) -> Option<&RocksDBMetrics> {
+        match self {
+            Self::ReadWrite { metrics, .. } | Self::Secondary { metrics, .. } => metrics.as_ref(),
+        }
+    }
+
+    /// Returns the read-write database, panicking if in read-only mode.
+    fn db_rw(&self) -> &OptimisticTransactionDB {
+        match self {
+            Self::ReadWrite { db, .. } => db,
+            Self::Secondary { .. } => {
+                panic!("Cannot perform write operation on secondary RocksDB provider")
+            }
+        }
+    }
+
+    /// Gets the column family handle for a table.
+    fn cf_handle<T: Table>(&self) -> Result<&rocksdb::ColumnFamily, DatabaseError> {
+        let cf = match self {
+            Self::ReadWrite { db, .. } => db.cf_handle(T::NAME),
+            Self::Secondary { db, .. } => db.cf_handle(T::NAME),
+        };
+        cf.ok_or_else(|| DatabaseError::Other(format!("Column family '{}' not found", T::NAME)))
+    }
+
+    /// Gets a value from a column family.
+    fn get_cf(
+        &self,
+        cf: &rocksdb::ColumnFamily,
+        key: impl AsRef<[u8]>,
+    ) -> Result<Option<Vec<u8>>, rocksdb::Error> {
+        match self {
+            Self::ReadWrite { db, .. } => db.get_cf(cf, key),
+            Self::Secondary { db, .. } => db.get_cf(cf, key),
+        }
+    }
+
+    /// Puts a value into a column family.
+    fn put_cf(
+        &self,
+        cf: &rocksdb::ColumnFamily,
+        key: impl AsRef<[u8]>,
+        value: impl AsRef<[u8]>,
+    ) -> Result<(), rocksdb::Error> {
+        self.db_rw().put_cf(cf, key, value)
+    }
+
+    /// Deletes a value from a column family.
+    fn delete_cf(
+        &self,
+        cf: &rocksdb::ColumnFamily,
+        key: impl AsRef<[u8]>,
+    ) -> Result<(), rocksdb::Error> {
+        self.db_rw().delete_cf(cf, key)
+    }
+
+    /// Deletes a range of values from a column family.
+    fn delete_range_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &rocksdb::ColumnFamily,
+        from: K,
+        to: K,
+    ) -> Result<(), rocksdb::Error> {
+        self.db_rw().delete_range_cf(cf, from, to)
+    }
+
+    /// Returns an iterator over a column family.
+    fn iterator_cf(
+        &self,
+        cf: &rocksdb::ColumnFamily,
+        mode: IteratorMode<'_>,
+    ) -> RocksDBIterEnum<'_> {
+        match self {
+            Self::ReadWrite { db, .. } => RocksDBIterEnum::ReadWrite(db.iterator_cf(cf, mode)),
+            Self::Secondary { db, .. } => RocksDBIterEnum::ReadOnly(db.iterator_cf(cf, mode)),
+        }
+    }
+
+    /// Returns a raw iterator over a column family.
+    ///
+    /// Unlike [`Self::iterator_cf`], raw iterators support `seek()` for efficient
+    /// repositioning without creating a new iterator.
+    fn raw_iterator_cf(&self, cf: &rocksdb::ColumnFamily) -> RocksDBRawIterEnum<'_> {
+        match self {
+            Self::ReadWrite { db, .. } => RocksDBRawIterEnum::ReadWrite(db.raw_iterator_cf(cf)),
+            Self::Secondary { db, .. } => RocksDBRawIterEnum::ReadOnly(db.raw_iterator_cf(cf)),
+        }
+    }
+
+    /// Returns a read-only, point-in-time snapshot of the database.
+    fn snapshot(&self) -> RocksReadSnapshotInner<'_> {
+        match self {
+            Self::ReadWrite { db, .. } => RocksReadSnapshotInner::ReadWrite(db.snapshot()),
+            Self::Secondary { db, .. } => RocksReadSnapshotInner::Secondary(db),
+        }
+    }
+
+    /// Returns the path to the database directory.
+    fn path(&self) -> &Path {
+        match self {
+            Self::ReadWrite { db, .. } => db.path(),
+            Self::Secondary { db, .. } => db.path(),
+        }
+    }
+
+    /// Returns the total size of WAL (Write-Ahead Log) files in bytes.
+    ///
+    /// WAL files have a `.log` extension in the `RocksDB` directory.
+    fn wal_size_bytes(&self) -> u64 {
+        let path = self.path();
+
+        match std::fs::read_dir(path) {
+            Ok(entries) => entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+                .filter_map(|e| e.metadata().ok())
+                .map(|m| m.len())
+                .sum(),
+            Err(_) => 0,
+        }
+    }
+
+    /// Returns statistics for all column families in the database.
+    fn table_stats(&self) -> Vec<RocksDBTableStats> {
+        let mut stats = Vec::new();
+
+        macro_rules! collect_stats {
+            ($db:expr) => {
+                for cf_name in ROCKSDB_TABLES {
+                    if let Some(cf) = $db.cf_handle(cf_name) {
+                        let estimated_num_keys = $db
+                            .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
+                            .ok()
+                            .flatten()
+                            .unwrap_or(0);
+
+                        // SST files size (on-disk) + memtable size (in-memory)
+                        let sst_size = $db
+                            .property_int_value_cf(cf, rocksdb::properties::LIVE_SST_FILES_SIZE)
+                            .ok()
+                            .flatten()
+                            .unwrap_or(0);
+
+                        let memtable_size = $db
+                            .property_int_value_cf(cf, rocksdb::properties::SIZE_ALL_MEM_TABLES)
+                            .ok()
+                            .flatten()
+                            .unwrap_or(0);
+
+                        let estimated_size_bytes = sst_size + memtable_size;
+
+                        let pending_compaction_bytes = $db
+                            .property_int_value_cf(
+                                cf,
+                                rocksdb::properties::ESTIMATE_PENDING_COMPACTION_BYTES,
+                            )
+                            .ok()
+                            .flatten()
+                            .unwrap_or(0);
+
+                        stats.push(RocksDBTableStats {
+                            sst_size_bytes: sst_size,
+                            memtable_size_bytes: memtable_size,
+                            name: cf_name.to_string(),
+                            estimated_num_keys,
+                            estimated_size_bytes,
+                            pending_compaction_bytes,
+                        });
+                    }
+                }
+            };
+        }
+
+        match self {
+            Self::ReadWrite { db, .. } => collect_stats!(db),
+            Self::Secondary { db, .. } => collect_stats!(db),
+        }
+
+        stats
+    }
+
+    /// Returns database-level statistics including per-table stats and WAL size.
+    fn db_stats(&self) -> RocksDBStats {
+        RocksDBStats { tables: self.table_stats(), wal_size_bytes: self.wal_size_bytes() }
+    }
+}
+
+impl fmt::Debug for RocksDBProviderInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadWrite { metrics, .. } => f
+                .debug_struct("RocksDBProviderInner::ReadWrite")
+                .field("db", &"<OptimisticTransactionDB>")
+                .field("metrics", metrics)
+                .finish(),
+            Self::Secondary { metrics, .. } => f
+                .debug_struct("RocksDBProviderInner::Secondary")
+                .field("db", &"<DB (secondary)>")
+                .field("metrics", metrics)
+                .finish(),
+        }
+    }
+}
+
+impl Drop for RocksDBProviderInner {
+    fn drop(&mut self) {
+        match self {
+            Self::ReadWrite { db, .. } => {
+                // Flush all memtables if possible. If not, they will be rebuilt from the WAL on
+                // restart
+                if let Err(e) = db.flush_wal(true) {
+                    tracing::warn!(target: "providers::rocksdb", ?e, "Failed to flush WAL on drop");
+                }
+                for cf_name in ROCKSDB_TABLES {
+                    if let Some(cf) = db.cf_handle(cf_name) &&
+                        let Err(e) = db.flush_cf(&cf)
+                    {
+                        tracing::warn!(target: "providers::rocksdb", cf = cf_name, ?e, "Failed to flush CF on drop");
+                    }
+                }
+                db.cancel_all_background_work(true);
+            }
+            Self::Secondary { db, secondary_path, .. } => {
+                db.cancel_all_background_work(true);
+                let _ = std::fs::remove_dir_all(secondary_path);
+            }
+        }
+    }
+}
+
+impl Clone for RocksDBProvider {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl DatabaseMetrics for RocksDBProvider {
+    fn gauge_metrics(&self) -> Vec<(&'static str, f64, Vec<Label>)> {
+        let mut metrics = Vec::new();
+
+        for stat in self.table_stats() {
+            metrics.push((
+                "rocksdb.table_size",
+                stat.estimated_size_bytes as f64,
+                vec![Label::new("table", stat.name.clone())],
+            ));
+            metrics.push((
+                "rocksdb.table_entries",
+                stat.estimated_num_keys as f64,
+                vec![Label::new("table", stat.name.clone())],
+            ));
+            metrics.push((
+                "rocksdb.pending_compaction_bytes",
+                stat.pending_compaction_bytes as f64,
+                vec![Label::new("table", stat.name.clone())],
+            ));
+            metrics.push((
+                "rocksdb.sst_size",
+                stat.sst_size_bytes as f64,
+                vec![Label::new("table", stat.name.clone())],
+            ));
+            metrics.push((
+                "rocksdb.memtable_size",
+                stat.memtable_size_bytes as f64,
+                vec![Label::new("table", stat.name)],
+            ));
+        }
+
+        // WAL size (DB-level, shared across all tables)
+        metrics.push(("rocksdb.wal_size", self.wal_size_bytes() as f64, vec![]));
+
+        metrics
+    }
+}
+
+impl RocksDBProvider {
+    /// Creates a new `RocksDB` provider.
+    pub fn new(path: impl AsRef<Path>) -> ProviderResult<Self> {
+        RocksDBBuilder::new(path).build()
+    }
+
+    /// Creates a new `RocksDB` provider builder.
+    pub fn builder(path: impl AsRef<Path>) -> RocksDBBuilder {
+        RocksDBBuilder::new(path)
+    }
+
+    /// Returns `true` if a `RocksDB` database exists at the given path.
+    ///
+    /// Checks for the presence of the `CURRENT` file, which `RocksDB` creates
+    /// when initializing a database.
+    pub fn exists(path: impl AsRef<Path>) -> bool {
+        path.as_ref().join("CURRENT").exists()
+    }
+
+    /// Returns `true` if this provider is in read-only mode.
+    pub fn is_read_only(&self) -> bool {
+        matches!(self.0.as_ref(), RocksDBProviderInner::Secondary { .. })
+    }
+
+    /// Tries to catch up with the primary instance by reading new WAL and MANIFEST entries.
+    ///
+    /// This is a no-op for read-write and read-only providers.
+    /// For secondary providers, this incrementally syncs with the primary's latest state.
+    pub fn try_catch_up_with_primary(&self) -> ProviderResult<()> {
+        match self.0.as_ref() {
+            RocksDBProviderInner::Secondary { db, .. } => {
+                db.try_catch_up_with_primary().map_err(|e| {
+                    ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    }))
+                })
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Returns a read-only, point-in-time snapshot of the database.
+    ///
+    /// Lighter weight than [`RocksTx`] — no write-conflict tracking, and `Send + Sync`.
+    pub fn snapshot(&self) -> RocksReadSnapshot<'_> {
+        RocksReadSnapshot { inner: self.0.snapshot(), provider: self }
+    }
+
+    /// Creates a new transaction with MDBX-like semantics (read-your-writes, rollback).
+    ///
+    /// Note: With `OptimisticTransactionDB`, commits may fail if there are conflicts.
+    /// Conflict detection happens at commit time, not at write time.
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    pub fn tx(&self) -> RocksTx<'_> {
+        let write_options = synced_write_options();
+        let txn_options = OptimisticTransactionOptions::default();
+        let inner = self.0.db_rw().transaction_opt(&write_options, &txn_options);
+        RocksTx { inner, provider: self }
+    }
+
+    /// Creates a new batch for atomic writes.
+    ///
+    /// Use [`Self::write_batch`] for closure-based atomic writes.
+    /// Use this method when the batch needs to be held by [`crate::EitherWriter`].
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode when attempting to commit.
+    pub fn batch(&self) -> RocksDBBatch<'_> {
+        RocksDBBatch {
+            provider: self,
+            inner: WriteBatchWithTransaction::<true>::default(),
+            buf: Vec::with_capacity(DEFAULT_COMPRESS_BUF_CAPACITY),
+            auto_commit_threshold: None,
+        }
+    }
+
+    /// Creates a new batch with auto-commit enabled.
+    ///
+    /// When the batch size exceeds the threshold (4 GiB), the batch is automatically
+    /// committed and reset. This prevents OOM during large bulk writes while maintaining
+    /// crash-safety via the consistency check on startup.
+    pub fn batch_with_auto_commit(&self) -> RocksDBBatch<'_> {
+        RocksDBBatch {
+            provider: self,
+            inner: WriteBatchWithTransaction::<true>::default(),
+            buf: Vec::with_capacity(DEFAULT_COMPRESS_BUF_CAPACITY),
+            auto_commit_threshold: Some(DEFAULT_AUTO_COMMIT_THRESHOLD),
+        }
+    }
+
+    /// Gets the column family handle for a table.
+    fn get_cf_handle<T: Table>(&self) -> Result<&rocksdb::ColumnFamily, DatabaseError> {
+        self.0.cf_handle::<T>()
+    }
+
+    /// Executes a function and records metrics with the given operation and table name.
+    fn execute_with_operation_metric<R>(
+        &self,
+        operation: RocksDBOperation,
+        table: &'static str,
+        f: impl FnOnce(&Self) -> R,
+    ) -> R {
+        let start = self.0.metrics().map(|_| Instant::now());
+        let res = f(self);
+
+        if let (Some(start), Some(metrics)) = (start, self.0.metrics()) {
+            metrics.record_operation(operation, table, start.elapsed());
+        }
+
+        res
+    }
+
+    /// Gets a value from the specified table.
+    pub fn get<T: Table>(&self, key: T::Key) -> ProviderResult<Option<T::Value>> {
+        self.get_encoded::<T>(&key.encode())
+    }
+
+    /// Gets a value from the specified table using pre-encoded key.
+    pub fn get_encoded<T: Table>(
+        &self,
+        key: &<T::Key as Encode>::Encoded,
+    ) -> ProviderResult<Option<T::Value>> {
+        self.execute_with_operation_metric(RocksDBOperation::Get, T::NAME, |this| {
+            let result = this.0.get_cf(this.get_cf_handle::<T>()?, key.as_ref()).map_err(|e| {
+                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
+
+            Ok(result.and_then(|value| T::Value::decompress(&value).ok()))
+        })
+    }
+
+    /// Gets raw bytes from the specified table without decompressing.
+    pub fn get_raw<T: Table>(&self, key: T::Key) -> ProviderResult<Option<Vec<u8>>> {
+        let encoded = key.encode();
+        self.execute_with_operation_metric(RocksDBOperation::Get, T::NAME, |this| {
+            this.0.get_cf(this.get_cf_handle::<T>()?, encoded.as_ref()).map_err(|e| {
+                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })
+        })
+    }
+
+    /// Puts upsert a value into the specified table with the given key.
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    pub fn put<T: Table>(&self, key: T::Key, value: &T::Value) -> ProviderResult<()> {
+        let encoded_key = key.encode();
+        self.put_encoded::<T>(&encoded_key, value)
+    }
+
+    /// Puts a value into the specified table using pre-encoded key.
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    pub fn put_encoded<T: Table>(
+        &self,
+        key: &<T::Key as Encode>::Encoded,
+        value: &T::Value,
+    ) -> ProviderResult<()> {
+        self.execute_with_operation_metric(RocksDBOperation::Put, T::NAME, |this| {
+            // for simplify the code, we need allocate buf here each time because `RocksDBProvider`
+            // is thread safe if user want to avoid allocate buf each time, they can use
+            // write_batch api
+            let mut buf = Vec::new();
+            let value_bytes = compress_to_buf_or_ref!(buf, value).unwrap_or(&buf);
+
+            this.0.put_cf(this.get_cf_handle::<T>()?, key, value_bytes).map_err(|e| {
+                ProviderError::Database(DatabaseError::Write(Box::new(DatabaseWriteError {
+                    info: DatabaseErrorInfo { message: e.to_string().into(), code: -1 },
+                    operation: DatabaseWriteOperation::PutUpsert,
+                    table_name: T::NAME,
+                    key: key.as_ref().to_vec(),
+                })))
+            })
+        })
+    }
+
+    /// Deletes a value from the specified table.
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    pub fn delete<T: Table>(&self, key: T::Key) -> ProviderResult<()> {
+        self.execute_with_operation_metric(RocksDBOperation::Delete, T::NAME, |this| {
+            this.0.delete_cf(this.get_cf_handle::<T>()?, key.encode().as_ref()).map_err(|e| {
+                ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })
+        })
+    }
+
+    /// Clears all entries from the specified table.
+    ///
+    /// Uses `delete_range_cf` from empty key to a max key (256 bytes of 0xFF).
+    /// This end key must exceed the maximum encoded key size for any table.
+    /// Current max is ~60 bytes (`StorageShardedKey` = 20 + 32 + 8).
+    pub fn clear<T: Table>(&self) -> ProviderResult<()> {
+        let cf = self.get_cf_handle::<T>()?;
+
+        self.0.delete_range_cf(cf, &[] as &[u8], &[0xFF; 256]).map_err(|e| {
+            ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        Ok(())
+    }
+
+    /// Retrieves the first or last entry from a table based on the iterator mode.
+    fn get_boundary<T: Table>(
+        &self,
+        mode: IteratorMode<'_>,
+    ) -> ProviderResult<Option<(T::Key, T::Value)>> {
+        self.execute_with_operation_metric(RocksDBOperation::Get, T::NAME, |this| {
+            let cf = this.get_cf_handle::<T>()?;
+            let mut iter = this.0.iterator_cf(cf, mode);
+
+            match iter.next() {
+                Some(Ok((key_bytes, value_bytes))) => {
+                    let key = <T::Key as reth_db_api::table::Decode>::decode(&key_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    let value = T::Value::decompress(&value_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    Ok(Some((key, value)))
+                }
+                Some(Err(e)) => {
+                    Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    })))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
+    /// Gets the first (smallest key) entry from the specified table.
+    #[inline]
+    pub fn first<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
+        self.get_boundary::<T>(IteratorMode::Start)
+    }
+
+    /// Gets the last (largest key) entry from the specified table.
+    #[inline]
+    pub fn last<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
+        self.get_boundary::<T>(IteratorMode::End)
+    }
+
+    /// Creates an iterator over all entries in the specified table.
+    ///
+    /// Returns decoded `(Key, Value)` pairs in key order.
+    pub fn iter<T: Table>(&self) -> ProviderResult<RocksDBIter<'_, T>> {
+        let cf = self.get_cf_handle::<T>()?;
+        let iter = self.0.iterator_cf(cf, IteratorMode::Start);
+        Ok(RocksDBIter { inner: iter, _marker: std::marker::PhantomData })
+    }
+
+    /// Creates an iterator starting from the given key (inclusive, seek forward).
+    ///
+    /// Returns decoded `(Key, Value)` pairs starting from the first key >= `key`.
+    pub fn iter_from<T: Table>(&self, key: T::Key) -> ProviderResult<RocksDBIter<'_, T>> {
+        let cf = self.get_cf_handle::<T>()?;
+        let encoded_key = key.encode();
+        let iter = self
+            .0
+            .iterator_cf(cf, IteratorMode::From(encoded_key.as_ref(), rocksdb::Direction::Forward));
+        Ok(RocksDBIter { inner: iter, _marker: std::marker::PhantomData })
+    }
+
+    /// Returns statistics for all column families in the database.
+    ///
+    /// Returns a vector of (`table_name`, `estimated_keys`, `estimated_size_bytes`) tuples.
+    pub fn table_stats(&self) -> Vec<RocksDBTableStats> {
+        self.0.table_stats()
+    }
+
+    /// Returns the total size of WAL (Write-Ahead Log) files in bytes.
+    ///
+    /// This scans the `RocksDB` directory for `.log` files and sums their sizes.
+    /// WAL files can be significant (e.g., 2.7GB observed) and are not included
+    /// in `table_size`, `sst_size`, or `memtable_size` metrics.
+    pub fn wal_size_bytes(&self) -> u64 {
+        self.0.wal_size_bytes()
+    }
+
+    /// Returns database-level statistics including per-table stats and WAL size.
+    ///
+    /// This combines [`Self::table_stats`] and [`Self::wal_size_bytes`] into a single struct.
+    pub fn db_stats(&self) -> RocksDBStats {
+        self.0.db_stats()
+    }
+
+    /// Flushes pending writes for the specified tables to disk.
+    ///
+    /// This performs a flush of:
+    /// 1. The column family memtables for the specified table names to SST files
+    /// 2. The Write-Ahead Log (WAL) with sync
+    ///
+    /// After this call completes, all data for the specified tables is durably persisted to disk.
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(tables = ?tables))]
+    pub fn flush(&self, tables: &[&'static str]) -> ProviderResult<()> {
+        let db = self.0.db_rw();
+
+        for cf_name in tables {
+            if let Some(cf) = db.cf_handle(cf_name) {
+                db.flush_cf(&cf).map_err(|e| {
+                    ProviderError::Database(DatabaseError::Write(Box::new(DatabaseWriteError {
+                        info: DatabaseErrorInfo { message: e.to_string().into(), code: -1 },
+                        operation: DatabaseWriteOperation::Flush,
+                        table_name: cf_name,
+                        key: Vec::new(),
+                    })))
+                })?;
+            }
+        }
+
+        db.flush_wal(true).map_err(|e| {
+            ProviderError::Database(DatabaseError::Write(Box::new(DatabaseWriteError {
+                info: DatabaseErrorInfo { message: e.to_string().into(), code: -1 },
+                operation: DatabaseWriteOperation::Flush,
+                table_name: "WAL",
+                key: Vec::new(),
+            })))
+        })?;
+
+        Ok(())
+    }
+
+    /// Flushes and compacts all tables in `RocksDB`.
+    ///
+    /// This:
+    /// 1. Flushes all column family memtables to SST files
+    /// 2. Flushes the Write-Ahead Log (WAL) with sync
+    /// 3. Triggers manual compaction on all column families to reclaim disk space
+    ///
+    /// Use this after large delete operations (like pruning) to reclaim disk space.
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    pub fn flush_and_compact(&self) -> ProviderResult<()> {
+        self.flush(ROCKSDB_TABLES)?;
+
+        let db = self.0.db_rw();
+
+        for cf_name in ROCKSDB_TABLES {
+            if let Some(cf) = db.cf_handle(cf_name) {
+                db.compact_range_cf(&cf, None::<&[u8]>, None::<&[u8]>);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Creates a raw iterator over all entries in the specified table.
+    ///
+    /// Returns raw `(key_bytes, value_bytes)` pairs without decoding.
+    pub fn raw_iter<T: Table>(&self) -> ProviderResult<RocksDBRawIter<'_>> {
+        let cf = self.get_cf_handle::<T>()?;
+        let iter = self.0.iterator_cf(cf, IteratorMode::Start);
+        Ok(RocksDBRawIter { inner: iter })
+    }
+
+    /// Returns all account history shards for the given address in ascending key order.
+    ///
+    /// This is used for unwind operations where we need to scan all shards for an address
+    /// and potentially delete or truncate them.
+    pub fn account_history_shards(
+        &self,
+        address: Address,
+    ) -> ProviderResult<Vec<(ShardedKey<Address>, BlockNumberList)>> {
+        // Get the column family handle for the AccountsHistory table.
+        let cf = self.get_cf_handle::<tables::AccountsHistory>()?;
+
+        // Build a seek key starting at the first shard (highest_block_number = 0) for this address.
+        // ShardedKey is (address, highest_block_number) so this positions us at the beginning.
+        let start_key = ShardedKey::new(address, 0u64);
+        let start_bytes = start_key.encode();
+
+        // Create a forward iterator starting from our seek position.
+        let iter = self
+            .0
+            .iterator_cf(cf, IteratorMode::From(start_bytes.as_ref(), rocksdb::Direction::Forward));
+
+        let mut result = Vec::new();
+        for item in iter {
+            match item {
+                Ok((key_bytes, value_bytes)) => {
+                    // Decode the sharded key to check if we're still on the same address.
+                    let key = ShardedKey::<Address>::decode(&key_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                    // Stop when we reach a different address (keys are sorted by address first).
+                    if key.key != address {
+                        break;
+                    }
+
+                    // Decompress the block number list stored in this shard.
+                    let value = BlockNumberList::decompress(&value_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                    result.push((key, value));
+                }
+                Err(e) => {
+                    return Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    })));
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Returns all storage history shards for the given `(address, storage_key)` pair.
+    ///
+    /// Iterates through all shards in ascending `highest_block_number` order until
+    /// a different `(address, storage_key)` is encountered.
+    pub fn storage_history_shards(
+        &self,
+        address: Address,
+        storage_key: B256,
+    ) -> ProviderResult<Vec<(StorageShardedKey, BlockNumberList)>> {
+        let cf = self.get_cf_handle::<tables::StoragesHistory>()?;
+
+        let start_key = StorageShardedKey::new(address, storage_key, 0u64);
+        let start_bytes = start_key.encode();
+
+        let iter = self
+            .0
+            .iterator_cf(cf, IteratorMode::From(start_bytes.as_ref(), rocksdb::Direction::Forward));
+
+        let mut result = Vec::new();
+        for item in iter {
+            match item {
+                Ok((key_bytes, value_bytes)) => {
+                    let key = StorageShardedKey::decode(&key_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                    if key.address != address || key.sharded_key.key != storage_key {
+                        break;
+                    }
+
+                    let value = BlockNumberList::decompress(&value_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                    result.push((key, value));
+                }
+                Err(e) => {
+                    return Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    })));
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Unwinds account history indices for the given `(address, block_number)` pairs.
+    ///
+    /// Groups addresses by their minimum block number and calls the appropriate unwind
+    /// operations. For each address, keeps only blocks less than the minimum block
+    /// (i.e., removes the minimum block and all higher blocks).
+    ///
+    /// Returns a `WriteBatchWithTransaction` that can be committed later.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    pub fn unwind_account_history_indices(
+        &self,
+        last_indices: &[(Address, BlockNumber)],
+    ) -> ProviderResult<WriteBatchWithTransaction<true>> {
+        let mut address_min_block: AddressMap<BlockNumber> =
+            AddressMap::with_capacity_and_hasher(last_indices.len(), Default::default());
+        for &(address, block_number) in last_indices {
+            address_min_block
+                .entry(address)
+                .and_modify(|min| *min = (*min).min(block_number))
+                .or_insert(block_number);
+        }
+
+        let mut batch = self.batch();
+        for (address, min_block) in address_min_block {
+            match min_block.checked_sub(1) {
+                Some(keep_to) => batch.unwind_account_history_to(address, keep_to)?,
+                None => batch.clear_account_history(address)?,
+            }
+        }
+
+        Ok(batch.into_inner())
+    }
+
+    /// Unwinds storage history indices for the given `(address, storage_key, block_number)` tuples.
+    ///
+    /// Groups by `(address, storage_key)` and finds the minimum block number for each.
+    /// For each key, keeps only blocks less than the minimum block
+    /// (i.e., removes the minimum block and all higher blocks).
+    ///
+    /// Returns a `WriteBatchWithTransaction` that can be committed later.
+    pub fn unwind_storage_history_indices(
+        &self,
+        storage_changesets: &[(Address, B256, BlockNumber)],
+    ) -> ProviderResult<WriteBatchWithTransaction<true>> {
+        let mut key_min_block: HashMap<(Address, B256), BlockNumber> =
+            HashMap::with_capacity_and_hasher(storage_changesets.len(), Default::default());
+        for &(address, storage_key, block_number) in storage_changesets {
+            key_min_block
+                .entry((address, storage_key))
+                .and_modify(|min| *min = (*min).min(block_number))
+                .or_insert(block_number);
+        }
+
+        let mut batch = self.batch();
+        for ((address, storage_key), min_block) in key_min_block {
+            match min_block.checked_sub(1) {
+                Some(keep_to) => batch.unwind_storage_history_to(address, storage_key, keep_to)?,
+                None => batch.clear_storage_history(address, storage_key)?,
+            }
+        }
+
+        Ok(batch.into_inner())
+    }
+
+    /// Writes a batch of operations atomically.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    pub fn write_batch<F>(&self, f: F) -> ProviderResult<()>
+    where
+        F: FnOnce(&mut RocksDBBatch<'_>) -> ProviderResult<()>,
+    {
+        self.execute_with_operation_metric(RocksDBOperation::BatchWrite, "Batch", |this| {
+            let mut batch_handle = this.batch();
+            f(&mut batch_handle)?;
+            batch_handle.commit()
+        })
+    }
+
+    /// Commits a raw `WriteBatchWithTransaction` to `RocksDB`.
+    ///
+    /// This is used when the batch was extracted via [`RocksDBBatch::into_inner`]
+    /// and needs to be committed at a later point (e.g., at provider commit time).
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(batch_len = batch.len(), batch_size = batch.size_in_bytes()))]
+    pub fn commit_batch(&self, batch: WriteBatchWithTransaction<true>) -> ProviderResult<()> {
+        self.0.db_rw().write_opt(batch, &synced_write_options()).map_err(|e| {
+            ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })
+    }
+
+    /// Writes all `RocksDB` data for multiple blocks in parallel.
+    ///
+    /// This handles transaction hash numbers, account history, and storage history based on
+    /// the provided storage settings. Each operation runs in parallel with its own batch,
+    /// pushing to `ctx.pending_batches` for later commit.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(num_blocks = blocks.len(), first_block = ctx.first_block_number))]
+    pub(crate) fn write_blocks_data<N: reth_node_types::NodePrimitives>(
+        &self,
+        blocks: &[ExecutedBlock<N>],
+        tx_nums: &[TxNumber],
+        ctx: RocksDBWriteCtx,
+        runtime: &reth_tasks::Runtime,
+    ) -> ProviderResult<()> {
+        if !ctx.storage_settings.storage_v2 {
+            return Ok(());
+        }
+
+        let mut r_tx_hash = None;
+        let mut r_account_history = None;
+        let mut r_storage_history = None;
+
+        let write_tx_hash =
+            ctx.storage_settings.storage_v2 && ctx.prune_tx_lookup.is_none_or(|m| !m.is_full());
+        let write_account_history = ctx.storage_settings.storage_v2;
+        let write_storage_history = ctx.storage_settings.storage_v2;
+
+        // Propagate tracing context into rayon-spawned threads so that RocksDB
+        // write spans appear as children of write_blocks_data in traces.
+        let span = tracing::Span::current();
+        runtime.storage_pool().in_place_scope(|s| {
+            if write_tx_hash {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    r_tx_hash = Some(self.write_tx_hash_numbers(blocks, tx_nums, &ctx));
+                });
+            }
+
+            if write_account_history {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    r_account_history = Some(self.write_account_history(blocks, &ctx));
+                });
+            }
+
+            if write_storage_history {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    r_storage_history = Some(self.write_storage_history(blocks, &ctx));
+                });
+            }
+        });
+
+        if write_tx_hash {
+            r_tx_hash.ok_or_else(|| {
+                ProviderError::Database(DatabaseError::Other(
+                    "rocksdb tx-hash write thread panicked".into(),
+                ))
+            })??;
+        }
+        if write_account_history {
+            r_account_history.ok_or_else(|| {
+                ProviderError::Database(DatabaseError::Other(
+                    "rocksdb account-history write thread panicked".into(),
+                ))
+            })??;
+        }
+        if write_storage_history {
+            r_storage_history.ok_or_else(|| {
+                ProviderError::Database(DatabaseError::Other(
+                    "rocksdb storage-history write thread panicked".into(),
+                ))
+            })??;
+        }
+
+        Ok(())
+    }
+
+    /// Writes transaction hash to number mappings for the given blocks.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    fn write_tx_hash_numbers<N: reth_node_types::NodePrimitives>(
+        &self,
+        blocks: &[ExecutedBlock<N>],
+        tx_nums: &[TxNumber],
+        ctx: &RocksDBWriteCtx,
+    ) -> ProviderResult<()> {
+        let mut batch = self.batch();
+        for (block, &first_tx_num) in blocks.iter().zip(tx_nums) {
+            let body = block.recovered_block().body();
+            for (tx_num, transaction) in (first_tx_num..).zip(body.transactions_iter()) {
+                batch.put::<tables::TransactionHashNumbers>(*transaction.tx_hash(), &tx_num)?;
+            }
+        }
+        ctx.pending_batches.lock().push(batch.into_inner());
+        Ok(())
+    }
+
+    /// Writes account history indices for the given blocks.
+    ///
+    /// Derives history indices from reverts (same source as changesets) to ensure consistency.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    fn write_account_history<N: reth_node_types::NodePrimitives>(
+        &self,
+        blocks: &[ExecutedBlock<N>],
+        ctx: &RocksDBWriteCtx,
+    ) -> ProviderResult<()> {
+        let mut batch = self.batch();
+        let mut account_history: BTreeMap<Address, Vec<u64>> = BTreeMap::new();
+
+        for (block_idx, block) in blocks.iter().enumerate() {
+            let block_number = ctx.first_block_number + block_idx as u64;
+            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+
+            // Iterate through account reverts - these are exactly the accounts that have
+            // changesets written, ensuring history indices match changeset entries.
+            for account_block_reverts in reverts.accounts {
+                for (address, _) in account_block_reverts {
+                    account_history.entry(address).or_default().push(block_number);
+                }
+            }
+        }
+
+        // Write account history using proper shard append logic
+        for (address, indices) in account_history {
+            batch.append_account_history_shard(address, indices)?;
+        }
+        ctx.pending_batches.lock().push(batch.into_inner());
+        Ok(())
+    }
+
+    /// Writes storage history indices for the given blocks.
+    ///
+    /// Derives history indices from reverts (same source as changesets) to ensure consistency.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    fn write_storage_history<N: reth_node_types::NodePrimitives>(
+        &self,
+        blocks: &[ExecutedBlock<N>],
+        ctx: &RocksDBWriteCtx,
+    ) -> ProviderResult<()> {
+        let mut batch = self.batch();
+        let mut storage_history: BTreeMap<(Address, B256), Vec<u64>> = BTreeMap::new();
+
+        for (block_idx, block) in blocks.iter().enumerate() {
+            let block_number = ctx.first_block_number + block_idx as u64;
+            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+
+            // Iterate through storage reverts - these are exactly the slots that have
+            // changesets written, ensuring history indices match changeset entries.
+            for storage_block_reverts in reverts.storage {
+                for revert in storage_block_reverts {
+                    for (slot, _) in revert.storage_revert {
+                        let plain_key = B256::new(slot.to_be_bytes());
+                        storage_history
+                            .entry((revert.address, plain_key))
+                            .or_default()
+                            .push(block_number);
+                    }
+                }
+            }
+        }
+
+        // Write storage history using proper shard append logic
+        for ((address, slot), indices) in storage_history {
+            batch.append_storage_history_shard(address, slot, indices)?;
+        }
+        ctx.pending_batches.lock().push(batch.into_inner());
+        Ok(())
+    }
+}
+
+/// A point-in-time read snapshot of the `RocksDB` database.
+///
+/// All reads through this snapshot see a consistent view of the database at the point
+/// the snapshot was created, regardless of concurrent writes. This is the primary reader
+/// used by [`EitherReader::RocksDB`](crate::either_writer::EitherReader) for history lookups.
+///
+/// Lighter weight than [`RocksTx`] — no transaction overhead, no write support.
+pub struct RocksReadSnapshot<'db> {
+    inner: RocksReadSnapshotInner<'db>,
+    provider: &'db RocksDBProvider,
+}
+
+/// Inner enum to hold the snapshot for either read-write or secondary mode.
+enum RocksReadSnapshotInner<'db> {
+    /// Snapshot from read-write `OptimisticTransactionDB`.
+    ReadWrite(SnapshotWithThreadMode<'db, OptimisticTransactionDB>),
+    /// Direct reads from a secondary `DB` instance (no snapshot).
+    Secondary(&'db DB),
+}
+
+impl<'db> RocksReadSnapshotInner<'db> {
+    /// Returns a raw iterator over a column family.
+    fn raw_iterator_cf(&self, cf: &rocksdb::ColumnFamily) -> RocksDBRawIterEnum<'_> {
+        match self {
+            Self::ReadWrite(snap) => RocksDBRawIterEnum::ReadWrite(snap.raw_iterator_cf(cf)),
+            Self::Secondary(db) => RocksDBRawIterEnum::ReadOnly(db.raw_iterator_cf(cf)),
+        }
+    }
+}
+
+impl fmt::Debug for RocksReadSnapshot<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksReadSnapshot")
+            .field("provider", &self.provider)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'db> RocksReadSnapshot<'db> {
+    /// Gets the column family handle for a table.
+    fn cf_handle<T: Table>(&self) -> Result<&'db rocksdb::ColumnFamily, DatabaseError> {
+        self.provider.get_cf_handle::<T>()
+    }
+
+    /// Gets a value from the specified table.
+    pub fn get<T: Table>(&self, key: T::Key) -> ProviderResult<Option<T::Value>> {
+        let encoded_key = key.encode();
+        let cf = self.cf_handle::<T>()?;
+        let result = match &self.inner {
+            RocksReadSnapshotInner::ReadWrite(snap) => snap.get_cf(cf, encoded_key.as_ref()),
+            RocksReadSnapshotInner::Secondary(db) => db.get_cf(cf, encoded_key.as_ref()),
+        }
+        .map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        Ok(result.and_then(|value| T::Value::decompress(&value).ok()))
+    }
+
+    /// Lookup account history and return [`HistoryInfo`] directly.
+    ///
+    /// `visible_tip` is the highest block considered visible from the companion MDBX snapshot.
+    /// History entries above it are ignored even if they already exist in `RocksDB`.
+    pub fn account_history_info(
+        &self,
+        address: Address,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+        visible_tip: BlockNumber,
+    ) -> ProviderResult<HistoryInfo> {
+        let key = ShardedKey::new(address, block_number);
+        self.history_info::<tables::AccountsHistory>(
+            key.encode().as_ref(),
+            block_number,
+            lowest_available_block_number,
+            visible_tip,
+            |key_bytes| Ok(<ShardedKey<Address> as Decode>::decode(key_bytes)?.key == address),
+            |prev_bytes| {
+                <ShardedKey<Address> as Decode>::decode(prev_bytes)
+                    .map(|k| k.key == address)
+                    .unwrap_or(false)
+            },
+        )
+    }
+
+    /// Lookup storage history and return [`HistoryInfo`] directly.
+    ///
+    /// `visible_tip` is the highest block considered visible from the companion MDBX snapshot.
+    /// History entries above it are ignored even if they already exist in `RocksDB`.
+    pub fn storage_history_info(
+        &self,
+        address: Address,
+        storage_key: B256,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+        visible_tip: BlockNumber,
+    ) -> ProviderResult<HistoryInfo> {
+        let key = StorageShardedKey::new(address, storage_key, block_number);
+        self.history_info::<tables::StoragesHistory>(
+            key.encode().as_ref(),
+            block_number,
+            lowest_available_block_number,
+            visible_tip,
+            |key_bytes| {
+                let k = <StorageShardedKey as Decode>::decode(key_bytes)?;
+                Ok(k.address == address && k.sharded_key.key == storage_key)
+            },
+            |prev_bytes| {
+                <StorageShardedKey as Decode>::decode(prev_bytes)
+                    .map(|k| k.address == address && k.sharded_key.key == storage_key)
+                    .unwrap_or(false)
+            },
+        )
+    }
+
+    /// Generic history lookup using the snapshot's raw iterator.
+    ///
+    /// The result is derived from the history that is visible through `visible_tip`, not from the
+    /// full contents of `RocksDB`. This lets a reader combine an older MDBX snapshot with a newer
+    /// Rocks snapshot without routing through history entries that MDBX cannot see yet.
+    fn history_info<T>(
+        &self,
+        encoded_key: &[u8],
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+        visible_tip: BlockNumber,
+        key_matches: impl FnOnce(&[u8]) -> Result<bool, reth_db_api::DatabaseError>,
+        prev_key_matches: impl Fn(&[u8]) -> bool,
+    ) -> ProviderResult<HistoryInfo>
+    where
+        T: Table<Value = BlockNumberList>,
+    {
+        let is_maybe_pruned = lowest_available_block_number.is_some();
+        let fallback = || {
+            Ok(if is_maybe_pruned {
+                HistoryInfo::MaybeInPlainState
+            } else {
+                HistoryInfo::NotYetWritten
+            })
+        };
+
+        let cf = self.cf_handle::<T>()?;
+        let mut iter = self.inner.raw_iterator_cf(cf);
+
+        iter.seek(encoded_key);
+        iter.status().map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        if !iter.valid() {
+            return fallback();
+        }
+
+        let Some(key_bytes) = iter.key() else {
+            return fallback();
+        };
+        if !key_matches(key_bytes)? {
+            return fallback();
+        }
+
+        let Some(value_bytes) = iter.value() else {
+            return fallback();
+        };
+        let chunk = BlockNumberList::decompress(value_bytes)?;
+
+        let (rank, found_block) = compute_history_rank(&chunk, block_number);
+        // Ignore later Rocks history that is ahead of the companion MDBX snapshot.
+        let found_block = found_block.filter(|block| *block <= visible_tip);
+
+        let is_before_first_write = if needs_prev_shard_check(rank, found_block, block_number) {
+            iter.prev();
+            iter.status().map_err(|e| {
+                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
+            let has_prev = iter.valid() && iter.key().is_some_and(&prev_key_matches);
+
+            // If the current shard only contains history above `visible_tip`, there is no usable
+            // later change. Without a previous shard for the same key, fall back to the existing
+            // not-written / maybe-pruned result instead of routing into plain state.
+            if found_block.is_none() && !has_prev {
+                return fallback()
+            }
+
+            !has_prev
+        } else {
+            false
+        };
+
+        Ok(HistoryInfo::from_lookup(
+            found_block,
+            is_before_first_write,
+            lowest_available_block_number,
+        ))
+    }
+}
+
+/// Outcome of pruning a history shard in `RocksDB`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PruneShardOutcome {
+    /// Shard was deleted entirely.
+    Deleted,
+    /// Shard was updated with filtered block numbers.
+    Updated,
+    /// Shard was unchanged (no blocks <= `to_block`).
+    Unchanged,
+}
+
+/// Tracks pruning outcomes for batch operations.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PrunedIndices {
+    /// Number of shards completely deleted.
+    pub deleted: usize,
+    /// Number of shards that were updated (filtered but still have entries).
+    pub updated: usize,
+    /// Number of shards that were unchanged.
+    pub unchanged: usize,
+}
+
+/// Handle for building a batch of operations atomically.
+///
+/// Uses `WriteBatchWithTransaction` for atomic writes without full transaction overhead.
+/// Unlike [`RocksTx`], this does NOT support read-your-writes. Use for write-only flows
+/// where you don't need to read back uncommitted data within the same operation
+/// (e.g., history index writes).
+///
+/// When `auto_commit_threshold` is set, the batch will automatically commit and reset
+/// when the batch size exceeds the threshold. This prevents OOM during large bulk writes.
+#[must_use = "batch must be committed"]
+pub struct RocksDBBatch<'a> {
+    provider: &'a RocksDBProvider,
+    inner: WriteBatchWithTransaction<true>,
+    buf: Vec<u8>,
+    /// If set, batch auto-commits when size exceeds this threshold (in bytes).
+    auto_commit_threshold: Option<usize>,
+}
+
+impl fmt::Debug for RocksDBBatch<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBBatch")
+            .field("provider", &self.provider)
+            .field("batch", &"<WriteBatchWithTransaction>")
+            // Number of operations in this batch
+            .field("length", &self.inner.len())
+            // Total serialized size (encoded key + compressed value + metadata) of this batch
+            // in bytes
+            .field("size_in_bytes", &self.inner.size_in_bytes())
+            .finish()
+    }
+}
+
+impl<'a> RocksDBBatch<'a> {
+    /// Puts a value into the batch.
+    ///
+    /// If auto-commit is enabled and the batch exceeds the threshold, commits and resets.
+    pub fn put<T: Table>(&mut self, key: T::Key, value: &T::Value) -> ProviderResult<()> {
+        let encoded_key = key.encode();
+        self.put_encoded::<T>(&encoded_key, value)
+    }
+
+    /// Puts a value into the batch using pre-encoded key.
+    ///
+    /// If auto-commit is enabled and the batch exceeds the threshold, commits and resets.
+    pub fn put_encoded<T: Table>(
+        &mut self,
+        key: &<T::Key as Encode>::Encoded,
+        value: &T::Value,
+    ) -> ProviderResult<()> {
+        let value_bytes = compress_to_buf_or_ref!(self.buf, value).unwrap_or(&self.buf);
+        self.inner.put_cf(self.provider.get_cf_handle::<T>()?, key, value_bytes);
+        self.maybe_auto_commit()?;
+        Ok(())
+    }
+
+    /// Deletes a value from the batch.
+    ///
+    /// If auto-commit is enabled and the batch exceeds the threshold, commits and resets.
+    pub fn delete<T: Table>(&mut self, key: T::Key) -> ProviderResult<()> {
+        self.inner.delete_cf(self.provider.get_cf_handle::<T>()?, key.encode().as_ref());
+        self.maybe_auto_commit()?;
+        Ok(())
+    }
+
+    /// Commits and resets the batch if it exceeds the auto-commit threshold.
+    ///
+    /// This is called after each `put` or `delete` operation to prevent unbounded memory growth.
+    /// Returns immediately if auto-commit is disabled or threshold not reached.
+    fn maybe_auto_commit(&mut self) -> ProviderResult<()> {
+        if let Some(threshold) = self.auto_commit_threshold &&
+            self.inner.size_in_bytes() >= threshold
+        {
+            tracing::debug!(
+                target: "providers::rocksdb",
+                batch_size = self.inner.size_in_bytes(),
+                threshold,
+                "Auto-committing RocksDB batch"
+            );
+            let old_batch = std::mem::take(&mut self.inner);
+            self.provider.0.db_rw().write_opt(old_batch, &synced_write_options()).map_err(|e| {
+                ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Commits the batch to the database.
+    ///
+    /// This consumes the batch and writes all operations atomically to `RocksDB`.
+    ///
+    /// # Panics
+    /// Panics if the provider is in read-only mode.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(batch_len = self.inner.len(), batch_size = self.inner.size_in_bytes()))]
+    pub fn commit(self) -> ProviderResult<()> {
+        self.provider.0.db_rw().write_opt(self.inner, &synced_write_options()).map_err(|e| {
+            ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })
+    }
+
+    /// Returns the number of write operations (puts + deletes) queued in this batch.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if the batch contains no operations.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the size of the batch in bytes.
+    pub fn size_in_bytes(&self) -> usize {
+        self.inner.size_in_bytes()
+    }
+
+    /// Returns a reference to the underlying `RocksDB` provider.
+    pub const fn provider(&self) -> &RocksDBProvider {
+        self.provider
+    }
+
+    /// Consumes the batch and returns the underlying `WriteBatchWithTransaction`.
+    ///
+    /// This is used to defer commits to the provider level.
+    pub fn into_inner(self) -> WriteBatchWithTransaction<true> {
+        self.inner
+    }
+
+    /// Gets a value from the database.
+    ///
+    /// **Important constraint:** This reads only committed state, not pending writes in this
+    /// batch or other pending batches in `pending_rocksdb_batches`.
+    pub fn get<T: Table>(&self, key: T::Key) -> ProviderResult<Option<T::Value>> {
+        self.provider.get::<T>(key)
+    }
+
+    /// Appends indices to an account history shard with proper shard management.
+    ///
+    /// Loads the existing shard (if any), appends new indices, and rechunks into
+    /// multiple shards if needed (respecting `NUM_OF_INDICES_IN_SHARD` limit).
+    ///
+    /// # Requirements
+    ///
+    /// - The `indices` MUST be strictly increasing and contain no duplicates.
+    /// - This method MUST only be called once per address per batch. The batch reads existing
+    ///   shards from committed DB state, not from pending writes. Calling twice for the same
+    ///   address will cause the second call to overwrite the first.
+    pub fn append_account_history_shard(
+        &mut self,
+        address: Address,
+        indices: impl IntoIterator<Item = u64>,
+    ) -> ProviderResult<()> {
+        let indices: Vec<u64> = indices.into_iter().collect();
+
+        if indices.is_empty() {
+            return Ok(());
+        }
+
+        debug_assert!(
+            indices.windows(2).all(|w| w[0] < w[1]),
+            "indices must be strictly increasing: {:?}",
+            indices
+        );
+
+        let last_key = ShardedKey::new(address, u64::MAX);
+        let last_shard_opt = self.provider.get::<tables::AccountsHistory>(last_key.clone())?;
+        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
+
+        last_shard.append(indices).map_err(ProviderError::other)?;
+
+        // Fast path: all indices fit in one shard
+        if last_shard.len() <= NUM_OF_INDICES_IN_SHARD as u64 {
+            self.put::<tables::AccountsHistory>(last_key, &last_shard)?;
+            return Ok(());
+        }
+
+        // Slow path: rechunk into multiple shards
+        let chunks = last_shard.iter().chunks(NUM_OF_INDICES_IN_SHARD);
+        let mut chunks_peekable = chunks.into_iter().peekable();
+
+        while let Some(chunk) = chunks_peekable.next() {
+            let shard = BlockNumberList::new_pre_sorted(chunk);
+            let highest_block_number = if chunks_peekable.peek().is_some() {
+                shard.iter().next_back().expect("`chunks` does not return empty list")
+            } else {
+                u64::MAX
+            };
+
+            self.put::<tables::AccountsHistory>(
+                ShardedKey::new(address, highest_block_number),
+                &shard,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Appends indices to a storage history shard with proper shard management.
+    ///
+    /// Loads the existing shard (if any), appends new indices, and rechunks into
+    /// multiple shards if needed (respecting `NUM_OF_INDICES_IN_SHARD` limit).
+    ///
+    /// # Requirements
+    ///
+    /// - The `indices` MUST be strictly increasing and contain no duplicates.
+    /// - This method MUST only be called once per (address, `storage_key`) pair per batch. The
+    ///   batch reads existing shards from committed DB state, not from pending writes. Calling
+    ///   twice for the same key will cause the second call to overwrite the first.
+    pub fn append_storage_history_shard(
+        &mut self,
+        address: Address,
+        storage_key: B256,
+        indices: impl IntoIterator<Item = u64>,
+    ) -> ProviderResult<()> {
+        let indices: Vec<u64> = indices.into_iter().collect();
+
+        if indices.is_empty() {
+            return Ok(());
+        }
+
+        debug_assert!(
+            indices.windows(2).all(|w| w[0] < w[1]),
+            "indices must be strictly increasing: {:?}",
+            indices
+        );
+
+        let last_key = StorageShardedKey::last(address, storage_key);
+        let last_shard_opt = self.provider.get::<tables::StoragesHistory>(last_key.clone())?;
+        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
+
+        last_shard.append(indices).map_err(ProviderError::other)?;
+
+        // Fast path: all indices fit in one shard
+        if last_shard.len() <= NUM_OF_INDICES_IN_SHARD as u64 {
+            self.put::<tables::StoragesHistory>(last_key, &last_shard)?;
+            return Ok(());
+        }
+
+        // Slow path: rechunk into multiple shards
+        let chunks = last_shard.iter().chunks(NUM_OF_INDICES_IN_SHARD);
+        let mut chunks_peekable = chunks.into_iter().peekable();
+
+        while let Some(chunk) = chunks_peekable.next() {
+            let shard = BlockNumberList::new_pre_sorted(chunk);
+            let highest_block_number = if chunks_peekable.peek().is_some() {
+                shard.iter().next_back().expect("`chunks` does not return empty list")
+            } else {
+                u64::MAX
+            };
+
+            self.put::<tables::StoragesHistory>(
+                StorageShardedKey::new(address, storage_key, highest_block_number),
+                &shard,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Unwinds account history for the given address, keeping only blocks <= `keep_to`.
+    ///
+    /// Mirrors MDBX `unwind_history_shards` behavior:
+    /// - Deletes shards entirely above `keep_to`
+    /// - Truncates boundary shards and re-keys to `u64::MAX` sentinel
+    /// - Preserves shards entirely below `keep_to`
+    pub fn unwind_account_history_to(
+        &mut self,
+        address: Address,
+        keep_to: BlockNumber,
+    ) -> ProviderResult<()> {
+        let shards = self.provider.account_history_shards(address)?;
+        if shards.is_empty() {
+            return Ok(());
+        }
+
+        // Find the first shard that might contain blocks > keep_to.
+        // A shard is affected if it's the sentinel (u64::MAX) or its highest_block_number > keep_to
+        let boundary_idx = shards.iter().position(|(key, _)| {
+            key.highest_block_number == u64::MAX || key.highest_block_number > keep_to
+        });
+
+        // Repair path: no shards affected means all blocks <= keep_to, just ensure sentinel exists
+        let Some(boundary_idx) = boundary_idx else {
+            let (last_key, last_value) = shards.last().expect("shards is non-empty");
+            if last_key.highest_block_number != u64::MAX {
+                self.delete::<tables::AccountsHistory>(last_key.clone())?;
+                self.put::<tables::AccountsHistory>(
+                    ShardedKey::new(address, u64::MAX),
+                    last_value,
+                )?;
+            }
+            return Ok(());
+        };
+
+        // Delete all shards strictly after the boundary (they are entirely > keep_to)
+        for (key, _) in shards.iter().skip(boundary_idx + 1) {
+            self.delete::<tables::AccountsHistory>(key.clone())?;
+        }
+
+        // Process the boundary shard: filter out blocks > keep_to
+        let (boundary_key, boundary_list) = &shards[boundary_idx];
+
+        // Delete the boundary shard (we'll either drop it or rewrite at u64::MAX)
+        self.delete::<tables::AccountsHistory>(boundary_key.clone())?;
+
+        // Build truncated list once; check emptiness directly (avoids double iteration)
+        let new_last =
+            BlockNumberList::new_pre_sorted(boundary_list.iter().take_while(|&b| b <= keep_to));
+
+        if new_last.is_empty() {
+            // Boundary shard is now empty. Previous shard becomes the last and must be keyed
+            // u64::MAX.
+            if boundary_idx == 0 {
+                // Nothing left for this address
+                return Ok(());
+            }
+
+            let (prev_key, prev_value) = &shards[boundary_idx - 1];
+            if prev_key.highest_block_number != u64::MAX {
+                self.delete::<tables::AccountsHistory>(prev_key.clone())?;
+                self.put::<tables::AccountsHistory>(
+                    ShardedKey::new(address, u64::MAX),
+                    prev_value,
+                )?;
+            }
+            return Ok(());
+        }
+
+        self.put::<tables::AccountsHistory>(ShardedKey::new(address, u64::MAX), &new_last)?;
+
+        Ok(())
+    }
+
+    /// Prunes history shards, removing blocks <= `to_block`.
+    ///
+    /// Generic implementation for both account and storage history pruning.
+    /// Mirrors MDBX `prune_shard` semantics. After pruning, the last remaining shard
+    /// (if any) will have the sentinel key (`u64::MAX`).
+    #[expect(clippy::too_many_arguments)]
+    fn prune_history_shards_inner<K>(
+        &mut self,
+        shards: Vec<(K, BlockNumberList)>,
+        to_block: BlockNumber,
+        get_highest: impl Fn(&K) -> u64,
+        is_sentinel: impl Fn(&K) -> bool,
+        delete_shard: impl Fn(&mut Self, K) -> ProviderResult<()>,
+        put_shard: impl Fn(&mut Self, K, &BlockNumberList) -> ProviderResult<()>,
+        create_sentinel: impl Fn() -> K,
+    ) -> ProviderResult<PruneShardOutcome>
+    where
+        K: Clone,
+    {
+        if shards.is_empty() {
+            return Ok(PruneShardOutcome::Unchanged);
+        }
+
+        let mut deleted = false;
+        let mut updated = false;
+        let mut last_remaining: Option<(K, BlockNumberList)> = None;
+
+        for (key, block_list) in shards {
+            if !is_sentinel(&key) && get_highest(&key) <= to_block {
+                delete_shard(self, key)?;
+                deleted = true;
+            } else {
+                let original_len = block_list.len();
+                let filtered =
+                    BlockNumberList::new_pre_sorted(block_list.iter().filter(|&b| b > to_block));
+
+                if filtered.is_empty() {
+                    delete_shard(self, key)?;
+                    deleted = true;
+                } else if filtered.len() < original_len {
+                    put_shard(self, key.clone(), &filtered)?;
+                    last_remaining = Some((key, filtered));
+                    updated = true;
+                } else {
+                    last_remaining = Some((key, block_list));
+                }
+            }
+        }
+
+        if let Some((last_key, last_value)) = last_remaining &&
+            !is_sentinel(&last_key)
+        {
+            delete_shard(self, last_key)?;
+            put_shard(self, create_sentinel(), &last_value)?;
+            updated = true;
+        }
+
+        if deleted {
+            Ok(PruneShardOutcome::Deleted)
+        } else if updated {
+            Ok(PruneShardOutcome::Updated)
+        } else {
+            Ok(PruneShardOutcome::Unchanged)
+        }
+    }
+
+    /// Prunes account history for the given address, removing blocks <= `to_block`.
+    ///
+    /// Mirrors MDBX `prune_shard` semantics. After pruning, the last remaining shard
+    /// (if any) will have the sentinel key (`u64::MAX`).
+    pub fn prune_account_history_to(
+        &mut self,
+        address: Address,
+        to_block: BlockNumber,
+    ) -> ProviderResult<PruneShardOutcome> {
+        let shards = self.provider.account_history_shards(address)?;
+        self.prune_history_shards_inner(
+            shards,
+            to_block,
+            |key| key.highest_block_number,
+            |key| key.highest_block_number == u64::MAX,
+            |batch, key| batch.delete::<tables::AccountsHistory>(key),
+            |batch, key, value| batch.put::<tables::AccountsHistory>(key, value),
+            || ShardedKey::new(address, u64::MAX),
+        )
+    }
+
+    /// Prunes account history for multiple addresses in a single iterator pass.
+    ///
+    /// This is more efficient than calling [`Self::prune_account_history_to`] repeatedly
+    /// because it reuses a single raw iterator and skips seeks when the iterator is already
+    /// positioned correctly (which happens when targets are sorted and adjacent in key order).
+    ///
+    /// `targets` MUST be sorted by address for correctness and optimal performance
+    /// (matches on-disk key order).
+    pub fn prune_account_history_batch(
+        &mut self,
+        targets: &[(Address, BlockNumber)],
+    ) -> ProviderResult<PrunedIndices> {
+        if targets.is_empty() {
+            return Ok(PrunedIndices::default());
+        }
+
+        debug_assert!(
+            targets.windows(2).all(|w| w[0].0 <= w[1].0),
+            "prune_account_history_batch: targets must be sorted by address"
+        );
+
+        // ShardedKey<Address> layout: [address: 20][block: 8] = 28 bytes
+        // The first 20 bytes are the "prefix" that identifies the address
+        const PREFIX_LEN: usize = 20;
+
+        let cf = self.provider.get_cf_handle::<tables::AccountsHistory>()?;
+        let mut iter = self.provider.0.raw_iterator_cf(cf);
+        let mut outcomes = PrunedIndices::default();
+
+        for (address, to_block) in targets {
+            // Build the target prefix (first 20 bytes = address)
+            let start_key = ShardedKey::new(*address, 0u64).encode();
+            let target_prefix = &start_key[..PREFIX_LEN];
+
+            // Check if we need to seek or if the iterator is already positioned correctly.
+            // After processing the previous target, the iterator is either:
+            // 1. Positioned at a key with a different prefix (we iterated past our shards)
+            // 2. Invalid (no more keys)
+            // If the current key's prefix >= our target prefix, we may be able to skip the seek.
+            let needs_seek = if iter.valid() {
+                if let Some(current_key) = iter.key() {
+                    // If current key's prefix < target prefix, we need to seek forward
+                    // If current key's prefix > target prefix, this target has no shards (skip)
+                    // If current key's prefix == target prefix, we're already positioned
+                    current_key.get(..PREFIX_LEN).is_none_or(|p| p < target_prefix)
+                } else {
+                    true
+                }
+            } else {
+                true
+            };
+
+            if needs_seek {
+                iter.seek(start_key);
+                iter.status().map_err(|e| {
+                    ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    }))
+                })?;
+            }
+
+            // Collect all shards for this address using raw prefix comparison
+            let mut shards = Vec::new();
+            while iter.valid() {
+                let Some(key_bytes) = iter.key() else { break };
+
+                // Use raw prefix comparison instead of full decode for the prefix check
+                let current_prefix = key_bytes.get(..PREFIX_LEN);
+                if current_prefix != Some(target_prefix) {
+                    break;
+                }
+
+                // Now decode the full key (we need the block number)
+                let key = ShardedKey::<Address>::decode(key_bytes)
+                    .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                let Some(value_bytes) = iter.value() else { break };
+                let value = BlockNumberList::decompress(value_bytes)
+                    .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                shards.push((key, value));
+                iter.next();
+            }
+
+            match self.prune_history_shards_inner(
+                shards,
+                *to_block,
+                |key| key.highest_block_number,
+                |key| key.highest_block_number == u64::MAX,
+                |batch, key| batch.delete::<tables::AccountsHistory>(key),
+                |batch, key, value| batch.put::<tables::AccountsHistory>(key, value),
+                || ShardedKey::new(*address, u64::MAX),
+            )? {
+                PruneShardOutcome::Deleted => outcomes.deleted += 1,
+                PruneShardOutcome::Updated => outcomes.updated += 1,
+                PruneShardOutcome::Unchanged => outcomes.unchanged += 1,
+            }
+        }
+
+        Ok(outcomes)
+    }
+
+    /// Prunes storage history for the given address and storage key, removing blocks <=
+    /// `to_block`.
+    ///
+    /// Mirrors MDBX `prune_shard` semantics. After pruning, the last remaining shard
+    /// (if any) will have the sentinel key (`u64::MAX`).
+    pub fn prune_storage_history_to(
+        &mut self,
+        address: Address,
+        storage_key: B256,
+        to_block: BlockNumber,
+    ) -> ProviderResult<PruneShardOutcome> {
+        let shards = self.provider.storage_history_shards(address, storage_key)?;
+        self.prune_history_shards_inner(
+            shards,
+            to_block,
+            |key| key.sharded_key.highest_block_number,
+            |key| key.sharded_key.highest_block_number == u64::MAX,
+            |batch, key| batch.delete::<tables::StoragesHistory>(key),
+            |batch, key, value| batch.put::<tables::StoragesHistory>(key, value),
+            || StorageShardedKey::last(address, storage_key),
+        )
+    }
+
+    /// Prunes storage history for multiple (address, `storage_key`) pairs in a single iterator
+    /// pass.
+    ///
+    /// This is more efficient than calling [`Self::prune_storage_history_to`] repeatedly
+    /// because it reuses a single raw iterator and skips seeks when the iterator is already
+    /// positioned correctly (which happens when targets are sorted and adjacent in key order).
+    ///
+    /// `targets` MUST be sorted by (address, `storage_key`) for correctness and optimal
+    /// performance (matches on-disk key order).
+    pub fn prune_storage_history_batch(
+        &mut self,
+        targets: &[((Address, B256), BlockNumber)],
+    ) -> ProviderResult<PrunedIndices> {
+        if targets.is_empty() {
+            return Ok(PrunedIndices::default());
+        }
+
+        debug_assert!(
+            targets.windows(2).all(|w| w[0].0 <= w[1].0),
+            "prune_storage_history_batch: targets must be sorted by (address, storage_key)"
+        );
+
+        // StorageShardedKey layout: [address: 20][storage_key: 32][block: 8] = 60 bytes
+        // The first 52 bytes are the "prefix" that identifies (address, storage_key)
+        const PREFIX_LEN: usize = 52;
+
+        let cf = self.provider.get_cf_handle::<tables::StoragesHistory>()?;
+        let mut iter = self.provider.0.raw_iterator_cf(cf);
+        let mut outcomes = PrunedIndices::default();
+
+        for ((address, storage_key), to_block) in targets {
+            // Build the target prefix (first 52 bytes of encoded key)
+            let start_key = StorageShardedKey::new(*address, *storage_key, 0u64).encode();
+            let target_prefix = &start_key[..PREFIX_LEN];
+
+            // Check if we need to seek or if the iterator is already positioned correctly.
+            // After processing the previous target, the iterator is either:
+            // 1. Positioned at a key with a different prefix (we iterated past our shards)
+            // 2. Invalid (no more keys)
+            // If the current key's prefix >= our target prefix, we may be able to skip the seek.
+            let needs_seek = if iter.valid() {
+                if let Some(current_key) = iter.key() {
+                    // If current key's prefix < target prefix, we need to seek forward
+                    // If current key's prefix > target prefix, this target has no shards (skip)
+                    // If current key's prefix == target prefix, we're already positioned
+                    current_key.get(..PREFIX_LEN).is_none_or(|p| p < target_prefix)
+                } else {
+                    true
+                }
+            } else {
+                true
+            };
+
+            if needs_seek {
+                iter.seek(start_key);
+                iter.status().map_err(|e| {
+                    ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    }))
+                })?;
+            }
+
+            // Collect all shards for this (address, storage_key) pair using prefix comparison
+            let mut shards = Vec::new();
+            while iter.valid() {
+                let Some(key_bytes) = iter.key() else { break };
+
+                // Use raw prefix comparison instead of full decode for the prefix check
+                let current_prefix = key_bytes.get(..PREFIX_LEN);
+                if current_prefix != Some(target_prefix) {
+                    break;
+                }
+
+                // Now decode the full key (we need the block number)
+                let key = StorageShardedKey::decode(key_bytes)
+                    .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                let Some(value_bytes) = iter.value() else { break };
+                let value = BlockNumberList::decompress(value_bytes)
+                    .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+                shards.push((key, value));
+                iter.next();
+            }
+
+            // Use existing prune_history_shards_inner logic
+            match self.prune_history_shards_inner(
+                shards,
+                *to_block,
+                |key| key.sharded_key.highest_block_number,
+                |key| key.sharded_key.highest_block_number == u64::MAX,
+                |batch, key| batch.delete::<tables::StoragesHistory>(key),
+                |batch, key, value| batch.put::<tables::StoragesHistory>(key, value),
+                || StorageShardedKey::last(*address, *storage_key),
+            )? {
+                PruneShardOutcome::Deleted => outcomes.deleted += 1,
+                PruneShardOutcome::Updated => outcomes.updated += 1,
+                PruneShardOutcome::Unchanged => outcomes.unchanged += 1,
+            }
+        }
+
+        Ok(outcomes)
+    }
+
+    /// Unwinds storage history to keep only blocks `<= keep_to`.
+    ///
+    /// Handles multi-shard scenarios by:
+    /// 1. Loading all shards for the `(address, storage_key)` pair
+    /// 2. Finding the boundary shard containing `keep_to`
+    /// 3. Deleting all shards after the boundary
+    /// 4. Truncating the boundary shard to keep only indices `<= keep_to`
+    /// 5. Ensuring the last shard is keyed with `u64::MAX`
+    pub fn unwind_storage_history_to(
+        &mut self,
+        address: Address,
+        storage_key: B256,
+        keep_to: BlockNumber,
+    ) -> ProviderResult<()> {
+        let shards = self.provider.storage_history_shards(address, storage_key)?;
+        if shards.is_empty() {
+            return Ok(());
+        }
+
+        // Find the first shard that might contain blocks > keep_to.
+        // A shard is affected if it's the sentinel (u64::MAX) or its highest_block_number > keep_to
+        let boundary_idx = shards.iter().position(|(key, _)| {
+            key.sharded_key.highest_block_number == u64::MAX ||
+                key.sharded_key.highest_block_number > keep_to
+        });
+
+        // Repair path: no shards affected means all blocks <= keep_to, just ensure sentinel exists
+        let Some(boundary_idx) = boundary_idx else {
+            let (last_key, last_value) = shards.last().expect("shards is non-empty");
+            if last_key.sharded_key.highest_block_number != u64::MAX {
+                self.delete::<tables::StoragesHistory>(last_key.clone())?;
+                self.put::<tables::StoragesHistory>(
+                    StorageShardedKey::last(address, storage_key),
+                    last_value,
+                )?;
+            }
+            return Ok(());
+        };
+
+        // Delete all shards strictly after the boundary (they are entirely > keep_to)
+        for (key, _) in shards.iter().skip(boundary_idx + 1) {
+            self.delete::<tables::StoragesHistory>(key.clone())?;
+        }
+
+        // Process the boundary shard: filter out blocks > keep_to
+        let (boundary_key, boundary_list) = &shards[boundary_idx];
+
+        // Delete the boundary shard (we'll either drop it or rewrite at u64::MAX)
+        self.delete::<tables::StoragesHistory>(boundary_key.clone())?;
+
+        // Build truncated list once; check emptiness directly (avoids double iteration)
+        let new_last =
+            BlockNumberList::new_pre_sorted(boundary_list.iter().take_while(|&b| b <= keep_to));
+
+        if new_last.is_empty() {
+            // Boundary shard is now empty. Previous shard becomes the last and must be keyed
+            // u64::MAX.
+            if boundary_idx == 0 {
+                // Nothing left for this (address, storage_key) pair
+                return Ok(());
+            }
+
+            let (prev_key, prev_value) = &shards[boundary_idx - 1];
+            if prev_key.sharded_key.highest_block_number != u64::MAX {
+                self.delete::<tables::StoragesHistory>(prev_key.clone())?;
+                self.put::<tables::StoragesHistory>(
+                    StorageShardedKey::last(address, storage_key),
+                    prev_value,
+                )?;
+            }
+            return Ok(());
+        }
+
+        self.put::<tables::StoragesHistory>(
+            StorageShardedKey::last(address, storage_key),
+            &new_last,
+        )?;
+
+        Ok(())
+    }
+
+    /// Clears all account history shards for the given address.
+    ///
+    /// Used when unwinding from block 0 (i.e., removing all history).
+    pub fn clear_account_history(&mut self, address: Address) -> ProviderResult<()> {
+        let shards = self.provider.account_history_shards(address)?;
+        for (key, _) in shards {
+            self.delete::<tables::AccountsHistory>(key)?;
+        }
+        Ok(())
+    }
+
+    /// Clears all storage history shards for the given `(address, storage_key)` pair.
+    ///
+    /// Used when unwinding from block 0 (i.e., removing all history for this storage slot).
+    pub fn clear_storage_history(
+        &mut self,
+        address: Address,
+        storage_key: B256,
+    ) -> ProviderResult<()> {
+        let shards = self.provider.storage_history_shards(address, storage_key)?;
+        for (key, _) in shards {
+            self.delete::<tables::StoragesHistory>(key)?;
+        }
+        Ok(())
+    }
+}
+
+/// `RocksDB` transaction wrapper providing MDBX-like semantics.
+///
+/// Supports:
+/// - Read-your-writes: reads see uncommitted writes within the same transaction
+/// - Atomic commit/rollback
+/// - Iteration over uncommitted data
+///
+/// Note: `Transaction` is `Send` but NOT `Sync`. This wrapper does not implement
+/// `DbTx`/`DbTxMut` traits directly; use RocksDB-specific methods instead.
+pub struct RocksTx<'db> {
+    inner: Transaction<'db, OptimisticTransactionDB>,
+    provider: &'db RocksDBProvider,
+}
+
+impl fmt::Debug for RocksTx<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksTx").field("provider", &self.provider).finish_non_exhaustive()
+    }
+}
+
+impl<'db> RocksTx<'db> {
+    /// Gets a value from the specified table. Sees uncommitted writes in this transaction.
+    pub fn get<T: Table>(&self, key: T::Key) -> ProviderResult<Option<T::Value>> {
+        let encoded_key = key.encode();
+        self.get_encoded::<T>(&encoded_key)
+    }
+
+    /// Gets a value using pre-encoded key. Sees uncommitted writes in this transaction.
+    pub fn get_encoded<T: Table>(
+        &self,
+        key: &<T::Key as Encode>::Encoded,
+    ) -> ProviderResult<Option<T::Value>> {
+        let cf = self.provider.get_cf_handle::<T>()?;
+        let result = self.inner.get_cf(cf, key.as_ref()).map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        Ok(result.and_then(|value| T::Value::decompress(&value).ok()))
+    }
+
+    /// Puts a value into the specified table.
+    pub fn put<T: Table>(&self, key: T::Key, value: &T::Value) -> ProviderResult<()> {
+        let encoded_key = key.encode();
+        self.put_encoded::<T>(&encoded_key, value)
+    }
+
+    /// Puts a value using pre-encoded key.
+    pub fn put_encoded<T: Table>(
+        &self,
+        key: &<T::Key as Encode>::Encoded,
+        value: &T::Value,
+    ) -> ProviderResult<()> {
+        let cf = self.provider.get_cf_handle::<T>()?;
+        let mut buf = Vec::new();
+        let value_bytes = compress_to_buf_or_ref!(buf, value).unwrap_or(&buf);
+
+        self.inner.put_cf(cf, key.as_ref(), value_bytes).map_err(|e| {
+            ProviderError::Database(DatabaseError::Write(Box::new(DatabaseWriteError {
+                info: DatabaseErrorInfo { message: e.to_string().into(), code: -1 },
+                operation: DatabaseWriteOperation::PutUpsert,
+                table_name: T::NAME,
+                key: key.as_ref().to_vec(),
+            })))
+        })
+    }
+
+    /// Deletes a value from the specified table.
+    pub fn delete<T: Table>(&self, key: T::Key) -> ProviderResult<()> {
+        let cf = self.provider.get_cf_handle::<T>()?;
+        self.inner.delete_cf(cf, key.encode().as_ref()).map_err(|e| {
+            ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })
+    }
+
+    /// Creates an iterator for the specified table. Sees uncommitted writes in this transaction.
+    ///
+    /// Returns an iterator that yields `(encoded_key, compressed_value)` pairs.
+    pub fn iter<T: Table>(&self) -> ProviderResult<RocksTxIter<'_, T>> {
+        let cf = self.provider.get_cf_handle::<T>()?;
+        let iter = self.inner.iterator_cf(cf, IteratorMode::Start);
+        Ok(RocksTxIter { inner: iter, _marker: std::marker::PhantomData })
+    }
+
+    /// Creates an iterator starting from the given key (inclusive).
+    pub fn iter_from<T: Table>(&self, key: T::Key) -> ProviderResult<RocksTxIter<'_, T>> {
+        let cf = self.provider.get_cf_handle::<T>()?;
+        let encoded_key = key.encode();
+        let iter = self
+            .inner
+            .iterator_cf(cf, IteratorMode::From(encoded_key.as_ref(), rocksdb::Direction::Forward));
+        Ok(RocksTxIter { inner: iter, _marker: std::marker::PhantomData })
+    }
+
+    /// Commits the transaction, persisting all changes.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    pub fn commit(self) -> ProviderResult<()> {
+        self.inner.commit().map_err(|e| {
+            ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })
+    }
+
+    /// Rolls back the transaction, discarding all changes.
+    #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
+    pub fn rollback(self) -> ProviderResult<()> {
+        self.inner.rollback().map_err(|e| {
+            ProviderError::Database(DatabaseError::Other(format!("rollback failed: {e}")))
+        })
+    }
+}
+
+/// Wrapper enum for `RocksDB` iterators that works in both read-write and read-only modes.
+enum RocksDBIterEnum<'db> {
+    /// Iterator from read-write `OptimisticTransactionDB`.
+    ReadWrite(rocksdb::DBIteratorWithThreadMode<'db, OptimisticTransactionDB>),
+    /// Iterator from read-only `DB`.
+    ReadOnly(rocksdb::DBIteratorWithThreadMode<'db, DB>),
+}
+
+impl Iterator for RocksDBIterEnum<'_> {
+    type Item = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::ReadWrite(iter) => iter.next(),
+            Self::ReadOnly(iter) => iter.next(),
+        }
+    }
+}
+
+/// Wrapper enum for raw `RocksDB` iterators that works in both read-write and read-only modes.
+///
+/// Unlike [`RocksDBIterEnum`], raw iterators expose `seek()` for efficient repositioning
+/// without reinitializing the iterator.
+enum RocksDBRawIterEnum<'db> {
+    /// Raw iterator from read-write `OptimisticTransactionDB`.
+    ReadWrite(DBRawIteratorWithThreadMode<'db, OptimisticTransactionDB>),
+    /// Raw iterator from read-only `DB`.
+    ReadOnly(DBRawIteratorWithThreadMode<'db, DB>),
+}
+
+impl RocksDBRawIterEnum<'_> {
+    /// Positions the iterator at the first key >= `key`.
+    fn seek(&mut self, key: impl AsRef<[u8]>) {
+        match self {
+            Self::ReadWrite(iter) => iter.seek(key),
+            Self::ReadOnly(iter) => iter.seek(key),
+        }
+    }
+
+    /// Returns true if the iterator is positioned at a valid key-value pair.
+    fn valid(&self) -> bool {
+        match self {
+            Self::ReadWrite(iter) => iter.valid(),
+            Self::ReadOnly(iter) => iter.valid(),
+        }
+    }
+
+    /// Returns the current key, if valid.
+    fn key(&self) -> Option<&[u8]> {
+        match self {
+            Self::ReadWrite(iter) => iter.key(),
+            Self::ReadOnly(iter) => iter.key(),
+        }
+    }
+
+    /// Returns the current value, if valid.
+    fn value(&self) -> Option<&[u8]> {
+        match self {
+            Self::ReadWrite(iter) => iter.value(),
+            Self::ReadOnly(iter) => iter.value(),
+        }
+    }
+
+    /// Advances the iterator to the next key.
+    fn next(&mut self) {
+        match self {
+            Self::ReadWrite(iter) => iter.next(),
+            Self::ReadOnly(iter) => iter.next(),
+        }
+    }
+
+    /// Moves the iterator to the previous key.
+    fn prev(&mut self) {
+        match self {
+            Self::ReadWrite(iter) => iter.prev(),
+            Self::ReadOnly(iter) => iter.prev(),
+        }
+    }
+
+    /// Returns the status of the iterator.
+    fn status(&self) -> Result<(), rocksdb::Error> {
+        match self {
+            Self::ReadWrite(iter) => iter.status(),
+            Self::ReadOnly(iter) => iter.status(),
+        }
+    }
+}
+
+/// Iterator over a `RocksDB` table (non-transactional).
+///
+/// Yields decoded `(Key, Value)` pairs in key order.
+pub struct RocksDBIter<'db, T: Table> {
+    inner: RocksDBIterEnum<'db>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Table> fmt::Debug for RocksDBIter<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBIter").field("table", &T::NAME).finish_non_exhaustive()
+    }
+}
+
+impl<T: Table> Iterator for RocksDBIter<'_, T> {
+    type Item = ProviderResult<(T::Key, T::Value)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(decode_iter_item::<T>(self.inner.next()?))
+    }
+}
+
+/// Raw iterator over a `RocksDB` table (non-transactional).
+///
+/// Yields raw `(key_bytes, value_bytes)` pairs without decoding.
+pub struct RocksDBRawIter<'db> {
+    inner: RocksDBIterEnum<'db>,
+}
+
+impl fmt::Debug for RocksDBRawIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBRawIter").finish_non_exhaustive()
+    }
+}
+
+impl Iterator for RocksDBRawIter<'_> {
+    type Item = ProviderResult<(Box<[u8]>, Box<[u8]>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.next()? {
+            Ok(kv) => Some(Ok(kv)),
+            Err(e) => Some(Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            })))),
+        }
+    }
+}
+
+/// Iterator over a `RocksDB` table within a transaction.
+///
+/// Yields decoded `(Key, Value)` pairs. Sees uncommitted writes.
+pub struct RocksTxIter<'tx, T: Table> {
+    inner: rocksdb::DBIteratorWithThreadMode<'tx, Transaction<'tx, OptimisticTransactionDB>>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Table> fmt::Debug for RocksTxIter<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksTxIter").field("table", &T::NAME).finish_non_exhaustive()
+    }
+}
+
+impl<T: Table> Iterator for RocksTxIter<'_, T> {
+    type Item = ProviderResult<(T::Key, T::Value)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(decode_iter_item::<T>(self.inner.next()?))
+    }
+}
+
+/// Decodes a raw key-value pair from a `RocksDB` iterator into typed table entries.
+///
+/// Handles both error propagation from the underlying iterator and
+/// decoding/decompression of the key and value bytes.
+fn decode_iter_item<T: Table>(result: RawKVResult) -> ProviderResult<(T::Key, T::Value)> {
+    let (key_bytes, value_bytes) = result.map_err(|e| {
+        ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+            message: e.to_string().into(),
+            code: -1,
+        }))
+    })?;
+
+    let key = <T::Key as reth_db_api::table::Decode>::decode(&key_bytes)
+        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+    let value = T::Value::decompress(&value_bytes)
+        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+
+    Ok((key, value))
+}
+
+/// Converts Reth's [`LogLevel`] to `RocksDB`'s [`rocksdb::LogLevel`].
+const fn convert_log_level(level: LogLevel) -> rocksdb::LogLevel {
+    match level {
+        LogLevel::Fatal => rocksdb::LogLevel::Fatal,
+        LogLevel::Error => rocksdb::LogLevel::Error,
+        LogLevel::Warn => rocksdb::LogLevel::Warn,
+        LogLevel::Notice | LogLevel::Verbose => rocksdb::LogLevel::Info,
+        LogLevel::Debug | LogLevel::Trace | LogLevel::Extra => rocksdb::LogLevel::Debug,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::HistoryInfo;
+    use alloy_primitives::{Address, TxHash, B256};
+    use reth_db_api::{
+        models::{
+            sharded_key::{ShardedKey, NUM_OF_INDICES_IN_SHARD},
+            storage_sharded_key::StorageShardedKey,
+            IntegerList,
+        },
+        table::Table,
+        tables,
+    };
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_with_default_tables_registers_required_column_families() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Build with default tables
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        // Should be able to write/read TransactionHashNumbers
+        let tx_hash = TxHash::from(B256::from([1u8; 32]));
+        provider.put::<tables::TransactionHashNumbers>(tx_hash, &100).unwrap();
+        assert_eq!(provider.get::<tables::TransactionHashNumbers>(tx_hash).unwrap(), Some(100));
+
+        // Should be able to write/read AccountsHistory
+        let key = ShardedKey::new(Address::ZERO, 100);
+        let value = IntegerList::default();
+        provider.put::<tables::AccountsHistory>(key.clone(), &value).unwrap();
+        assert!(provider.get::<tables::AccountsHistory>(key).unwrap().is_some());
+
+        // Should be able to write/read StoragesHistory
+        let key = StorageShardedKey::new(Address::ZERO, B256::ZERO, 100);
+        provider.put::<tables::StoragesHistory>(key.clone(), &value).unwrap();
+        assert!(provider.get::<tables::StoragesHistory>(key).unwrap().is_some());
+    }
+
+    #[derive(Debug)]
+    struct TestTable;
+
+    impl Table for TestTable {
+        const NAME: &'static str = "TestTable";
+        const DUPSORT: bool = false;
+        type Key = u64;
+        type Value = Vec<u8>;
+    }
+
+    #[test]
+    fn test_basic_operations() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<TestTable>() // Type-safe!
+            .build()
+            .unwrap();
+
+        let key = 42u64;
+        let value = b"test_value".to_vec();
+
+        // Test write
+        provider.put::<TestTable>(key, &value).unwrap();
+
+        // Test read
+        let result = provider.get::<TestTable>(key).unwrap();
+        assert_eq!(result, Some(value));
+
+        // Test delete
+        provider.delete::<TestTable>(key).unwrap();
+
+        // Verify deletion
+        assert_eq!(provider.get::<TestTable>(key).unwrap(), None);
+    }
+
+    #[test]
+    fn test_batch_operations() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Write multiple entries in a batch
+        provider
+            .write_batch(|batch| {
+                for i in 0..10u64 {
+                    let value = format!("value_{i}").into_bytes();
+                    batch.put::<TestTable>(i, &value)?;
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        // Read all entries
+        for i in 0..10u64 {
+            let value = format!("value_{i}").into_bytes();
+            assert_eq!(provider.get::<TestTable>(i).unwrap(), Some(value));
+        }
+
+        // Delete all entries in a batch
+        provider
+            .write_batch(|batch| {
+                for i in 0..10u64 {
+                    batch.delete::<TestTable>(i)?;
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        // Verify all deleted
+        for i in 0..10u64 {
+            assert_eq!(provider.get::<TestTable>(i).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn test_with_real_table() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .with_metrics()
+            .build()
+            .unwrap();
+
+        let tx_hash = TxHash::from(B256::from([1u8; 32]));
+
+        // Insert and retrieve
+        provider.put::<tables::TransactionHashNumbers>(tx_hash, &100).unwrap();
+        assert_eq!(provider.get::<tables::TransactionHashNumbers>(tx_hash).unwrap(), Some(100));
+
+        // Batch insert multiple transactions
+        provider
+            .write_batch(|batch| {
+                for i in 0..10u64 {
+                    let hash = TxHash::from(B256::from([i as u8; 32]));
+                    let value = i * 100;
+                    batch.put::<tables::TransactionHashNumbers>(hash, &value)?;
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        // Verify batch insertions
+        for i in 0..10u64 {
+            let hash = TxHash::from(B256::from([i as u8; 32]));
+            assert_eq!(
+                provider.get::<tables::TransactionHashNumbers>(hash).unwrap(),
+                Some(i * 100)
+            );
+        }
+    }
+    #[test]
+    fn test_statistics_enabled() {
+        let temp_dir = TempDir::new().unwrap();
+        // Just verify that building with statistics doesn't panic
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<TestTable>()
+            .with_statistics()
+            .build()
+            .unwrap();
+
+        // Do operations - data should be immediately readable with OptimisticTransactionDB
+        for i in 0..10 {
+            let value = vec![i as u8];
+            provider.put::<TestTable>(i, &value).unwrap();
+            // Verify write is visible
+            assert_eq!(provider.get::<TestTable>(i).unwrap(), Some(value));
+        }
+    }
+
+    #[test]
+    fn test_data_persistence() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Insert data - OptimisticTransactionDB writes are immediately visible
+        let value = vec![42u8; 1000];
+        for i in 0..100 {
+            provider.put::<TestTable>(i, &value).unwrap();
+        }
+
+        // Verify data is readable
+        for i in 0..100 {
+            assert!(provider.get::<TestTable>(i).unwrap().is_some(), "Data should be readable");
+        }
+    }
+
+    #[test]
+    fn test_transaction_read_your_writes() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Create a transaction
+        let tx = provider.tx();
+
+        // Write data within the transaction
+        let key = 42u64;
+        let value = b"test_value".to_vec();
+        tx.put::<TestTable>(key, &value).unwrap();
+
+        // Read-your-writes: should see uncommitted data in same transaction
+        let result = tx.get::<TestTable>(key).unwrap();
+        assert_eq!(
+            result,
+            Some(value.clone()),
+            "Transaction should see its own uncommitted writes"
+        );
+
+        // Data should NOT be visible via provider (outside transaction)
+        let provider_result = provider.get::<TestTable>(key).unwrap();
+        assert_eq!(provider_result, None, "Uncommitted data should not be visible outside tx");
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Now data should be visible via provider
+        let committed_result = provider.get::<TestTable>(key).unwrap();
+        assert_eq!(committed_result, Some(value), "Committed data should be visible");
+    }
+
+    #[test]
+    fn test_transaction_rollback() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // First, put some initial data
+        let key = 100u64;
+        let initial_value = b"initial".to_vec();
+        provider.put::<TestTable>(key, &initial_value).unwrap();
+
+        // Create a transaction and modify data
+        let tx = provider.tx();
+        let new_value = b"modified".to_vec();
+        tx.put::<TestTable>(key, &new_value).unwrap();
+
+        // Verify modification is visible within transaction
+        assert_eq!(tx.get::<TestTable>(key).unwrap(), Some(new_value));
+
+        // Rollback instead of commit
+        tx.rollback().unwrap();
+
+        // Data should be unchanged (initial value)
+        let result = provider.get::<TestTable>(key).unwrap();
+        assert_eq!(result, Some(initial_value), "Rollback should preserve original data");
+    }
+
+    #[test]
+    fn test_transaction_iterator() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Create a transaction
+        let tx = provider.tx();
+
+        // Write multiple entries
+        for i in 0..5u64 {
+            let value = format!("value_{i}").into_bytes();
+            tx.put::<TestTable>(i, &value).unwrap();
+        }
+
+        // Iterate - should see uncommitted writes
+        let mut count = 0;
+        for result in tx.iter::<TestTable>().unwrap() {
+            let (key, value) = result.unwrap();
+            assert_eq!(value, format!("value_{key}").into_bytes());
+            count += 1;
+        }
+        assert_eq!(count, 5, "Iterator should see all uncommitted writes");
+
+        // Commit
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn test_batch_manual_commit() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Create a batch via provider.batch()
+        let mut batch = provider.batch();
+
+        // Add entries
+        for i in 0..10u64 {
+            let value = format!("batch_value_{i}").into_bytes();
+            batch.put::<TestTable>(i, &value).unwrap();
+        }
+
+        // Verify len/is_empty
+        assert_eq!(batch.len(), 10);
+        assert!(!batch.is_empty());
+
+        // Data should NOT be visible before commit
+        assert_eq!(provider.get::<TestTable>(0).unwrap(), None);
+
+        // Commit the batch
+        batch.commit().unwrap();
+
+        // Now data should be visible
+        for i in 0..10u64 {
+            let value = format!("batch_value_{i}").into_bytes();
+            assert_eq!(provider.get::<TestTable>(i).unwrap(), Some(value));
+        }
+    }
+
+    #[test]
+    fn test_first_and_last_entry() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Empty table should return None for both
+        assert_eq!(provider.first::<TestTable>().unwrap(), None);
+        assert_eq!(provider.last::<TestTable>().unwrap(), None);
+
+        // Insert some entries
+        provider.put::<TestTable>(10, &b"value_10".to_vec()).unwrap();
+        provider.put::<TestTable>(20, &b"value_20".to_vec()).unwrap();
+        provider.put::<TestTable>(5, &b"value_5".to_vec()).unwrap();
+
+        // First should return the smallest key
+        let first = provider.first::<TestTable>().unwrap();
+        assert_eq!(first, Some((5, b"value_5".to_vec())));
+
+        // Last should return the largest key
+        let last = provider.last::<TestTable>().unwrap();
+        assert_eq!(last, Some((20, b"value_20".to_vec())));
+    }
+
+    /// Tests the edge case where block < `lowest_available_block_number`.
+    /// This case cannot be tested via `HistoricalStateProviderRef` (which errors before lookup),
+    /// so we keep this RocksDB-specific test to verify the low-level behavior.
+    #[test]
+    fn test_account_history_info_pruned_before_first_entry() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Create a single shard starting at block 100
+        let chunk = IntegerList::new([100, 200, 300]).unwrap();
+        let shard_key = ShardedKey::new(address, u64::MAX);
+        provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
+
+        // Query for block 50 with lowest_available_block_number = 100
+        // This simulates a pruned state where data before block 100 is not available.
+        // Since we're before the first write AND pruning boundary is set, we need to
+        // check the changeset at the first write block.
+        let result =
+            provider.snapshot().account_history_info(address, 50, Some(100), u64::MAX).unwrap();
+        assert_eq!(result, HistoryInfo::InChangeset(100));
+    }
+
+    /// Verifies that a read-only (secondary) provider can catch up with primary writes.
+    #[test]
+    fn test_account_history_info_read_only_and_catch_up() {
+        let temp_dir = TempDir::new().unwrap();
+        let address = Address::from([0x42; 20]);
+        let chunk = IntegerList::new([100, 200, 300]).unwrap();
+        let shard_key = ShardedKey::new(address, u64::MAX);
+
+        // Write data with a read-write provider
+        let rw_provider =
+            RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+        rw_provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
+
+        // Open read-only provider — it sees the initial data.
+        let ro_provider = RocksDBBuilder::new(temp_dir.path())
+            .with_default_tables()
+            .with_read_only(true)
+            .build()
+            .unwrap();
+
+        let result =
+            ro_provider.snapshot().account_history_info(address, 200, None, u64::MAX).unwrap();
+        assert_eq!(result, HistoryInfo::InChangeset(200));
+
+        let result =
+            ro_provider.snapshot().account_history_info(address, 50, None, u64::MAX).unwrap();
+        assert_eq!(result, HistoryInfo::NotYetWritten);
+
+        let result =
+            ro_provider.snapshot().account_history_info(address, 400, None, u64::MAX).unwrap();
+        assert_eq!(result, HistoryInfo::InPlainState);
+
+        // Write new data via the primary.
+        let address2 = Address::from([0x43; 20]);
+        let chunk2 = IntegerList::new([500, 600]).unwrap();
+        let shard_key2 = ShardedKey::new(address2, u64::MAX);
+        rw_provider.put::<tables::AccountsHistory>(shard_key2, &chunk2).unwrap();
+
+        // Read-only doesn't see the new data yet.
+        let result =
+            ro_provider.snapshot().account_history_info(address2, 500, None, u64::MAX).unwrap();
+        assert_eq!(result, HistoryInfo::NotYetWritten);
+
+        // Catch up — now it sees the new data.
+        ro_provider.try_catch_up_with_primary().unwrap();
+
+        let result =
+            ro_provider.snapshot().account_history_info(address2, 500, None, u64::MAX).unwrap();
+        assert_eq!(result, HistoryInfo::InChangeset(500));
+    }
+
+    #[test]
+    fn test_account_history_info_ignores_blocks_above_visible_tip() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        provider
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(address, 110),
+                &IntegerList::new([100, 110]).unwrap(),
+            )
+            .unwrap();
+        provider
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(address, u64::MAX),
+                &IntegerList::new([200, 210]).unwrap(),
+            )
+            .unwrap();
+
+        let result = provider.snapshot().account_history_info(address, 150, None, 150).unwrap();
+        assert_eq!(result, HistoryInfo::InPlainState);
+    }
+
+    #[test]
+    fn test_account_history_info_mixed_shard_respects_visible_tip() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+        provider
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(address, u64::MAX),
+                &IntegerList::new([100, 150, 300]).unwrap(),
+            )
+            .unwrap();
+
+        let result = provider.snapshot().account_history_info(address, 120, None, 200).unwrap();
+        assert_eq!(result, HistoryInfo::InChangeset(150));
+
+        let result = provider.snapshot().account_history_info(address, 201, None, 200).unwrap();
+        assert_eq!(result, HistoryInfo::InPlainState);
+    }
+
+    #[test]
+    fn test_account_history_info_only_stale_entries_use_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+        provider
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(address, u64::MAX),
+                &IntegerList::new([200, 210]).unwrap(),
+            )
+            .unwrap();
+
+        let result = provider.snapshot().account_history_info(address, 150, None, 150).unwrap();
+        assert_eq!(result, HistoryInfo::NotYetWritten);
+
+        let result =
+            provider.snapshot().account_history_info(address, 150, Some(100), 150).unwrap();
+        assert_eq!(result, HistoryInfo::MaybeInPlainState);
+    }
+
+    #[test]
+    fn test_account_history_shard_split_at_boundary() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+        let limit = NUM_OF_INDICES_IN_SHARD;
+
+        // Add exactly NUM_OF_INDICES_IN_SHARD + 1 indices to trigger a split
+        let indices: Vec<u64> = (0..=(limit as u64)).collect();
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, indices).unwrap();
+        batch.commit().unwrap();
+
+        // Should have 2 shards: one completed shard and one sentinel shard
+        let completed_key = ShardedKey::new(address, (limit - 1) as u64);
+        let sentinel_key = ShardedKey::new(address, u64::MAX);
+
+        let completed_shard = provider.get::<tables::AccountsHistory>(completed_key).unwrap();
+        let sentinel_shard = provider.get::<tables::AccountsHistory>(sentinel_key).unwrap();
+
+        assert!(completed_shard.is_some(), "completed shard should exist");
+        assert!(sentinel_shard.is_some(), "sentinel shard should exist");
+
+        let completed_shard = completed_shard.unwrap();
+        let sentinel_shard = sentinel_shard.unwrap();
+
+        assert_eq!(completed_shard.len(), limit as u64, "completed shard should be full");
+        assert_eq!(sentinel_shard.len(), 1, "sentinel shard should have 1 element");
+    }
+
+    #[test]
+    fn test_account_history_multiple_shard_splits() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x43; 20]);
+        let limit = NUM_OF_INDICES_IN_SHARD;
+
+        // First batch: add NUM_OF_INDICES_IN_SHARD indices
+        let first_batch_indices: Vec<u64> = (0..limit as u64).collect();
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, first_batch_indices).unwrap();
+        batch.commit().unwrap();
+
+        // Should have just a sentinel shard (exactly at limit, not over)
+        let sentinel_key = ShardedKey::new(address, u64::MAX);
+        let shard = provider.get::<tables::AccountsHistory>(sentinel_key.clone()).unwrap();
+        assert!(shard.is_some());
+        assert_eq!(shard.unwrap().len(), limit as u64);
+
+        // Second batch: add another NUM_OF_INDICES_IN_SHARD + 1 indices (causing 2 more shards)
+        let second_batch_indices: Vec<u64> = (limit as u64..=(2 * limit) as u64).collect();
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, second_batch_indices).unwrap();
+        batch.commit().unwrap();
+
+        // Now we should have: 2 completed shards + 1 sentinel shard
+        let first_completed = ShardedKey::new(address, (limit - 1) as u64);
+        let second_completed = ShardedKey::new(address, (2 * limit - 1) as u64);
+
+        assert!(
+            provider.get::<tables::AccountsHistory>(first_completed).unwrap().is_some(),
+            "first completed shard should exist"
+        );
+        assert!(
+            provider.get::<tables::AccountsHistory>(second_completed).unwrap().is_some(),
+            "second completed shard should exist"
+        );
+        assert!(
+            provider.get::<tables::AccountsHistory>(sentinel_key).unwrap().is_some(),
+            "sentinel shard should exist"
+        );
+    }
+
+    #[test]
+    fn test_storage_history_shard_split_at_boundary() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x44; 20]);
+        let slot = B256::from([0x55; 32]);
+        let limit = NUM_OF_INDICES_IN_SHARD;
+
+        // Add exactly NUM_OF_INDICES_IN_SHARD + 1 indices to trigger a split
+        let indices: Vec<u64> = (0..=(limit as u64)).collect();
+        let mut batch = provider.batch();
+        batch.append_storage_history_shard(address, slot, indices).unwrap();
+        batch.commit().unwrap();
+
+        // Should have 2 shards: one completed shard and one sentinel shard
+        let completed_key = StorageShardedKey::new(address, slot, (limit - 1) as u64);
+        let sentinel_key = StorageShardedKey::new(address, slot, u64::MAX);
+
+        let completed_shard = provider.get::<tables::StoragesHistory>(completed_key).unwrap();
+        let sentinel_shard = provider.get::<tables::StoragesHistory>(sentinel_key).unwrap();
+
+        assert!(completed_shard.is_some(), "completed shard should exist");
+        assert!(sentinel_shard.is_some(), "sentinel shard should exist");
+
+        let completed_shard = completed_shard.unwrap();
+        let sentinel_shard = sentinel_shard.unwrap();
+
+        assert_eq!(completed_shard.len(), limit as u64, "completed shard should be full");
+        assert_eq!(sentinel_shard.len(), 1, "sentinel shard should have 1 element");
+    }
+
+    #[test]
+    fn test_storage_history_multiple_shard_splits() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x46; 20]);
+        let slot = B256::from([0x57; 32]);
+        let limit = NUM_OF_INDICES_IN_SHARD;
+
+        // First batch: add NUM_OF_INDICES_IN_SHARD indices
+        let first_batch_indices: Vec<u64> = (0..limit as u64).collect();
+        let mut batch = provider.batch();
+        batch.append_storage_history_shard(address, slot, first_batch_indices).unwrap();
+        batch.commit().unwrap();
+
+        // Should have just a sentinel shard (exactly at limit, not over)
+        let sentinel_key = StorageShardedKey::new(address, slot, u64::MAX);
+        let shard = provider.get::<tables::StoragesHistory>(sentinel_key.clone()).unwrap();
+        assert!(shard.is_some());
+        assert_eq!(shard.unwrap().len(), limit as u64);
+
+        // Second batch: add another NUM_OF_INDICES_IN_SHARD + 1 indices (causing 2 more shards)
+        let second_batch_indices: Vec<u64> = (limit as u64..=(2 * limit) as u64).collect();
+        let mut batch = provider.batch();
+        batch.append_storage_history_shard(address, slot, second_batch_indices).unwrap();
+        batch.commit().unwrap();
+
+        // Now we should have: 2 completed shards + 1 sentinel shard
+        let first_completed = StorageShardedKey::new(address, slot, (limit - 1) as u64);
+        let second_completed = StorageShardedKey::new(address, slot, (2 * limit - 1) as u64);
+
+        assert!(
+            provider.get::<tables::StoragesHistory>(first_completed).unwrap().is_some(),
+            "first completed shard should exist"
+        );
+        assert!(
+            provider.get::<tables::StoragesHistory>(second_completed).unwrap().is_some(),
+            "second completed shard should exist"
+        );
+        assert!(
+            provider.get::<tables::StoragesHistory>(sentinel_key).unwrap().is_some(),
+            "sentinel shard should exist"
+        );
+    }
+
+    #[test]
+    fn test_clear_table() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+        let key = ShardedKey::new(address, u64::MAX);
+        let blocks = BlockNumberList::new_pre_sorted([1, 2, 3]);
+
+        provider.put::<tables::AccountsHistory>(key.clone(), &blocks).unwrap();
+        assert!(provider.get::<tables::AccountsHistory>(key.clone()).unwrap().is_some());
+
+        provider.clear::<tables::AccountsHistory>().unwrap();
+
+        assert!(
+            provider.get::<tables::AccountsHistory>(key).unwrap().is_none(),
+            "table should be empty after clear"
+        );
+        assert!(
+            provider.first::<tables::AccountsHistory>().unwrap().is_none(),
+            "first() should return None after clear"
+        );
+    }
+
+    #[test]
+    fn test_clear_empty_table() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        assert!(provider.first::<tables::AccountsHistory>().unwrap().is_none());
+
+        provider.clear::<tables::AccountsHistory>().unwrap();
+
+        assert!(provider.first::<tables::AccountsHistory>().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_unwind_account_history_to_basic() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Add blocks 0-10
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, 0..=10).unwrap();
+        batch.commit().unwrap();
+
+        // Verify we have blocks 0-10
+        let key = ShardedKey::new(address, u64::MAX);
+        let result = provider.get::<tables::AccountsHistory>(key.clone()).unwrap();
+        assert!(result.is_some());
+        let blocks: Vec<u64> = result.unwrap().iter().collect();
+        assert_eq!(blocks, (0..=10).collect::<Vec<_>>());
+
+        // Unwind to block 5 (keep blocks 0-5, remove 6-10)
+        let mut batch = provider.batch();
+        batch.unwind_account_history_to(address, 5).unwrap();
+        batch.commit().unwrap();
+
+        // Verify only blocks 0-5 remain
+        let result = provider.get::<tables::AccountsHistory>(key).unwrap();
+        assert!(result.is_some());
+        let blocks: Vec<u64> = result.unwrap().iter().collect();
+        assert_eq!(blocks, (0..=5).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_unwind_account_history_to_removes_all() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Add blocks 5-10
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, 5..=10).unwrap();
+        batch.commit().unwrap();
+
+        // Unwind to block 4 (removes all blocks since they're all > 4)
+        let mut batch = provider.batch();
+        batch.unwind_account_history_to(address, 4).unwrap();
+        batch.commit().unwrap();
+
+        // Verify no data remains for this address
+        let key = ShardedKey::new(address, u64::MAX);
+        let result = provider.get::<tables::AccountsHistory>(key).unwrap();
+        assert!(result.is_none(), "Should have no data after full unwind");
+    }
+
+    #[test]
+    fn test_unwind_account_history_to_no_op() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Add blocks 0-5
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, 0..=5).unwrap();
+        batch.commit().unwrap();
+
+        // Unwind to block 10 (no-op since all blocks are <= 10)
+        let mut batch = provider.batch();
+        batch.unwind_account_history_to(address, 10).unwrap();
+        batch.commit().unwrap();
+
+        // Verify blocks 0-5 still remain
+        let key = ShardedKey::new(address, u64::MAX);
+        let result = provider.get::<tables::AccountsHistory>(key).unwrap();
+        assert!(result.is_some());
+        let blocks: Vec<u64> = result.unwrap().iter().collect();
+        assert_eq!(blocks, (0..=5).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_unwind_account_history_to_block_zero() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Add blocks 0-5 (including block 0)
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, 0..=5).unwrap();
+        batch.commit().unwrap();
+
+        // Unwind to block 0 (keep only block 0, remove 1-5)
+        // This simulates the caller doing: unwind_to = min_block.checked_sub(1) where min_block = 1
+        let mut batch = provider.batch();
+        batch.unwind_account_history_to(address, 0).unwrap();
+        batch.commit().unwrap();
+
+        // Verify only block 0 remains
+        let key = ShardedKey::new(address, u64::MAX);
+        let result = provider.get::<tables::AccountsHistory>(key).unwrap();
+        assert!(result.is_some());
+        let blocks: Vec<u64> = result.unwrap().iter().collect();
+        assert_eq!(blocks, vec![0]);
+    }
+
+    #[test]
+    fn test_unwind_account_history_to_multi_shard() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Create multiple shards by adding more than NUM_OF_INDICES_IN_SHARD entries
+        // For testing, we'll manually create shards with specific keys
+        let mut batch = provider.batch();
+
+        // First shard: blocks 1-50, keyed by 50
+        let shard1 = BlockNumberList::new_pre_sorted(1..=50);
+        batch.put::<tables::AccountsHistory>(ShardedKey::new(address, 50), &shard1).unwrap();
+
+        // Second shard: blocks 51-100, keyed by MAX (sentinel)
+        let shard2 = BlockNumberList::new_pre_sorted(51..=100);
+        batch.put::<tables::AccountsHistory>(ShardedKey::new(address, u64::MAX), &shard2).unwrap();
+
+        batch.commit().unwrap();
+
+        // Verify we have 2 shards
+        let shards = provider.account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 2);
+
+        // Unwind to block 75 (keep 1-75, remove 76-100)
+        let mut batch = provider.batch();
+        batch.unwind_account_history_to(address, 75).unwrap();
+        batch.commit().unwrap();
+
+        // Verify: shard1 should be untouched, shard2 should be truncated
+        let shards = provider.account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 2);
+
+        // First shard unchanged
+        assert_eq!(shards[0].0.highest_block_number, 50);
+        assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), (1..=50).collect::<Vec<_>>());
+
+        // Second shard truncated and re-keyed to MAX
+        assert_eq!(shards[1].0.highest_block_number, u64::MAX);
+        assert_eq!(shards[1].1.iter().collect::<Vec<_>>(), (51..=75).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_unwind_account_history_to_multi_shard_boundary_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Create two shards
+        let mut batch = provider.batch();
+
+        // First shard: blocks 1-50, keyed by 50
+        let shard1 = BlockNumberList::new_pre_sorted(1..=50);
+        batch.put::<tables::AccountsHistory>(ShardedKey::new(address, 50), &shard1).unwrap();
+
+        // Second shard: blocks 75-100, keyed by MAX
+        let shard2 = BlockNumberList::new_pre_sorted(75..=100);
+        batch.put::<tables::AccountsHistory>(ShardedKey::new(address, u64::MAX), &shard2).unwrap();
+
+        batch.commit().unwrap();
+
+        // Unwind to block 60 (removes all of shard2 since 75 > 60, promotes shard1 to MAX)
+        let mut batch = provider.batch();
+        batch.unwind_account_history_to(address, 60).unwrap();
+        batch.commit().unwrap();
+
+        // Verify: only shard1 remains, now keyed as MAX
+        let shards = provider.account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].0.highest_block_number, u64::MAX);
+        assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), (1..=50).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_account_history_shards_iterator() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+        let other_address = Address::from([0x43; 20]);
+
+        // Add data for two addresses
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, 0..=5).unwrap();
+        batch.append_account_history_shard(other_address, 10..=15).unwrap();
+        batch.commit().unwrap();
+
+        // Query shards for first address only
+        let shards = provider.account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].0.key, address);
+
+        // Query shards for second address only
+        let shards = provider.account_history_shards(other_address).unwrap();
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].0.key, other_address);
+
+        // Query shards for non-existent address
+        let non_existent = Address::from([0x99; 20]);
+        let shards = provider.account_history_shards(non_existent).unwrap();
+        assert!(shards.is_empty());
+    }
+
+    #[test]
+    fn test_clear_account_history() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Add blocks 0-10
+        let mut batch = provider.batch();
+        batch.append_account_history_shard(address, 0..=10).unwrap();
+        batch.commit().unwrap();
+
+        // Clear all history (simulates unwind from block 0)
+        let mut batch = provider.batch();
+        batch.clear_account_history(address).unwrap();
+        batch.commit().unwrap();
+
+        // Verify no data remains
+        let shards = provider.account_history_shards(address).unwrap();
+        assert!(shards.is_empty(), "All shards should be deleted");
+    }
+
+    #[test]
+    fn test_unwind_non_sentinel_boundary() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+
+        // Create three shards with non-sentinel boundary
+        let mut batch = provider.batch();
+
+        // Shard 1: blocks 1-50, keyed by 50
+        let shard1 = BlockNumberList::new_pre_sorted(1..=50);
+        batch.put::<tables::AccountsHistory>(ShardedKey::new(address, 50), &shard1).unwrap();
+
+        // Shard 2: blocks 51-100, keyed by 100 (non-sentinel, will be boundary)
+        let shard2 = BlockNumberList::new_pre_sorted(51..=100);
+        batch.put::<tables::AccountsHistory>(ShardedKey::new(address, 100), &shard2).unwrap();
+
+        // Shard 3: blocks 101-150, keyed by MAX (will be deleted)
+        let shard3 = BlockNumberList::new_pre_sorted(101..=150);
+        batch.put::<tables::AccountsHistory>(ShardedKey::new(address, u64::MAX), &shard3).unwrap();
+
+        batch.commit().unwrap();
+
+        // Verify 3 shards
+        let shards = provider.account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 3);
+
+        // Unwind to block 75 (truncates shard2, deletes shard3)
+        let mut batch = provider.batch();
+        batch.unwind_account_history_to(address, 75).unwrap();
+        batch.commit().unwrap();
+
+        // Verify: shard1 unchanged, shard2 truncated and re-keyed to MAX, shard3 deleted
+        let shards = provider.account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 2);
+
+        // First shard unchanged
+        assert_eq!(shards[0].0.highest_block_number, 50);
+        assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), (1..=50).collect::<Vec<_>>());
+
+        // Second shard truncated and re-keyed to MAX
+        assert_eq!(shards[1].0.highest_block_number, u64::MAX);
+        assert_eq!(shards[1].1.iter().collect::<Vec<_>>(), (51..=75).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_batch_auto_commit_on_threshold() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Create batch with tiny threshold (1KB) to force auto-commits
+        let mut batch = RocksDBBatch {
+            provider: &provider,
+            inner: WriteBatchWithTransaction::<true>::default(),
+            buf: Vec::new(),
+            auto_commit_threshold: Some(1024), // 1KB
+        };
+
+        // Write entries until we exceed threshold multiple times
+        // Each entry is ~20 bytes, so 100 entries = ~2KB = 2 auto-commits
+        for i in 0..100u64 {
+            let value = format!("value_{i:04}").into_bytes();
+            batch.put::<TestTable>(i, &value).unwrap();
+        }
+
+        // Data should already be visible (auto-committed) even before final commit
+        // At least some entries should be readable
+        let first_visible = provider.get::<TestTable>(0).unwrap();
+        assert!(first_visible.is_some(), "Auto-committed data should be visible");
+
+        // Final commit for remaining batch
+        batch.commit().unwrap();
+
+        // All entries should now be visible
+        for i in 0..100u64 {
+            let value = format!("value_{i:04}").into_bytes();
+            assert_eq!(provider.get::<TestTable>(i).unwrap(), Some(value));
+        }
+    }
+
+    // ==================== PARAMETERIZED PRUNE TESTS ====================
+
+    /// Test case for account history pruning
+    struct AccountPruneCase {
+        name: &'static str,
+        initial_shards: &'static [(u64, &'static [u64])],
+        prune_to: u64,
+        expected_outcome: PruneShardOutcome,
+        expected_shards: &'static [(u64, &'static [u64])],
+    }
+
+    /// Test case for storage history pruning
+    struct StoragePruneCase {
+        name: &'static str,
+        initial_shards: &'static [(u64, &'static [u64])],
+        prune_to: u64,
+        expected_outcome: PruneShardOutcome,
+        expected_shards: &'static [(u64, &'static [u64])],
+    }
+
+    #[test]
+    fn test_prune_account_history_cases() {
+        const MAX: u64 = u64::MAX;
+        const CASES: &[AccountPruneCase] = &[
+            AccountPruneCase {
+                name: "single_shard_truncate",
+                initial_shards: &[(MAX, &[10, 20, 30, 40])],
+                prune_to: 25,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(MAX, &[30, 40])],
+            },
+            AccountPruneCase {
+                name: "single_shard_delete_all",
+                initial_shards: &[(MAX, &[10, 20])],
+                prune_to: 20,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[],
+            },
+            AccountPruneCase {
+                name: "single_shard_noop",
+                initial_shards: &[(MAX, &[10, 20])],
+                prune_to: 5,
+                expected_outcome: PruneShardOutcome::Unchanged,
+                expected_shards: &[(MAX, &[10, 20])],
+            },
+            AccountPruneCase {
+                name: "no_shards",
+                initial_shards: &[],
+                prune_to: 100,
+                expected_outcome: PruneShardOutcome::Unchanged,
+                expected_shards: &[],
+            },
+            AccountPruneCase {
+                name: "multi_shard_truncate_first",
+                initial_shards: &[(30, &[10, 20, 30]), (MAX, &[40, 50, 60])],
+                prune_to: 25,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(30, &[30]), (MAX, &[40, 50, 60])],
+            },
+            AccountPruneCase {
+                name: "delete_first_shard_sentinel_unchanged",
+                initial_shards: &[(20, &[10, 20]), (MAX, &[30, 40])],
+                prune_to: 20,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(MAX, &[30, 40])],
+            },
+            AccountPruneCase {
+                name: "multi_shard_delete_all_but_last",
+                initial_shards: &[(10, &[5, 10]), (20, &[15, 20]), (MAX, &[25, 30])],
+                prune_to: 22,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(MAX, &[25, 30])],
+            },
+            AccountPruneCase {
+                name: "mid_shard_preserves_key",
+                initial_shards: &[(50, &[10, 20, 30, 40, 50]), (MAX, &[60, 70])],
+                prune_to: 25,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(50, &[30, 40, 50]), (MAX, &[60, 70])],
+            },
+            // Equivalence tests
+            AccountPruneCase {
+                name: "equiv_delete_early_shards_keep_sentinel",
+                initial_shards: &[(20, &[10, 15, 20]), (50, &[30, 40, 50]), (MAX, &[60, 70])],
+                prune_to: 55,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(MAX, &[60, 70])],
+            },
+            AccountPruneCase {
+                name: "equiv_sentinel_becomes_empty_with_prev",
+                initial_shards: &[(50, &[30, 40, 50]), (MAX, &[35])],
+                prune_to: 40,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(MAX, &[50])],
+            },
+            AccountPruneCase {
+                name: "equiv_all_shards_become_empty",
+                initial_shards: &[(50, &[30, 40, 50]), (MAX, &[51])],
+                prune_to: 51,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[],
+            },
+            AccountPruneCase {
+                name: "equiv_non_sentinel_last_shard_promoted",
+                initial_shards: &[(100, &[50, 75, 100])],
+                prune_to: 60,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(MAX, &[75, 100])],
+            },
+            AccountPruneCase {
+                name: "equiv_filter_within_shard",
+                initial_shards: &[(MAX, &[10, 20, 30, 40])],
+                prune_to: 25,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(MAX, &[30, 40])],
+            },
+            AccountPruneCase {
+                name: "equiv_multi_shard_partial_delete",
+                initial_shards: &[(20, &[10, 20]), (50, &[30, 40, 50]), (MAX, &[60, 70])],
+                prune_to: 35,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(50, &[40, 50]), (MAX, &[60, 70])],
+            },
+        ];
+
+        let address = Address::from([0x42; 20]);
+
+        for case in CASES {
+            let temp_dir = TempDir::new().unwrap();
+            let provider =
+                RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+            // Setup initial shards
+            let mut batch = provider.batch();
+            for (highest, blocks) in case.initial_shards {
+                let shard = BlockNumberList::new_pre_sorted(blocks.iter().copied());
+                batch
+                    .put::<tables::AccountsHistory>(ShardedKey::new(address, *highest), &shard)
+                    .unwrap();
+            }
+            batch.commit().unwrap();
+
+            // Prune
+            let mut batch = provider.batch();
+            let outcome = batch.prune_account_history_to(address, case.prune_to).unwrap();
+            batch.commit().unwrap();
+
+            // Assert outcome
+            assert_eq!(outcome, case.expected_outcome, "case '{}': wrong outcome", case.name);
+
+            // Assert final shards
+            let shards = provider.account_history_shards(address).unwrap();
+            assert_eq!(
+                shards.len(),
+                case.expected_shards.len(),
+                "case '{}': wrong shard count",
+                case.name
+            );
+            for (i, ((key, blocks), (exp_key, exp_blocks))) in
+                shards.iter().zip(case.expected_shards.iter()).enumerate()
+            {
+                assert_eq!(
+                    key.highest_block_number, *exp_key,
+                    "case '{}': shard {} wrong key",
+                    case.name, i
+                );
+                assert_eq!(
+                    blocks.iter().collect::<Vec<_>>(),
+                    *exp_blocks,
+                    "case '{}': shard {} wrong blocks",
+                    case.name,
+                    i
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_prune_storage_history_cases() {
+        const MAX: u64 = u64::MAX;
+        const CASES: &[StoragePruneCase] = &[
+            StoragePruneCase {
+                name: "single_shard_truncate",
+                initial_shards: &[(MAX, &[10, 20, 30, 40])],
+                prune_to: 25,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(MAX, &[30, 40])],
+            },
+            StoragePruneCase {
+                name: "single_shard_delete_all",
+                initial_shards: &[(MAX, &[10, 20])],
+                prune_to: 20,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[],
+            },
+            StoragePruneCase {
+                name: "noop",
+                initial_shards: &[(MAX, &[10, 20])],
+                prune_to: 5,
+                expected_outcome: PruneShardOutcome::Unchanged,
+                expected_shards: &[(MAX, &[10, 20])],
+            },
+            StoragePruneCase {
+                name: "no_shards",
+                initial_shards: &[],
+                prune_to: 100,
+                expected_outcome: PruneShardOutcome::Unchanged,
+                expected_shards: &[],
+            },
+            StoragePruneCase {
+                name: "mid_shard_preserves_key",
+                initial_shards: &[(50, &[10, 20, 30, 40, 50]), (MAX, &[60, 70])],
+                prune_to: 25,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(50, &[30, 40, 50]), (MAX, &[60, 70])],
+            },
+            // Equivalence tests
+            StoragePruneCase {
+                name: "equiv_sentinel_promotion",
+                initial_shards: &[(100, &[50, 75, 100])],
+                prune_to: 60,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(MAX, &[75, 100])],
+            },
+            StoragePruneCase {
+                name: "equiv_delete_early_shards_keep_sentinel",
+                initial_shards: &[(20, &[10, 15, 20]), (50, &[30, 40, 50]), (MAX, &[60, 70])],
+                prune_to: 55,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(MAX, &[60, 70])],
+            },
+            StoragePruneCase {
+                name: "equiv_sentinel_becomes_empty_with_prev",
+                initial_shards: &[(50, &[30, 40, 50]), (MAX, &[35])],
+                prune_to: 40,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(MAX, &[50])],
+            },
+            StoragePruneCase {
+                name: "equiv_all_shards_become_empty",
+                initial_shards: &[(50, &[30, 40, 50]), (MAX, &[51])],
+                prune_to: 51,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[],
+            },
+            StoragePruneCase {
+                name: "equiv_filter_within_shard",
+                initial_shards: &[(MAX, &[10, 20, 30, 40])],
+                prune_to: 25,
+                expected_outcome: PruneShardOutcome::Updated,
+                expected_shards: &[(MAX, &[30, 40])],
+            },
+            StoragePruneCase {
+                name: "equiv_multi_shard_partial_delete",
+                initial_shards: &[(20, &[10, 20]), (50, &[30, 40, 50]), (MAX, &[60, 70])],
+                prune_to: 35,
+                expected_outcome: PruneShardOutcome::Deleted,
+                expected_shards: &[(50, &[40, 50]), (MAX, &[60, 70])],
+            },
+        ];
+
+        let address = Address::from([0x42; 20]);
+        let storage_key = B256::from([0x01; 32]);
+
+        for case in CASES {
+            let temp_dir = TempDir::new().unwrap();
+            let provider =
+                RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+            // Setup initial shards
+            let mut batch = provider.batch();
+            for (highest, blocks) in case.initial_shards {
+                let shard = BlockNumberList::new_pre_sorted(blocks.iter().copied());
+                let key = if *highest == MAX {
+                    StorageShardedKey::last(address, storage_key)
+                } else {
+                    StorageShardedKey::new(address, storage_key, *highest)
+                };
+                batch.put::<tables::StoragesHistory>(key, &shard).unwrap();
+            }
+            batch.commit().unwrap();
+
+            // Prune
+            let mut batch = provider.batch();
+            let outcome =
+                batch.prune_storage_history_to(address, storage_key, case.prune_to).unwrap();
+            batch.commit().unwrap();
+
+            // Assert outcome
+            assert_eq!(outcome, case.expected_outcome, "case '{}': wrong outcome", case.name);
+
+            // Assert final shards
+            let shards = provider.storage_history_shards(address, storage_key).unwrap();
+            assert_eq!(
+                shards.len(),
+                case.expected_shards.len(),
+                "case '{}': wrong shard count",
+                case.name
+            );
+            for (i, ((key, blocks), (exp_key, exp_blocks))) in
+                shards.iter().zip(case.expected_shards.iter()).enumerate()
+            {
+                assert_eq!(
+                    key.sharded_key.highest_block_number, *exp_key,
+                    "case '{}': shard {} wrong key",
+                    case.name, i
+                );
+                assert_eq!(
+                    blocks.iter().collect::<Vec<_>>(),
+                    *exp_blocks,
+                    "case '{}': shard {} wrong blocks",
+                    case.name,
+                    i
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_prune_storage_history_does_not_affect_other_slots() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let address = Address::from([0x42; 20]);
+        let slot1 = B256::from([0x01; 32]);
+        let slot2 = B256::from([0x02; 32]);
+
+        // Two different storage slots
+        let mut batch = provider.batch();
+        batch
+            .put::<tables::StoragesHistory>(
+                StorageShardedKey::last(address, slot1),
+                &BlockNumberList::new_pre_sorted([10u64, 20]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::StoragesHistory>(
+                StorageShardedKey::last(address, slot2),
+                &BlockNumberList::new_pre_sorted([30u64, 40]),
+            )
+            .unwrap();
+        batch.commit().unwrap();
+
+        // Prune slot1 to block 20 (deletes all)
+        let mut batch = provider.batch();
+        let outcome = batch.prune_storage_history_to(address, slot1, 20).unwrap();
+        batch.commit().unwrap();
+
+        assert_eq!(outcome, PruneShardOutcome::Deleted);
+
+        // slot1 should be empty
+        let shards1 = provider.storage_history_shards(address, slot1).unwrap();
+        assert!(shards1.is_empty());
+
+        // slot2 should be unchanged
+        let shards2 = provider.storage_history_shards(address, slot2).unwrap();
+        assert_eq!(shards2.len(), 1);
+        assert_eq!(shards2[0].1.iter().collect::<Vec<_>>(), vec![30, 40]);
+    }
+
+    #[test]
+    fn test_prune_invariants() {
+        // Test invariants: no empty shards, sentinel is always last
+        let address = Address::from([0x42; 20]);
+        let storage_key = B256::from([0x01; 32]);
+
+        // Test cases that exercise invariants
+        #[expect(clippy::type_complexity)]
+        let invariant_cases: &[(&[(u64, &[u64])], u64)] = &[
+            // Account: shards where middle becomes empty
+            (&[(10, &[5, 10]), (20, &[15, 20]), (u64::MAX, &[25, 30])], 20),
+            // Account: non-sentinel shard only, partial prune -> must become sentinel
+            (&[(100, &[50, 100])], 60),
+        ];
+
+        for (initial_shards, prune_to) in invariant_cases {
+            // Test account history invariants
+            {
+                let temp_dir = TempDir::new().unwrap();
+                let provider =
+                    RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+                let mut batch = provider.batch();
+                for (highest, blocks) in *initial_shards {
+                    let shard = BlockNumberList::new_pre_sorted(blocks.iter().copied());
+                    batch
+                        .put::<tables::AccountsHistory>(ShardedKey::new(address, *highest), &shard)
+                        .unwrap();
+                }
+                batch.commit().unwrap();
+
+                let mut batch = provider.batch();
+                batch.prune_account_history_to(address, *prune_to).unwrap();
+                batch.commit().unwrap();
+
+                let shards = provider.account_history_shards(address).unwrap();
+
+                // Invariant 1: no empty shards
+                for (key, blocks) in &shards {
+                    assert!(
+                        !blocks.is_empty(),
+                        "Account: empty shard at key {}",
+                        key.highest_block_number
+                    );
+                }
+
+                // Invariant 2: last shard is sentinel
+                if !shards.is_empty() {
+                    let last = shards.last().unwrap();
+                    assert_eq!(
+                        last.0.highest_block_number,
+                        u64::MAX,
+                        "Account: last shard must be sentinel"
+                    );
+                }
+            }
+
+            // Test storage history invariants
+            {
+                let temp_dir = TempDir::new().unwrap();
+                let provider =
+                    RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+                let mut batch = provider.batch();
+                for (highest, blocks) in *initial_shards {
+                    let shard = BlockNumberList::new_pre_sorted(blocks.iter().copied());
+                    let key = if *highest == u64::MAX {
+                        StorageShardedKey::last(address, storage_key)
+                    } else {
+                        StorageShardedKey::new(address, storage_key, *highest)
+                    };
+                    batch.put::<tables::StoragesHistory>(key, &shard).unwrap();
+                }
+                batch.commit().unwrap();
+
+                let mut batch = provider.batch();
+                batch.prune_storage_history_to(address, storage_key, *prune_to).unwrap();
+                batch.commit().unwrap();
+
+                let shards = provider.storage_history_shards(address, storage_key).unwrap();
+
+                // Invariant 1: no empty shards
+                for (key, blocks) in &shards {
+                    assert!(
+                        !blocks.is_empty(),
+                        "Storage: empty shard at key {}",
+                        key.sharded_key.highest_block_number
+                    );
+                }
+
+                // Invariant 2: last shard is sentinel
+                if !shards.is_empty() {
+                    let last = shards.last().unwrap();
+                    assert_eq!(
+                        last.0.sharded_key.highest_block_number,
+                        u64::MAX,
+                        "Storage: last shard must be sentinel"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_prune_account_history_batch_multiple_sorted_targets() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let addr1 = Address::from([0x01; 20]);
+        let addr2 = Address::from([0x02; 20]);
+        let addr3 = Address::from([0x03; 20]);
+
+        // Setup shards for each address
+        let mut batch = provider.batch();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr1, u64::MAX),
+                &BlockNumberList::new_pre_sorted([10, 20, 30]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr2, u64::MAX),
+                &BlockNumberList::new_pre_sorted([5, 10, 15]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr3, u64::MAX),
+                &BlockNumberList::new_pre_sorted([100, 200]),
+            )
+            .unwrap();
+        batch.commit().unwrap();
+
+        // Prune all three (sorted by address)
+        let mut targets = vec![(addr1, 15), (addr2, 10), (addr3, 50)];
+        targets.sort_by_key(|(addr, _)| *addr);
+
+        let mut batch = provider.batch();
+        let outcomes = batch.prune_account_history_batch(&targets).unwrap();
+        batch.commit().unwrap();
+
+        // addr1: prune <=15, keep [20, 30] -> updated
+        // addr2: prune <=10, keep [15] -> updated
+        // addr3: prune <=50, keep [100, 200] -> unchanged
+        assert_eq!(outcomes.updated, 2);
+        assert_eq!(outcomes.unchanged, 1);
+
+        let shards1 = provider.account_history_shards(addr1).unwrap();
+        assert_eq!(shards1[0].1.iter().collect::<Vec<_>>(), vec![20, 30]);
+
+        let shards2 = provider.account_history_shards(addr2).unwrap();
+        assert_eq!(shards2[0].1.iter().collect::<Vec<_>>(), vec![15]);
+
+        let shards3 = provider.account_history_shards(addr3).unwrap();
+        assert_eq!(shards3[0].1.iter().collect::<Vec<_>>(), vec![100, 200]);
+    }
+
+    #[test]
+    fn test_prune_account_history_batch_target_with_no_shards() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let addr1 = Address::from([0x01; 20]);
+        let addr2 = Address::from([0x02; 20]); // No shards for this one
+        let addr3 = Address::from([0x03; 20]);
+
+        // Only setup shards for addr1 and addr3
+        let mut batch = provider.batch();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr1, u64::MAX),
+                &BlockNumberList::new_pre_sorted([10, 20]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr3, u64::MAX),
+                &BlockNumberList::new_pre_sorted([30, 40]),
+            )
+            .unwrap();
+        batch.commit().unwrap();
+
+        // Prune all three (addr2 has no shards - tests p > target_prefix case)
+        let mut targets = vec![(addr1, 15), (addr2, 100), (addr3, 35)];
+        targets.sort_by_key(|(addr, _)| *addr);
+
+        let mut batch = provider.batch();
+        let outcomes = batch.prune_account_history_batch(&targets).unwrap();
+        batch.commit().unwrap();
+
+        // addr1: updated (keep [20])
+        // addr2: unchanged (no shards)
+        // addr3: updated (keep [40])
+        assert_eq!(outcomes.updated, 2);
+        assert_eq!(outcomes.unchanged, 1);
+
+        let shards1 = provider.account_history_shards(addr1).unwrap();
+        assert_eq!(shards1[0].1.iter().collect::<Vec<_>>(), vec![20]);
+
+        let shards3 = provider.account_history_shards(addr3).unwrap();
+        assert_eq!(shards3[0].1.iter().collect::<Vec<_>>(), vec![40]);
+    }
+
+    #[test]
+    fn test_prune_storage_history_batch_multiple_sorted_targets() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let addr = Address::from([0x42; 20]);
+        let slot1 = B256::from([0x01; 32]);
+        let slot2 = B256::from([0x02; 32]);
+
+        // Setup shards
+        let mut batch = provider.batch();
+        batch
+            .put::<tables::StoragesHistory>(
+                StorageShardedKey::new(addr, slot1, u64::MAX),
+                &BlockNumberList::new_pre_sorted([10, 20, 30]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::StoragesHistory>(
+                StorageShardedKey::new(addr, slot2, u64::MAX),
+                &BlockNumberList::new_pre_sorted([5, 15, 25]),
+            )
+            .unwrap();
+        batch.commit().unwrap();
+
+        // Prune both (sorted)
+        let mut targets = vec![((addr, slot1), 15), ((addr, slot2), 10)];
+        targets.sort_by_key(|((a, s), _)| (*a, *s));
+
+        let mut batch = provider.batch();
+        let outcomes = batch.prune_storage_history_batch(&targets).unwrap();
+        batch.commit().unwrap();
+
+        assert_eq!(outcomes.updated, 2);
+
+        let shards1 = provider.storage_history_shards(addr, slot1).unwrap();
+        assert_eq!(shards1[0].1.iter().collect::<Vec<_>>(), vec![20, 30]);
+
+        let shards2 = provider.storage_history_shards(addr, slot2).unwrap();
+        assert_eq!(shards2[0].1.iter().collect::<Vec<_>>(), vec![15, 25]);
+    }
+}

--- a/patches/reth-provider/src/providers/state/historical.rs
+++ b/patches/reth-provider/src/providers/state/historical.rs
@@ -1,0 +1,1460 @@
+use super::overlay::{Overlay, OverlayBuilder, OverlaySource};
+use crate::{
+    AccountReader, BlockHashReader, ChangeSetReader, EitherReader, HashedPostStateProvider,
+    ProviderError, RocksDBProviderFactory, StateProvider, StateRootProvider,
+};
+use alloy_eips::merge::EPOCH_SLOTS;
+use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use reth_db_api::{
+    cursor::{DbCursorRO, DbDupCursorRO},
+    table::Table,
+    tables,
+    transaction::DbTx,
+    BlockNumberList,
+};
+use reth_primitives_traits::{Account, Bytecode, NodePrimitives};
+use reth_storage_api::{
+    BlockNumReader, BytecodeReader, DBProvider, NodePrimitivesProvider, PruneCheckpointReader,
+    StageCheckpointReader, StateProofProvider, StorageChangeSetReader, StorageRootProvider,
+    StorageSettingsCache,
+};
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::{
+    hashed_cursor::HashedPostStateCursorFactory,
+    proof::{Proof, StorageProof},
+    trie_cursor::InMemoryTrieCursorFactory,
+    updates::TrieUpdates,
+    witness::TrieWitness,
+    AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, KeccakKeyHasher,
+    MultiProof, MultiProofTargets, StateRoot, StorageMultiProof, StorageRoot, TrieInput,
+    TrieInputSorted,
+};
+use reth_trie_db::{
+    ChangesetCache, DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot,
+};
+
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+
+type DbStateRoot<'a, TX, A> = StateRoot<
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+type DbStorageRoot<'a, TX, A> = StorageRoot<
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+type DbStorageProof<'a, TX, A> = StorageProof<
+    'static,
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+type DbProof<'a, TX, A> = Proof<
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+
+/// Result of a history lookup for an account or storage slot.
+///
+/// Indicates where to find the historical value for a given key at a specific block.
+#[derive(Debug, Eq, PartialEq)]
+pub enum HistoryInfo {
+    /// The key is written to, but only after our block (not yet written at the target block). Or
+    /// it has never been written.
+    NotYetWritten,
+    /// The chunk contains an entry for a write after our block at the given block number.
+    /// The value should be looked up in the changeset at this block.
+    InChangeset(u64),
+    /// The chunk does not contain an entry for a write after our block. This can only
+    /// happen if this is the last chunk, so we need to look in the plain state.
+    InPlainState,
+    /// The key may have been written, but due to pruning we may not have changesets and
+    /// history, so we need to make a plain state lookup.
+    MaybeInPlainState,
+}
+
+impl HistoryInfo {
+    /// Determines where to find the historical value based on computed shard lookup results.
+    ///
+    /// This is a pure function shared by both MDBX and `RocksDB` backends.
+    ///
+    /// # Arguments
+    /// * `found_block` - The block number from the shard lookup
+    /// * `is_before_first_write` - True if the target block is before the first write to this key.
+    ///   This should be computed as: `rank == 0 && found_block != Some(block_number) &&
+    ///   !has_previous_shard` where `has_previous_shard` comes from a lazy `cursor.prev()` check.
+    /// * `lowest_available` - Lowest block where history is available (pruning boundary)
+    pub const fn from_lookup(
+        found_block: Option<u64>,
+        is_before_first_write: bool,
+        lowest_available: Option<BlockNumber>,
+    ) -> Self {
+        if is_before_first_write {
+            if let (Some(_), Some(block_number)) = (lowest_available, found_block) {
+                // The key may have been written, but due to pruning we may not have changesets
+                // and history, so we need to make a changeset lookup.
+                return Self::InChangeset(block_number)
+            }
+            // The key is written to, but only after our block.
+            return Self::NotYetWritten
+        }
+
+        if let Some(block_number) = found_block {
+            // The chunk contains an entry for a write after our block, return it.
+            Self::InChangeset(block_number)
+        } else {
+            // The chunk does not contain an entry for a write after our block. This can only
+            // happen if this is the last chunk and so we need to look in the plain state.
+            Self::InPlainState
+        }
+    }
+}
+
+/// State provider for a given block number which takes a tx reference.
+///
+/// Historical state provider accesses the state at the start of the provided block number.
+/// It means that all changes made in the provided block number are not included.
+///
+/// Historical state provider reads the following tables:
+/// - [`tables::AccountsHistory`]
+/// - [`tables::Bytecodes`]
+/// - [`tables::StoragesHistory`]
+/// - [`tables::AccountChangeSets`]
+/// - [`tables::StorageChangeSets`]
+#[derive(Debug)]
+pub struct HistoricalStateProviderRef<
+    'b,
+    Provider,
+    N: NodePrimitives = <Provider as NodePrimitivesProvider>::Primitives,
+> where
+    Provider: NodePrimitivesProvider<Primitives = N>,
+{
+    /// Database provider
+    provider: &'b Provider,
+    /// Changeset cache handle for retrieving trie changesets.
+    changeset_cache: ChangesetCache,
+    /// Block number is main index for the history state of accounts and storages.
+    block_number: BlockNumber,
+    /// Lowest blocks at which different parts of the state are available.
+    lowest_available_blocks: LowestAvailableBlocks,
+    /// Marker for the provider's node primitives.
+    _primitives: PhantomData<N>,
+}
+
+impl<'b, Provider, N> HistoricalStateProviderRef<'b, Provider, N>
+where
+    Provider: DBProvider
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    /// Create new `StateProvider` for historical block number
+    pub fn new(
+        provider: &'b Provider,
+        block_number: BlockNumber,
+        changeset_cache: ChangesetCache,
+    ) -> Self {
+        Self {
+            provider,
+            changeset_cache,
+            block_number,
+            lowest_available_blocks: Default::default(),
+            _primitives: PhantomData,
+        }
+    }
+
+    /// Create new `StateProvider` for historical block number and lowest block numbers at which
+    /// account & storage histories are available.
+    pub const fn new_with_lowest_available_blocks(
+        provider: &'b Provider,
+        block_number: BlockNumber,
+        lowest_available_blocks: LowestAvailableBlocks,
+        changeset_cache: ChangesetCache,
+    ) -> Self {
+        Self {
+            provider,
+            changeset_cache,
+            block_number,
+            lowest_available_blocks,
+            _primitives: PhantomData,
+        }
+    }
+
+    /// Lookup an account in the `AccountsHistory` table using `EitherReader`.
+    pub fn account_history_lookup(&self, address: Address) -> ProviderResult<HistoryInfo>
+    where
+        Provider: StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider,
+    {
+        if !self.lowest_available_blocks.is_account_history_available(self.block_number) {
+            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+        }
+
+        let visible_tip = self.provider.best_block_number()?;
+
+        self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
+            let mut reader = EitherReader::new_accounts_history(self.provider, rocksdb_ref)?;
+            reader.account_history_info(
+                address,
+                self.block_number,
+                self.lowest_available_blocks.account_history_block_number,
+                visible_tip,
+            )
+        })
+    }
+
+    /// Lookup a storage key in the `StoragesHistory` table using `EitherReader`.
+    ///
+    /// `lookup_key` is always a plain (unhashed) storage key.
+    pub fn storage_history_lookup(
+        &self,
+        address: Address,
+        lookup_key: B256,
+    ) -> ProviderResult<HistoryInfo>
+    where
+        Provider: StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider,
+    {
+        if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
+            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+        }
+
+        let visible_tip = self.provider.best_block_number()?;
+
+        self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
+            let mut reader = EitherReader::new_storages_history(self.provider, rocksdb_ref)?;
+            reader.storage_history_info(
+                address,
+                lookup_key,
+                self.block_number,
+                self.lowest_available_blocks.storage_history_block_number,
+                visible_tip,
+            )
+        })
+    }
+
+    /// Resolves a storage value by looking up the given key in history, changesets, or
+    /// plain state.
+    ///
+    /// `lookup_key` is always a plain (unhashed) storage key.
+    fn storage_by_lookup_key(
+        &self,
+        address: Address,
+        lookup_key: B256,
+    ) -> ProviderResult<Option<StorageValue>>
+    where
+        Provider: StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider,
+    {
+        match self.storage_history_lookup(address, lookup_key)? {
+            HistoryInfo::NotYetWritten => Ok(None),
+            HistoryInfo::InChangeset(changeset_block_number) => self
+                .provider
+                .get_storage_before_block(changeset_block_number, address, lookup_key)?
+                .ok_or_else(|| ProviderError::StorageChangesetNotFound {
+                    block_number: changeset_block_number,
+                    address,
+                    storage_key: Box::new(lookup_key),
+                })
+                .map(|entry| entry.value)
+                .map(Some),
+            HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                if self.provider.cached_storage_settings().use_hashed_state() {
+                    let hashed_address = alloy_primitives::keccak256(address);
+                    let hashed_slot = alloy_primitives::keccak256(lookup_key);
+                    Ok(self
+                        .tx()
+                        .cursor_dup_read::<tables::HashedStorages>()?
+                        .seek_by_key_subkey(hashed_address, hashed_slot)?
+                        .filter(|entry| entry.key == hashed_slot)
+                        .map(|entry| entry.value)
+                        .or(Some(StorageValue::ZERO)))
+                } else {
+                    Ok(self
+                        .tx()
+                        .cursor_dup_read::<tables::PlainStorageState>()?
+                        .seek_by_key_subkey(address, lookup_key)?
+                        .filter(|entry| entry.key == lookup_key)
+                        .map(|entry| entry.value)
+                        .or(Some(StorageValue::ZERO)))
+                }
+            }
+        }
+    }
+
+    /// Checks and returns `true` if distance to historical block exceeds the provided limit.
+    fn check_distance_against_limit(&self, limit: u64) -> ProviderResult<bool> {
+        let tip = self.provider.last_block_number()?;
+
+        Ok(tip.saturating_sub(self.block_number) > limit)
+    }
+
+    fn build_overlay(&self, input: TrieInputSorted) -> ProviderResult<TrieInputSorted>
+    where
+        Provider:
+            BlockHashReader + PruneCheckpointReader + StageCheckpointReader + StorageSettingsCache,
+    {
+        if self.check_distance_against_limit(EPOCH_SLOTS)? {
+            tracing::warn!(
+                target: "providers::historical_sp",
+                target = self.block_number,
+                "Attempt to calculate state root for an old block might result in OOM"
+            );
+        }
+
+        // Historical providers expose state at the start of `self.block_number`, so the overlay
+        // builder needs the previous canonical block hash to preserve those semantics.
+        let target_block = self.block_number.saturating_sub(1);
+        let anchor_hash = self
+            .provider
+            .block_hash(target_block)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(target_block.into()))?;
+
+        let TrieInputSorted { nodes, state, prefix_sets } = input;
+        let overlay_builder = OverlayBuilder::<N>::new(anchor_hash, self.changeset_cache.clone())
+            .with_overlay_source(Some(OverlaySource::Immediate { trie: nodes, state }));
+        let Overlay { trie_updates, hashed_post_state } =
+            overlay_builder.build_overlay(self.provider)?;
+
+        Ok(TrieInputSorted::new(trie_updates, hashed_post_state, prefix_sets))
+    }
+
+    /// Set the lowest block number at which the account history is available.
+    pub const fn with_lowest_available_account_history_block_number(
+        mut self,
+        block_number: BlockNumber,
+    ) -> Self {
+        self.lowest_available_blocks.account_history_block_number = Some(block_number);
+        self
+    }
+
+    /// Set the lowest block number at which the storage history is available.
+    pub const fn with_lowest_available_storage_history_block_number(
+        mut self,
+        block_number: BlockNumber,
+    ) -> Self {
+        self.lowest_available_blocks.storage_history_block_number = Some(block_number);
+        self
+    }
+}
+
+impl<Provider, N> HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: DBProvider + BlockNumReader + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    fn tx(&self) -> &Provider::Tx {
+        self.provider.tx_ref()
+    }
+}
+
+impl<Provider, N> AccountReader for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: DBProvider
+        + BlockNumReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    /// Get basic account information.
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        match self.account_history_lookup(*address)? {
+            HistoryInfo::NotYetWritten => Ok(None),
+            HistoryInfo::InChangeset(changeset_block_number) => {
+                // Use ChangeSetReader trait method to get the account from changesets
+                self.provider
+                    .get_account_before_block(changeset_block_number, *address)?
+                    .ok_or(ProviderError::AccountChangesetNotFound {
+                        block_number: changeset_block_number,
+                        address: *address,
+                    })
+                    .map(|account_before| account_before.info)
+            }
+            HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                if self.provider.cached_storage_settings().use_hashed_state() {
+                    let hashed_address = alloy_primitives::keccak256(address);
+                    Ok(self.tx().get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)?)
+                } else {
+                    Ok(self.tx().get_by_encoded_key::<tables::PlainAccountState>(address)?)
+                }
+            }
+        }
+    }
+}
+
+impl<Provider, N> BlockHashReader for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider:
+        DBProvider + BlockNumReader + BlockHashReader + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    /// Get block hash by number.
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.provider.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.provider.canonical_hashes_range(start, end)
+    }
+}
+
+impl<Provider, N> StateRootProvider for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: DBProvider
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + BlockHashReader
+        + PruneCheckpointReader
+        + StageCheckpointReader
+        + StorageSettingsCache
+        + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(hashed_state),
+            ))?;
+            Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.tx(), input)?)
+        })
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.tx(), input)?)
+        })
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(hashed_state),
+            ))?;
+            Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(self.tx(), input)?)
+        })
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(self.tx(), input)?)
+        })
+    }
+}
+
+impl<Provider, N> StorageRootProvider for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: DBProvider
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + BlockHashReader
+        + PruneCheckpointReader
+        + StageCheckpointReader
+        + StorageSettingsCache
+        + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )),
+            ))?;
+            let hashed_storage = input
+                .state
+                .account_storages()
+                .get(&alloy_primitives::keccak256(address))
+                .cloned()
+                .unwrap_or_default()
+                .into();
+            <DbStorageRoot<'_, _, A>>::overlay_root(self.tx(), address, hashed_storage)
+                .map_err(|err| ProviderError::Database(err.into()))
+        })
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<reth_trie::StorageProof> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )),
+            ))?;
+            let hashed_storage = input
+                .state
+                .account_storages()
+                .get(&alloy_primitives::keccak256(address))
+                .cloned()
+                .unwrap_or_default()
+                .into();
+            <DbStorageProof<'_, _, A>>::overlay_storage_proof(
+                self.tx(),
+                address,
+                slot,
+                hashed_storage,
+            )
+            .map_err(ProviderError::from)
+        })
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )),
+            ))?;
+            let hashed_storage = input
+                .state
+                .account_storages()
+                .get(&alloy_primitives::keccak256(address))
+                .cloned()
+                .unwrap_or_default()
+                .into();
+            <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(
+                self.tx(),
+                address,
+                slots,
+                hashed_storage,
+            )
+            .map_err(ProviderError::from)
+        })
+    }
+}
+
+impl<Provider, N> StateProofProvider for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: DBProvider
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + BlockHashReader
+        + PruneCheckpointReader
+        + StageCheckpointReader
+        + StorageSettingsCache
+        + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    /// Get account and storage proofs.
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let TrieInputSorted { nodes, state, prefix_sets } =
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = TrieInput::new(
+                Arc::unwrap_or_clone(nodes).into(),
+                Arc::unwrap_or_clone(state).into(),
+                prefix_sets,
+            );
+            let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.tx());
+            proof.overlay_account_proof(input, address, slots).map_err(ProviderError::from)
+        })
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let TrieInputSorted { nodes, state, prefix_sets } =
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = TrieInput::new(
+                Arc::unwrap_or_clone(nodes).into(),
+                Arc::unwrap_or_clone(state).into(),
+                prefix_sets,
+            );
+            let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.tx());
+            proof.overlay_multiproof(input, targets).map_err(ProviderError::from)
+        })
+    }
+
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+        mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            let TrieInputSorted { nodes, state, prefix_sets } =
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let witness = TrieWitness::new(
+                InMemoryTrieCursorFactory::new(
+                    reth_trie_db::DatabaseTrieCursorFactory::<_, A>::new(self.tx()),
+                    nodes.as_ref(),
+                ),
+                HashedPostStateCursorFactory::new(
+                    reth_trie_db::DatabaseHashedCursorFactory::new(self.tx()),
+                    state.as_ref(),
+                ),
+            )
+            .with_prefix_sets_mut(prefix_sets)
+            .with_execution_witness_mode(mode);
+            let witness =
+                if mode.is_canonical() { witness } else { witness.always_include_root_node() };
+            witness.compute(target).map_err(ProviderError::from).map(|hm| {
+                let mut values: Vec<_> = hm.into_values().collect();
+                if mode.is_canonical() {
+                    values.sort_unstable();
+                }
+                values
+            })
+        })
+    }
+}
+
+impl<Provider, N> HashedPostStateProvider for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+}
+
+impl<Provider, N> StateProvider for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: DBProvider
+        + BlockNumReader
+        + BlockHashReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + PruneCheckpointReader
+        + StageCheckpointReader
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    /// Expects a plain (unhashed) storage key slot.
+    fn storage(
+        &self,
+        address: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        self.storage_by_lookup_key(address, storage_key)
+    }
+}
+
+impl<Provider, N> BytecodeReader for HistoricalStateProviderRef<'_, Provider, N>
+where
+    Provider: DBProvider + BlockNumReader + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    /// Get account code by its hash
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
+    }
+}
+
+/// State provider for a given block number.
+/// For more detailed description, see [`HistoricalStateProviderRef`].
+#[derive(Debug)]
+pub struct HistoricalStateProvider<Provider> {
+    /// Database provider.
+    provider: Provider,
+    /// Changeset cache handle for retrieving trie changesets.
+    changeset_cache: ChangesetCache,
+    /// State at the block number is the main indexer of the state.
+    block_number: BlockNumber,
+    /// Lowest blocks at which different parts of the state are available.
+    lowest_available_blocks: LowestAvailableBlocks,
+}
+
+impl<Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + BlockNumReader>
+    HistoricalStateProvider<Provider>
+{
+    /// Create new `StateProvider` for historical block number
+    pub fn new(
+        provider: Provider,
+        block_number: BlockNumber,
+        changeset_cache: ChangesetCache,
+    ) -> Self {
+        Self {
+            provider,
+            changeset_cache,
+            block_number,
+            lowest_available_blocks: Default::default(),
+        }
+    }
+
+    /// Set the lowest block number at which the account history is available.
+    pub const fn with_lowest_available_account_history_block_number(
+        mut self,
+        block_number: BlockNumber,
+    ) -> Self {
+        self.lowest_available_blocks.account_history_block_number = Some(block_number);
+        self
+    }
+
+    /// Set the lowest block number at which the storage history is available.
+    pub const fn with_lowest_available_storage_history_block_number(
+        mut self,
+        block_number: BlockNumber,
+    ) -> Self {
+        self.lowest_available_blocks.storage_history_block_number = Some(block_number);
+        self
+    }
+}
+
+impl<
+        Provider: DBProvider
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + BlockNumReader
+            + NodePrimitivesProvider,
+    > HistoricalStateProvider<Provider>
+{
+    /// Returns a new provider that takes the `TX` as reference
+    #[inline(always)]
+    fn as_ref(&self) -> HistoricalStateProviderRef<'_, Provider> {
+        HistoricalStateProviderRef::new_with_lowest_available_blocks(
+            &self.provider,
+            self.block_number,
+            self.lowest_available_blocks,
+            self.changeset_cache.clone(),
+        )
+    }
+}
+
+// Delegates all provider impls to [HistoricalStateProviderRef]
+reth_storage_api::macros::delegate_provider_impls!(HistoricalStateProvider<Provider> where [Provider: DBProvider + BlockNumReader + BlockHashReader + ChangeSetReader + StorageChangeSetReader + PruneCheckpointReader + StageCheckpointReader + StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider]);
+
+/// Lowest blocks at which different parts of the state are available.
+/// They may be [Some] if pruning is enabled.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LowestAvailableBlocks {
+    /// Lowest block number at which the account history is available. It may not be available if
+    /// [`reth_prune_types::PruneSegment::AccountHistory`] was pruned.
+    /// [`Option::None`] means all history is available.
+    pub account_history_block_number: Option<BlockNumber>,
+    /// Lowest block number at which the storage history is available. It may not be available if
+    /// [`reth_prune_types::PruneSegment::StorageHistory`] was pruned.
+    /// [`Option::None`] means all history is available.
+    pub storage_history_block_number: Option<BlockNumber>,
+}
+
+impl LowestAvailableBlocks {
+    /// Check if account history is available at the provided block number, i.e. lowest available
+    /// block number for account history is less than or equal to the provided block number.
+    pub fn is_account_history_available(&self, at: BlockNumber) -> bool {
+        self.account_history_block_number.map(|block_number| block_number <= at).unwrap_or(true)
+    }
+
+    /// Check if storage history is available at the provided block number, i.e. lowest available
+    /// block number for storage history is less than or equal to the provided block number.
+    pub fn is_storage_history_available(&self, at: BlockNumber) -> bool {
+        self.storage_history_block_number.map(|block_number| block_number <= at).unwrap_or(true)
+    }
+}
+
+/// Computes the rank and finds the next modification block in a history shard.
+///
+/// Given a `block_number`, this function returns:
+/// - `rank`: The number of entries strictly before `block_number` in the shard
+/// - `found_block`: The block number at position `rank` (i.e., the first block >= `block_number`
+///   where a modification occurred), or `None` if `rank` is out of bounds
+///
+/// The rank is adjusted when `block_number` exactly matches an entry in the shard,
+/// so that `found_block` always returns the modification at or after the target.
+///
+/// This logic is shared between MDBX cursor-based lookups and `RocksDB` iterator lookups.
+#[inline]
+pub fn compute_history_rank(
+    chunk: &reth_db_api::BlockNumberList,
+    block_number: BlockNumber,
+) -> (u64, Option<u64>) {
+    let mut rank = chunk.rank(block_number);
+    // `rank(block_number)` returns count of entries <= block_number.
+    // We want the first entry >= block_number, so if block_number is in the shard,
+    // we need to step back one position to point at it (not past it).
+    if rank.checked_sub(1).and_then(|r| chunk.select(r)) == Some(block_number) {
+        rank -= 1;
+    }
+    (rank, chunk.select(rank))
+}
+
+/// Checks if a previous shard lookup is needed to determine if we're before the first write.
+///
+/// Returns `true` when `rank == 0` (first entry in shard) and the found block doesn't match
+/// the target block number. In this case, we need to check if there's a previous shard.
+#[inline]
+pub fn needs_prev_shard_check(
+    rank: u64,
+    found_block: Option<u64>,
+    block_number: BlockNumber,
+) -> bool {
+    rank == 0 && found_block != Some(block_number)
+}
+
+/// Generic history lookup for sharded history tables.
+///
+/// Seeks to the shard containing `block_number`, verifies the key via `key_filter`,
+/// and checks previous shard to detect if we're before the first write.
+pub fn history_info<T, K, C>(
+    cursor: &mut C,
+    key: K,
+    block_number: BlockNumber,
+    key_filter: impl Fn(&K) -> bool,
+    lowest_available_block_number: Option<BlockNumber>,
+) -> ProviderResult<HistoryInfo>
+where
+    T: Table<Key = K, Value = BlockNumberList>,
+    C: DbCursorRO<T>,
+{
+    // Lookup the history chunk in the history index. If the key does not appear in the
+    // index, the first chunk for the next key will be returned so we filter out chunks that
+    // have a different key.
+    if let Some(chunk) = cursor.seek(key)?.filter(|(k, _)| key_filter(k)).map(|x| x.1) {
+        let (rank, found_block) = compute_history_rank(&chunk, block_number);
+
+        // If our block is before the first entry in the index chunk and this first entry
+        // doesn't equal to our block, it might be before the first write ever. To check, we
+        // look at the previous entry and check if the key is the same.
+        // This check is worth it, the `cursor.prev()` check is rarely triggered (the if will
+        // short-circuit) and when it passes we save a full seek into the changeset/plain state
+        // table.
+        let is_before_first_write = needs_prev_shard_check(rank, found_block, block_number) &&
+            !cursor.prev()?.is_some_and(|(k, _)| key_filter(&k));
+
+        Ok(HistoryInfo::from_lookup(
+            found_block,
+            is_before_first_write,
+            lowest_available_block_number,
+        ))
+    } else if lowest_available_block_number.is_some() {
+        // The key may have been written, but due to pruning we may not have changesets and
+        // history, so we need to make a plain state lookup.
+        Ok(HistoryInfo::MaybeInPlainState)
+    } else {
+        // The key has not been written to at all.
+        Ok(HistoryInfo::NotYetWritten)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::needs_prev_shard_check;
+    use crate::{
+        providers::state::historical::{HistoryInfo, LowestAvailableBlocks},
+        test_utils::create_test_provider_factory,
+        AccountReader, HistoricalStateProvider, HistoricalStateProviderRef, RocksDBProviderFactory,
+        StateProvider,
+    };
+    use alloy_primitives::{address, b256, Address, B256, U256};
+    use reth_db_api::{
+        models::{storage_sharded_key::StorageShardedKey, AccountBeforeTx, ShardedKey},
+        tables,
+        transaction::{DbTx, DbTxMut},
+        BlockNumberList,
+    };
+    use reth_primitives_traits::{Account, StorageEntry};
+    use reth_storage_api::{
+        BlockHashReader, BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
+        NodePrimitivesProvider, PruneCheckpointReader, StageCheckpointReader,
+        StorageChangeSetReader, StorageSettingsCache,
+    };
+    use reth_storage_errors::provider::ProviderError;
+    use reth_trie_db::ChangesetCache;
+
+    const ADDRESS: Address = address!("0x0000000000000000000000000000000000000001");
+    const HIGHER_ADDRESS: Address = address!("0x0000000000000000000000000000000000000005");
+    const STORAGE: B256 =
+        b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+    const fn assert_state_provider<T: StateProvider>() {}
+    #[expect(dead_code)]
+    const fn assert_historical_state_provider<
+        T: DBProvider
+            + BlockNumReader
+            + BlockHashReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + PruneCheckpointReader
+            + StageCheckpointReader
+            + StorageSettingsCache
+            + RocksDBProviderFactory
+            + NodePrimitivesProvider,
+    >() {
+        assert_state_provider::<HistoricalStateProvider<T>>();
+    }
+
+    #[test]
+    fn history_provider_get_account() {
+        let factory = create_test_provider_factory();
+        let tx = factory.provider_rw().unwrap().into_tx();
+
+        tx.put::<tables::AccountsHistory>(
+            ShardedKey { key: ADDRESS, highest_block_number: 7 },
+            BlockNumberList::new([1, 3, 7]).unwrap(),
+        )
+        .unwrap();
+        tx.put::<tables::AccountsHistory>(
+            ShardedKey { key: ADDRESS, highest_block_number: u64::MAX },
+            BlockNumberList::new([10, 15]).unwrap(),
+        )
+        .unwrap();
+        tx.put::<tables::AccountsHistory>(
+            ShardedKey { key: HIGHER_ADDRESS, highest_block_number: u64::MAX },
+            BlockNumberList::new([4]).unwrap(),
+        )
+        .unwrap();
+
+        let acc_plain = Account { nonce: 100, balance: U256::ZERO, bytecode_hash: None };
+        let acc_at15 = Account { nonce: 15, balance: U256::ZERO, bytecode_hash: None };
+        let acc_at10 = Account { nonce: 10, balance: U256::ZERO, bytecode_hash: None };
+        let acc_at7 = Account { nonce: 7, balance: U256::ZERO, bytecode_hash: None };
+        let acc_at3 = Account { nonce: 3, balance: U256::ZERO, bytecode_hash: None };
+
+        let higher_acc_plain = Account { nonce: 4, balance: U256::ZERO, bytecode_hash: None };
+
+        // setup
+        tx.put::<tables::AccountChangeSets>(1, AccountBeforeTx { address: ADDRESS, info: None })
+            .unwrap();
+        tx.put::<tables::AccountChangeSets>(
+            3,
+            AccountBeforeTx { address: ADDRESS, info: Some(acc_at3) },
+        )
+        .unwrap();
+        tx.put::<tables::AccountChangeSets>(
+            4,
+            AccountBeforeTx { address: HIGHER_ADDRESS, info: None },
+        )
+        .unwrap();
+        tx.put::<tables::AccountChangeSets>(
+            7,
+            AccountBeforeTx { address: ADDRESS, info: Some(acc_at7) },
+        )
+        .unwrap();
+        tx.put::<tables::AccountChangeSets>(
+            10,
+            AccountBeforeTx { address: ADDRESS, info: Some(acc_at10) },
+        )
+        .unwrap();
+        tx.put::<tables::AccountChangeSets>(
+            15,
+            AccountBeforeTx { address: ADDRESS, info: Some(acc_at15) },
+        )
+        .unwrap();
+
+        // setup plain state
+        tx.put::<tables::PlainAccountState>(ADDRESS, acc_plain).unwrap();
+        tx.put::<tables::PlainAccountState>(HIGHER_ADDRESS, higher_acc_plain).unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+
+        // run
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 2, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_at3
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 3, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_at3
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 4, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_at7
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 7, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_at7
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 9, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_at10
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 10, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_at10
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 11, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_at15
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 16, ChangesetCache::new()).basic_account(&ADDRESS),
+            Ok(Some(acc)) if acc == acc_plain
+        ));
+
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1, ChangesetCache::new())
+                .basic_account(&HIGHER_ADDRESS),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1000, ChangesetCache::new()).basic_account(&HIGHER_ADDRESS),
+            Ok(Some(acc)) if acc == higher_acc_plain
+        ));
+    }
+
+    #[test]
+    fn history_provider_get_storage() {
+        let factory = create_test_provider_factory();
+        let tx = factory.provider_rw().unwrap().into_tx();
+
+        tx.put::<tables::StoragesHistory>(
+            StorageShardedKey {
+                address: ADDRESS,
+                sharded_key: ShardedKey { key: STORAGE, highest_block_number: 7 },
+            },
+            BlockNumberList::new([3, 7]).unwrap(),
+        )
+        .unwrap();
+        tx.put::<tables::StoragesHistory>(
+            StorageShardedKey {
+                address: ADDRESS,
+                sharded_key: ShardedKey { key: STORAGE, highest_block_number: u64::MAX },
+            },
+            BlockNumberList::new([10, 15]).unwrap(),
+        )
+        .unwrap();
+        tx.put::<tables::StoragesHistory>(
+            StorageShardedKey {
+                address: HIGHER_ADDRESS,
+                sharded_key: ShardedKey { key: STORAGE, highest_block_number: u64::MAX },
+            },
+            BlockNumberList::new([4]).unwrap(),
+        )
+        .unwrap();
+
+        let higher_entry_plain = StorageEntry { key: STORAGE, value: U256::from(1000) };
+        let higher_entry_at4 = StorageEntry { key: STORAGE, value: U256::from(0) };
+        let entry_plain = StorageEntry { key: STORAGE, value: U256::from(100) };
+        let entry_at15 = StorageEntry { key: STORAGE, value: U256::from(15) };
+        let entry_at10 = StorageEntry { key: STORAGE, value: U256::from(10) };
+        let entry_at7 = StorageEntry { key: STORAGE, value: U256::from(7) };
+        let entry_at3 = StorageEntry { key: STORAGE, value: U256::from(0) };
+
+        // setup
+        tx.put::<tables::StorageChangeSets>((3, ADDRESS).into(), entry_at3).unwrap();
+        tx.put::<tables::StorageChangeSets>((4, HIGHER_ADDRESS).into(), higher_entry_at4).unwrap();
+        tx.put::<tables::StorageChangeSets>((7, ADDRESS).into(), entry_at7).unwrap();
+        tx.put::<tables::StorageChangeSets>((10, ADDRESS).into(), entry_at10).unwrap();
+        tx.put::<tables::StorageChangeSets>((15, ADDRESS).into(), entry_at15).unwrap();
+
+        // setup plain state
+        tx.put::<tables::PlainStorageState>(ADDRESS, entry_plain).unwrap();
+        tx.put::<tables::PlainStorageState>(HIGHER_ADDRESS, higher_entry_plain).unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+
+        // run
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 0, ChangesetCache::new())
+                .storage(ADDRESS, STORAGE),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 3, ChangesetCache::new())
+                .storage(ADDRESS, STORAGE),
+            Ok(Some(U256::ZERO))
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 4, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at7.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 7, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at7.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 9, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at10.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 10, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at10.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 11, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at15.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 16, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_plain.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1, ChangesetCache::new())
+                .storage(HIGHER_ADDRESS, STORAGE),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1000, ChangesetCache::new()).storage(HIGHER_ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == higher_entry_plain.value
+        ));
+    }
+
+    #[test]
+    fn history_provider_unavailable() {
+        let factory = create_test_provider_factory();
+        let db = factory.database_provider_rw().unwrap();
+
+        // provider block_number < lowest available block number,
+        // i.e. state at provider block is pruned
+        let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
+            &db,
+            2,
+            LowestAvailableBlocks {
+                account_history_block_number: Some(3),
+                storage_history_block_number: Some(3),
+            },
+            ChangesetCache::new(),
+        );
+        assert!(matches!(
+            provider.account_history_lookup(ADDRESS),
+            Err(ProviderError::StateAtBlockPruned(number)) if number == provider.block_number
+        ));
+        assert!(matches!(
+            provider.storage_history_lookup(ADDRESS, STORAGE),
+            Err(ProviderError::StateAtBlockPruned(number)) if number == provider.block_number
+        ));
+
+        // provider block_number == lowest available block number,
+        // i.e. state at provider block is available
+        let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
+            &db,
+            2,
+            LowestAvailableBlocks {
+                account_history_block_number: Some(2),
+                storage_history_block_number: Some(2),
+            },
+            ChangesetCache::new(),
+        );
+        assert!(matches!(
+            provider.account_history_lookup(ADDRESS),
+            Ok(HistoryInfo::MaybeInPlainState)
+        ));
+        assert!(matches!(
+            provider.storage_history_lookup(ADDRESS, STORAGE),
+            Ok(HistoryInfo::MaybeInPlainState)
+        ));
+
+        // provider block_number == lowest available block number,
+        // i.e. state at provider block is available
+        let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
+            &db,
+            2,
+            LowestAvailableBlocks {
+                account_history_block_number: Some(1),
+                storage_history_block_number: Some(1),
+            },
+            ChangesetCache::new(),
+        );
+        assert!(matches!(
+            provider.account_history_lookup(ADDRESS),
+            Ok(HistoryInfo::MaybeInPlainState)
+        ));
+        assert!(matches!(
+            provider.storage_history_lookup(ADDRESS, STORAGE),
+            Ok(HistoryInfo::MaybeInPlainState)
+        ));
+    }
+
+    #[test]
+    fn test_history_info_from_lookup() {
+        // Before first write, no pruning → not yet written
+        assert_eq!(HistoryInfo::from_lookup(Some(10), true, None), HistoryInfo::NotYetWritten);
+        assert_eq!(HistoryInfo::from_lookup(None, true, None), HistoryInfo::NotYetWritten);
+
+        // Before first write WITH pruning → check changeset (pruning may have removed history)
+        assert_eq!(HistoryInfo::from_lookup(Some(10), true, Some(5)), HistoryInfo::InChangeset(10));
+        assert_eq!(HistoryInfo::from_lookup(None, true, Some(5)), HistoryInfo::NotYetWritten);
+
+        // Not before first write → check changeset or plain state
+        assert_eq!(HistoryInfo::from_lookup(Some(10), false, None), HistoryInfo::InChangeset(10));
+        assert_eq!(HistoryInfo::from_lookup(None, false, None), HistoryInfo::InPlainState);
+    }
+
+    #[test]
+    fn history_provider_get_storage_legacy() {
+        let factory = create_test_provider_factory();
+
+        assert!(!factory.provider().unwrap().cached_storage_settings().use_hashed_state());
+
+        let tx = factory.provider_rw().unwrap().into_tx();
+
+        tx.put::<tables::StoragesHistory>(
+            StorageShardedKey {
+                address: ADDRESS,
+                sharded_key: ShardedKey { key: STORAGE, highest_block_number: 7 },
+            },
+            BlockNumberList::new([3, 7]).unwrap(),
+        )
+        .unwrap();
+        tx.put::<tables::StoragesHistory>(
+            StorageShardedKey {
+                address: ADDRESS,
+                sharded_key: ShardedKey { key: STORAGE, highest_block_number: u64::MAX },
+            },
+            BlockNumberList::new([10, 15]).unwrap(),
+        )
+        .unwrap();
+        tx.put::<tables::StoragesHistory>(
+            StorageShardedKey {
+                address: HIGHER_ADDRESS,
+                sharded_key: ShardedKey { key: STORAGE, highest_block_number: u64::MAX },
+            },
+            BlockNumberList::new([4]).unwrap(),
+        )
+        .unwrap();
+
+        let higher_entry_plain = StorageEntry { key: STORAGE, value: U256::from(1000) };
+        let higher_entry_at4 = StorageEntry { key: STORAGE, value: U256::from(0) };
+        let entry_plain = StorageEntry { key: STORAGE, value: U256::from(100) };
+        let entry_at15 = StorageEntry { key: STORAGE, value: U256::from(15) };
+        let entry_at10 = StorageEntry { key: STORAGE, value: U256::from(10) };
+        let entry_at7 = StorageEntry { key: STORAGE, value: U256::from(7) };
+        let entry_at3 = StorageEntry { key: STORAGE, value: U256::from(0) };
+
+        tx.put::<tables::StorageChangeSets>((3, ADDRESS).into(), entry_at3).unwrap();
+        tx.put::<tables::StorageChangeSets>((4, HIGHER_ADDRESS).into(), higher_entry_at4).unwrap();
+        tx.put::<tables::StorageChangeSets>((7, ADDRESS).into(), entry_at7).unwrap();
+        tx.put::<tables::StorageChangeSets>((10, ADDRESS).into(), entry_at10).unwrap();
+        tx.put::<tables::StorageChangeSets>((15, ADDRESS).into(), entry_at15).unwrap();
+
+        tx.put::<tables::PlainStorageState>(ADDRESS, entry_plain).unwrap();
+        tx.put::<tables::PlainStorageState>(HIGHER_ADDRESS, higher_entry_plain).unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 0, ChangesetCache::new())
+                .storage(ADDRESS, STORAGE),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 3, ChangesetCache::new())
+                .storage(ADDRESS, STORAGE),
+            Ok(Some(U256::ZERO))
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 4, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at7.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 7, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at7.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 9, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at10.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 10, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at10.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 11, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_at15.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 16, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == entry_plain.value
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1, ChangesetCache::new())
+                .storage(HIGHER_ADDRESS, STORAGE),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1000, ChangesetCache::new()).storage(HIGHER_ADDRESS, STORAGE),
+            Ok(Some(expected_value)) if expected_value == higher_entry_plain.value
+        ));
+    }
+
+    #[test]
+    fn history_provider_get_storage_hashed_state() {
+        use crate::BlockWriter;
+        use alloy_primitives::keccak256;
+        use reth_db_api::models::StorageSettings;
+        use reth_execution_types::ExecutionOutcome;
+        use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
+        use revm_database::BundleState;
+        use std::collections::HashMap;
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let slot = U256::from_be_bytes(*STORAGE);
+        let account: revm_state::AccountInfo =
+            Account { nonce: 1, balance: U256::from(1000), bytecode_hash: None }.into();
+        let higher_account: revm_state::AccountInfo =
+            Account { nonce: 1, balance: U256::from(2000), bytecode_hash: None }.into();
+
+        let mut rng = generators::rng();
+        let blocks = random_block_range(
+            &mut rng,
+            0..=15,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+
+        let mut addr_storage = HashMap::default();
+        addr_storage.insert(slot, (U256::ZERO, U256::from(100)));
+        let mut higher_storage = HashMap::default();
+        higher_storage.insert(slot, (U256::ZERO, U256::from(1000)));
+
+        type Revert = Vec<(Address, Option<Option<revm_state::AccountInfo>>, Vec<(U256, U256)>)>;
+        let mut reverts: Vec<Revert> = vec![Vec::new(); 16];
+
+        reverts[3] = vec![(ADDRESS, Some(Some(account.clone())), vec![(slot, U256::ZERO)])];
+        reverts[4] =
+            vec![(HIGHER_ADDRESS, Some(Some(higher_account.clone())), vec![(slot, U256::ZERO)])];
+        reverts[7] = vec![(ADDRESS, Some(Some(account.clone())), vec![(slot, U256::from(7))])];
+        reverts[10] = vec![(ADDRESS, Some(Some(account.clone())), vec![(slot, U256::from(10))])];
+        reverts[15] = vec![(ADDRESS, Some(Some(account.clone())), vec![(slot, U256::from(15))])];
+
+        let bundle = BundleState::new(
+            [
+                (ADDRESS, None, Some(account), addr_storage),
+                (HIGHER_ADDRESS, None, Some(higher_account), higher_storage),
+            ],
+            reverts,
+            [],
+        );
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw
+            .append_blocks_with_state(
+                blocks
+                    .into_iter()
+                    .map(|b| b.try_recover().expect("failed to seal block with senders"))
+                    .collect(),
+                &ExecutionOutcome { bundle, first_block: 0, ..Default::default() },
+                Default::default(),
+            )
+            .unwrap();
+
+        let hashed_address = keccak256(ADDRESS);
+        let hashed_higher_address = keccak256(HIGHER_ADDRESS);
+        let hashed_storage = keccak256(STORAGE);
+
+        provider_rw
+            .tx_ref()
+            .put::<tables::HashedStorages>(
+                hashed_address,
+                StorageEntry { key: hashed_storage, value: U256::from(100) },
+            )
+            .unwrap();
+        provider_rw
+            .tx_ref()
+            .put::<tables::HashedStorages>(
+                hashed_higher_address,
+                StorageEntry { key: hashed_storage, value: U256::from(1000) },
+            )
+            .unwrap();
+        provider_rw
+            .tx_ref()
+            .put::<tables::HashedAccounts>(
+                hashed_address,
+                Account { nonce: 1, balance: U256::from(1000), bytecode_hash: None },
+            )
+            .unwrap();
+        provider_rw
+            .tx_ref()
+            .put::<tables::HashedAccounts>(
+                hashed_higher_address,
+                Account { nonce: 1, balance: U256::from(2000), bytecode_hash: None },
+            )
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 0, ChangesetCache::new())
+                .storage(ADDRESS, STORAGE),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 3, ChangesetCache::new())
+                .storage(ADDRESS, STORAGE),
+            Ok(Some(U256::ZERO))
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 4, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(v)) if v == U256::from(7)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 7, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(v)) if v == U256::from(7)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 9, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(v)) if v == U256::from(10)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 10, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(v)) if v == U256::from(10)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 11, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(v)) if v == U256::from(15)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 16, ChangesetCache::new()).storage(ADDRESS, STORAGE),
+            Ok(Some(v)) if v == U256::from(100)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1, ChangesetCache::new())
+                .storage(HIGHER_ADDRESS, STORAGE),
+            Ok(None)
+        ));
+        assert!(matches!(
+            HistoricalStateProviderRef::new(&db, 1000, ChangesetCache::new()).storage(HIGHER_ADDRESS, STORAGE),
+            Ok(Some(v)) if v == U256::from(1000)
+        ));
+    }
+
+    #[test]
+    fn test_needs_prev_shard_check() {
+        // Only needs check when rank == 0 and found_block != block_number
+        assert!(needs_prev_shard_check(0, Some(10), 5));
+        assert!(needs_prev_shard_check(0, None, 5));
+        assert!(!needs_prev_shard_check(0, Some(5), 5)); // found_block == block_number
+        assert!(!needs_prev_shard_check(1, Some(10), 5)); // rank > 0
+    }
+}

--- a/patches/reth-provider/src/providers/state/latest.rs
+++ b/patches/reth-provider/src/providers/state/latest.rs
@@ -1,0 +1,590 @@
+use crate::{
+    AccountReader, BlockHashReader, HashedPostStateProvider, StateProvider, StateRootProvider,
+};
+use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
+use reth_primitives_traits::{Account, Bytecode};
+use reth_storage_api::{
+    BytecodeReader, DBProvider, StateProofProvider, StorageRootProvider, StorageSettingsCache,
+};
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
+use reth_trie::{
+    hashed_cursor::HashedPostStateCursorFactory,
+    proof::{Proof, StorageProof},
+    trie_cursor::InMemoryTrieCursorFactory,
+    updates::TrieUpdates,
+    witness::TrieWitness,
+    AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, KeccakKeyHasher,
+    MultiProof, MultiProofTargets, StateRoot, StorageMultiProof, StorageRoot, TrieInput,
+    TrieInputSorted,
+};
+use reth_trie_db::{DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot};
+
+type DbStateRoot<'a, TX, A> = StateRoot<
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+type DbStorageRoot<'a, TX, A> = StorageRoot<
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+type DbStorageProof<'a, TX, A> = StorageProof<
+    'static,
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+type DbProof<'a, TX, A> = Proof<
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+/// State provider over latest state that takes tx reference.
+///
+/// Wraps a [`DBProvider`] to get access to database.
+#[derive(Debug)]
+pub struct LatestStateProviderRef<'b, Provider>(&'b Provider);
+
+impl<'b, Provider: DBProvider> LatestStateProviderRef<'b, Provider> {
+    /// Create new state provider
+    pub const fn new(provider: &'b Provider) -> Self {
+        Self(provider)
+    }
+
+    fn tx(&self) -> &Provider::Tx {
+        self.0.tx_ref()
+    }
+
+    fn hashed_storage_lookup(
+        &self,
+        hashed_address: B256,
+        hashed_slot: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let mut cursor = self.tx().cursor_dup_read::<tables::HashedStorages>()?;
+        Ok(cursor
+            .seek_by_key_subkey(hashed_address, hashed_slot)?
+            .filter(|e| e.key == hashed_slot)
+            .map(|e| e.value))
+    }
+}
+
+impl<Provider: DBProvider + StorageSettingsCache> AccountReader
+    for LatestStateProviderRef<'_, Provider>
+{
+    /// Get basic account information.
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        if self.0.cached_storage_settings().use_hashed_state() {
+            let hashed_address = alloy_primitives::keccak256(address);
+            self.tx()
+                .get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)
+                .map_err(Into::into)
+        } else {
+            // [MANTLE PATCH] (hashed-snapshot exec fix): on a legacy (storage_v2=false) DB built via
+            // `init-state --without-evm` from a hashed-only snapshot, accounts whose address
+            // preimage was unavailable live ONLY in `HashedAccounts` (never in `PlainAccountState`).
+            // The plain lookup below misses them and returns None → the executor reads their balance
+            // as 0 → stateRoot diverges → consensus fork. When the hashed-snapshot marker is set,
+            // fall back to the hashed table so execution reads the real value. This only triggers on
+            // snapshot-imported DBs; ordinary legacy DBs always hit plain and never reach the fallback.
+            if let Some(account) =
+                self.tx().get_by_encoded_key::<tables::PlainAccountState>(address)?
+            {
+                return Ok(Some(account));
+            }
+            if super::has_hashed_snapshot_marker(self.tx())? {
+                let hashed_address = alloy_primitives::keccak256(address);
+                return self
+                    .tx()
+                    .get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)
+                    .map_err(Into::into);
+            }
+            Ok(None)
+        }
+    }
+}
+
+impl<Provider: BlockHashReader> BlockHashReader for LatestStateProviderRef<'_, Provider> {
+    /// Get block hash by number.
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.0.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.0.canonical_hashes_range(start, end)
+    }
+}
+
+impl<Provider: DBProvider + StorageSettingsCache> StateRootProvider
+    for LatestStateProviderRef<'_, Provider>
+{
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            let sorted = hashed_state.into_sorted();
+            Ok(<DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root(self.tx(), &sorted)?)
+        })
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            Ok(<DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes(
+                self.tx(),
+                TrieInputSorted::from_unsorted(input),
+            )?)
+        })
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            let sorted = hashed_state.into_sorted();
+            Ok(<DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_with_updates(
+                self.tx(),
+                &sorted,
+            )?)
+        })
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            Ok(
+                <DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes_with_updates(
+                    self.tx(),
+                    TrieInputSorted::from_unsorted(input),
+                )?,
+            )
+        })
+    }
+}
+
+impl<Provider: DBProvider + StorageSettingsCache> StorageRootProvider
+    for LatestStateProviderRef<'_, Provider>
+{
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            <DbStorageRoot<'_, _, A>>::overlay_root(self.tx(), address, hashed_storage)
+                .map_err(|err| ProviderError::Database(err.into()))
+        })
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<reth_trie::StorageProof> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            <DbStorageProof<'_, _, A>>::overlay_storage_proof(
+                self.tx(),
+                address,
+                slot,
+                hashed_storage,
+            )
+            .map_err(ProviderError::from)
+        })
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(
+                self.tx(),
+                address,
+                slots,
+                hashed_storage,
+            )
+            .map_err(ProviderError::from)
+        })
+    }
+}
+
+impl<Provider: DBProvider + StorageSettingsCache> StateProofProvider
+    for LatestStateProviderRef<'_, Provider>
+{
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.tx());
+            proof.overlay_account_proof(input, address, slots).map_err(ProviderError::from)
+        })
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.tx());
+            proof.overlay_multiproof(input, targets).map_err(ProviderError::from)
+        })
+    }
+
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+        mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            let nodes_sorted = input.nodes.into_sorted();
+            let state_sorted = input.state.into_sorted();
+            let witness = TrieWitness::new(
+                InMemoryTrieCursorFactory::new(
+                    reth_trie_db::DatabaseTrieCursorFactory::<_, A>::new(self.tx()),
+                    &nodes_sorted,
+                ),
+                HashedPostStateCursorFactory::new(
+                    reth_trie_db::DatabaseHashedCursorFactory::new(self.tx()),
+                    &state_sorted,
+                ),
+            )
+            .with_prefix_sets_mut(input.prefix_sets)
+            .with_execution_witness_mode(mode);
+            let witness =
+                if mode.is_canonical() { witness } else { witness.always_include_root_node() };
+            let mut values: Vec<_> = witness.compute(target)?.into_values().collect();
+            if mode.is_canonical() {
+                values.sort_unstable();
+            }
+            Ok(values)
+        })
+    }
+}
+
+impl<Provider: DBProvider> HashedPostStateProvider for LatestStateProviderRef<'_, Provider> {
+    fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+}
+
+impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvider
+    for LatestStateProviderRef<'_, Provider>
+{
+    /// Get storage by plain (unhashed) storage key slot.
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        if self.0.cached_storage_settings().use_hashed_state() {
+            self.hashed_storage_lookup(
+                alloy_primitives::keccak256(account),
+                alloy_primitives::keccak256(storage_key),
+            )
+        } else {
+            let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
+            if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)? &&
+                entry.key == storage_key
+            {
+                return Ok(Some(entry.value));
+            }
+            // [MANTLE PATCH] (hashed-snapshot exec fix): mirror basic_account. Storage of a
+            // preimage-less account imported from a hashed-only snapshot lives only in
+            // `HashedStorages`. Fall back to it when the marker is set so execution reads the
+            // real slot value instead of 0.
+            if super::has_hashed_snapshot_marker(self.tx())? {
+                return self.hashed_storage_lookup(
+                    alloy_primitives::keccak256(account),
+                    alloy_primitives::keccak256(storage_key),
+                );
+            }
+            Ok(None)
+        }
+    }
+}
+
+impl<Provider: DBProvider + BlockHashReader> BytecodeReader
+    for LatestStateProviderRef<'_, Provider>
+{
+    /// Get account code by its hash
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
+    }
+}
+
+/// State provider for the latest state.
+#[derive(Debug)]
+pub struct LatestStateProvider<Provider>(Provider);
+
+impl<Provider: DBProvider> LatestStateProvider<Provider> {
+    /// Create new state provider
+    pub const fn new(db: Provider) -> Self {
+        Self(db)
+    }
+
+    /// Returns a new provider that takes the `TX` as reference
+    #[inline(always)]
+    const fn as_ref(&self) -> LatestStateProviderRef<'_, Provider> {
+        LatestStateProviderRef::new(&self.0)
+    }
+}
+
+// Delegates all provider impls to [LatestStateProviderRef]
+reth_storage_api::macros::delegate_provider_impls!(LatestStateProvider<Provider> where [Provider: DBProvider + BlockHashReader + StorageSettingsCache]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{create_test_provider_factory, MockNodeTypesWithDB};
+    use crate::ProviderFactory;
+    use alloy_primitives::{address, b256, keccak256, U256};
+    use reth_db_api::{
+        models::StorageSettings,
+        tables,
+        transaction::{DbTx, DbTxMut},
+    };
+    use reth_primitives_traits::StorageEntry;
+    use reth_storage_api::StorageSettingsCache;
+
+    const fn assert_state_provider<T: StateProvider>() {}
+    #[expect(dead_code)]
+    const fn assert_latest_state_provider<
+        T: DBProvider + BlockHashReader + StorageSettingsCache,
+    >() {
+        assert_state_provider::<LatestStateProvider<T>>();
+    }
+
+    #[test]
+    fn test_latest_storage_hashed_state() {
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let address = address!("0x0000000000000000000000000000000000000001");
+        let slot = b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        let hashed_address = keccak256(address);
+        let hashed_slot = keccak256(slot);
+
+        let tx = factory.provider_rw().unwrap().into_tx();
+        tx.put::<tables::HashedStorages>(
+            hashed_address,
+            StorageEntry { key: hashed_slot, value: U256::from(42) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+        let provider_ref = LatestStateProviderRef::new(&db);
+
+        assert_eq!(provider_ref.storage(address, slot).unwrap(), Some(U256::from(42)));
+
+        let other_address = address!("0x0000000000000000000000000000000000000099");
+        let other_slot =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+        assert_eq!(provider_ref.storage(other_address, other_slot).unwrap(), None);
+
+        let tx = factory.provider_rw().unwrap().into_tx();
+        let plain_address = address!("0x0000000000000000000000000000000000000002");
+        let plain_slot =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000002");
+        tx.put::<tables::PlainStorageState>(
+            plain_address,
+            StorageEntry { key: plain_slot, value: U256::from(99) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+        let provider_ref = LatestStateProviderRef::new(&db);
+        assert_eq!(provider_ref.storage(plain_address, plain_slot).unwrap(), None);
+    }
+
+    #[test]
+    fn test_latest_storage_hashed_state_returns_none_for_missing() {
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let address = address!("0x0000000000000000000000000000000000000001");
+        let slot = b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        let db = factory.provider().unwrap();
+        let provider_ref = LatestStateProviderRef::new(&db);
+        assert_eq!(provider_ref.storage(address, slot).unwrap(), None);
+    }
+
+    #[test]
+    fn test_latest_storage_legacy() {
+        let factory = create_test_provider_factory();
+        assert!(!factory.provider().unwrap().cached_storage_settings().use_hashed_state());
+
+        let address = address!("0x0000000000000000000000000000000000000001");
+        let slot = b256!("0x0000000000000000000000000000000000000000000000000000000000000005");
+
+        let tx = factory.provider_rw().unwrap().into_tx();
+        tx.put::<tables::PlainStorageState>(
+            address,
+            StorageEntry { key: slot, value: U256::from(42) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+        let provider_ref = LatestStateProviderRef::new(&db);
+
+        assert_eq!(provider_ref.storage(address, slot).unwrap(), Some(U256::from(42)));
+
+        let other_slot =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+        assert_eq!(provider_ref.storage(address, other_slot).unwrap(), None);
+    }
+
+    #[test]
+    fn test_latest_storage_legacy_does_not_read_hashed() {
+        let factory = create_test_provider_factory();
+        assert!(!factory.provider().unwrap().cached_storage_settings().use_hashed_state());
+
+        let address = address!("0x0000000000000000000000000000000000000001");
+        let slot = b256!("0x0000000000000000000000000000000000000000000000000000000000000005");
+        let hashed_address = keccak256(address);
+        let hashed_slot = keccak256(slot);
+
+        let tx = factory.provider_rw().unwrap().into_tx();
+        tx.put::<tables::HashedStorages>(
+            hashed_address,
+            StorageEntry { key: hashed_slot, value: U256::from(42) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+        let provider_ref = LatestStateProviderRef::new(&db);
+        assert_eq!(provider_ref.storage(address, slot).unwrap(), None);
+    }
+
+    // ==================== [MANTLE PATCH] hashed-snapshot exec-read fallback ====================
+    // Coverage matrix for the fix. Legacy layout (storage_v2=false) is the rpc41/init-state case.
+    // The marker (`__hashed_only_state_snapshot__`) gates whether a plain-state miss falls back to
+    // the hashed tables. These tests pin the full behavior matrix so the fix can't silently regress
+    // into either the v1.9.3 bug (historical RPC) or the pre-fix v2.2.1 bug (execution fork).
+
+    /// Writes the hashed-snapshot marker so `has_hashed_snapshot_marker` returns true.
+    fn set_hashed_snapshot_marker(factory: &ProviderFactory<MockNodeTypesWithDB>) {
+        let tx = factory.provider_rw().unwrap().into_tx();
+        tx.put::<tables::StageCheckpointProgresses>(
+            super::super::HASHED_SNAPSHOT_MARKER.to_string(),
+            vec![1u8],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+    }
+
+    const A: Address = address!("0x00000000000000000000000000000000000000aa");
+
+    fn put_hashed_account(factory: &ProviderFactory<MockNodeTypesWithDB>, addr: Address, bal: u64) {
+        let tx = factory.provider_rw().unwrap().into_tx();
+        tx.put::<tables::HashedAccounts>(
+            keccak256(addr),
+            Account { nonce: 0, balance: U256::from(bal), bytecode_hash: None },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+    }
+
+    fn put_plain_account(factory: &ProviderFactory<MockNodeTypesWithDB>, addr: Address, bal: u64) {
+        let tx = factory.provider_rw().unwrap().into_tx();
+        tx.put::<tables::PlainAccountState>(
+            addr,
+            Account { nonce: 0, balance: U256::from(bal), bytecode_hash: None },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+    }
+
+    /// 缺原像账户（只在 HashedAccounts），legacy + 无 marker → 返回 None（保留旧语义，防回归）。
+    #[test]
+    fn basic_account_legacy_no_marker_ignores_hashed() {
+        let factory = create_test_provider_factory();
+        assert!(!factory.provider().unwrap().cached_storage_settings().use_hashed_state());
+        put_hashed_account(&factory, A, 100);
+
+        let db = factory.provider().unwrap();
+        assert_eq!(LatestStateProviderRef::new(&db).basic_account(&A).unwrap(), None);
+    }
+
+    /// 缺原像账户，legacy + 有 marker → 回退读 HashedAccounts，返回真实值（修复行为，修分叉）。
+    #[test]
+    fn basic_account_legacy_marker_reads_hashed() {
+        let factory = create_test_provider_factory();
+        put_hashed_account(&factory, A, 100);
+        set_hashed_snapshot_marker(&factory);
+
+        let db = factory.provider().unwrap();
+        let acc = LatestStateProviderRef::new(&db).basic_account(&A).unwrap();
+        assert_eq!(acc.map(|a| a.balance), Some(U256::from(100)));
+    }
+
+    /// 有原像的普通账户（在 PlainAccountState），legacy + 有 marker → 仍读 plain，marker 不干扰。
+    #[test]
+    fn basic_account_legacy_marker_prefers_plain() {
+        let factory = create_test_provider_factory();
+        put_plain_account(&factory, A, 55);
+        // 同时在 hashed 放一个不同值，确认命中的是 plain 而非 hashed。
+        put_hashed_account(&factory, A, 999);
+        set_hashed_snapshot_marker(&factory);
+
+        let db = factory.provider().unwrap();
+        let acc = LatestStateProviderRef::new(&db).basic_account(&A).unwrap();
+        assert_eq!(acc.map(|a| a.balance), Some(U256::from(55)));
+    }
+
+    /// 全新/从不存在的账户，legacy + 有 marker + 两表皆无 → 返回 None（不会误报，仍正确返 0）。
+    #[test]
+    fn basic_account_legacy_marker_absent_account_is_none() {
+        let factory = create_test_provider_factory();
+        set_hashed_snapshot_marker(&factory);
+
+        let db = factory.provider().unwrap();
+        assert_eq!(LatestStateProviderRef::new(&db).basic_account(&A).unwrap(), None);
+    }
+
+    /// storage：缺原像账户的槽只在 HashedStorages，legacy + 有 marker → 回退读到真实值。
+    #[test]
+    fn storage_legacy_marker_reads_hashed() {
+        let factory = create_test_provider_factory();
+        let slot = b256!("0x0000000000000000000000000000000000000000000000000000000000000005");
+        let tx = factory.provider_rw().unwrap().into_tx();
+        tx.put::<tables::HashedStorages>(
+            keccak256(A),
+            StorageEntry { key: keccak256(slot), value: U256::from(42) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        set_hashed_snapshot_marker(&factory);
+
+        let db = factory.provider().unwrap();
+        assert_eq!(
+            LatestStateProviderRef::new(&db).storage(A, slot).unwrap(),
+            Some(U256::from(42))
+        );
+    }
+
+    /// storage：全新槽，legacy + 有 marker + 两表皆无 → 返回 None。
+    #[test]
+    fn storage_legacy_marker_absent_slot_is_none() {
+        let factory = create_test_provider_factory();
+        set_hashed_snapshot_marker(&factory);
+        let slot = b256!("0x0000000000000000000000000000000000000000000000000000000000000005");
+
+        let db = factory.provider().unwrap();
+        assert_eq!(LatestStateProviderRef::new(&db).storage(A, slot).unwrap(), None);
+    }
+}

--- a/patches/reth-provider/src/providers/state/mod.rs
+++ b/patches/reth-provider/src/providers/state/mod.rs
@@ -1,0 +1,32 @@
+//! [`StateProvider`](crate::StateProvider) implementations
+pub(crate) mod historical;
+pub(crate) mod latest;
+pub(crate) mod overlay;
+
+use crate::ProviderResult;
+use reth_db_api::{tables, transaction::DbTx};
+use reth_stages_types::StageId;
+
+// ==================== [MANTLE PATCH] hashed-snapshot marker ====================
+// Entire block below is a Mantle addition (absent in upstream reth-provider). It lets the
+// execution-path reads in `latest.rs` recognize a DB built from a hashed-only state snapshot
+// and fall back to the hashed tables for preimage-less accounts. See latest.rs for the rationale.
+
+/// DB-key identifying a database that was initialized from a hashed-only state snapshot
+/// (`init-state --without-evm` where some accounts lacked an address preimage). Stored in
+/// [`tables::StageCheckpointProgresses`] under this custom [`StageId`]. Matches the key written by
+/// the v1.9.3 init-state path so a DB built by either version is recognized. `[MANTLE PATCH]`
+pub(crate) const HASHED_SNAPSHOT_MARKER: StageId = StageId::Other("__hashed_only_state_snapshot__");
+
+/// Returns `true` if this database was built from a hashed-only state snapshot, i.e. it may contain
+/// accounts/storage that exist only in the hashed tables (no plain-state / address preimage).
+///
+/// Execution-path reads ([`latest::LatestStateProviderRef`]) consult this to fall back to the
+/// hashed tables when a plain lookup misses, so preimage-less accounts are read at their real value
+/// instead of 0 (which would diverge the state root and fork the chain). `[MANTLE PATCH]`
+pub(crate) fn has_hashed_snapshot_marker<TX: DbTx>(tx: &TX) -> ProviderResult<bool> {
+    tx.get::<tables::StageCheckpointProgresses>(HASHED_SNAPSHOT_MARKER.to_string())
+        .map(|marker| marker.is_some())
+        .map_err(Into::into)
+}
+

--- a/patches/reth-provider/src/providers/state/overlay.rs
+++ b/patches/reth-provider/src/providers/state/overlay.rs
@@ -1,0 +1,653 @@
+use alloy_eips::BlockNumHash;
+use alloy_primitives::{BlockHash, BlockNumber, B256};
+use metrics::{Counter, Histogram};
+use reth_chain_state::{EthPrimitives, LazyOverlay};
+use reth_db_api::{tables, transaction::DbTx, DatabaseError};
+use reth_errors::{ProviderError, ProviderResult};
+use reth_metrics::Metrics;
+use reth_primitives_traits::{
+    dashmap::{self, DashMap},
+    NodePrimitives,
+};
+use reth_prune_types::PruneSegment;
+use reth_stages_types::StageId;
+use reth_storage_api::{
+    BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
+    DatabaseProviderROFactory, PruneCheckpointReader, StageCheckpointReader,
+    StorageChangeSetReader, StorageSettingsCache,
+};
+use reth_trie::{
+    hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
+    trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
+    updates::TrieUpdatesSorted,
+    HashedPostStateSorted,
+};
+use reth_trie_db::{
+    ChangesetCache, DatabaseAccountTrieCursor, DatabaseHashedCursorFactory,
+    DatabaseStorageTrieCursor, LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter,
+    PackedStoragesTrie,
+};
+use std::{
+    ops::RangeInclusive,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tracing::{debug, debug_span, instrument};
+
+/// Metrics for overlay state provider operations.
+#[derive(Clone, Metrics)]
+#[metrics(scope = "storage.providers.overlay")]
+pub(crate) struct OverlayStateProviderMetrics {
+    /// Duration of creating the database provider transaction
+    create_provider_duration: Histogram,
+    /// Duration of retrieving trie updates from the database
+    retrieve_trie_reverts_duration: Histogram,
+    /// Duration of retrieving hashed state from the database
+    retrieve_hashed_state_reverts_duration: Histogram,
+    /// Size of trie updates (number of entries)
+    trie_updates_size: Histogram,
+    /// Size of hashed state (number of entries)
+    hashed_state_size: Histogram,
+    /// Overall duration of the [`OverlayStateProviderFactory::database_provider_ro`] call
+    database_provider_ro_duration: Histogram,
+    /// Number of cache misses when fetching [`Overlay`]s from the overlay cache.
+    overlay_cache_misses: Counter,
+}
+
+/// Contains all fields required to initialize an [`OverlayStateProvider`].
+#[derive(Debug, Clone)]
+pub(super) struct Overlay {
+    pub(super) trie_updates: Arc<TrieUpdatesSorted>,
+    pub(super) hashed_post_state: Arc<HashedPostStateSorted>,
+}
+
+/// Source of overlay data for [`OverlayStateProviderFactory`].
+///
+/// Either provides immediate pre-computed overlay data, or a lazy overlay that computes
+/// on first access.
+#[derive(Debug, Clone)]
+pub(super) enum OverlaySource<N: NodePrimitives = EthPrimitives> {
+    /// Immediate overlay with already-computed data.
+    Immediate {
+        /// Trie updates overlay.
+        trie: Arc<TrieUpdatesSorted>,
+        /// Hashed state overlay.
+        state: Arc<HashedPostStateSorted>,
+    },
+    /// Lazy overlay computed on first access.
+    Lazy(LazyOverlay<N>),
+}
+
+/// Builder for calculating trie and hashed-state overlays.
+///
+/// This stores the overlay configuration and the logic for resolving immediate/lazy overlays and
+/// collecting reverts. It is intentionally independent from any provider factory or overlay cache.
+#[derive(Debug, Clone)]
+pub struct OverlayBuilder<N: NodePrimitives = EthPrimitives> {
+    /// Anchor hash to revert the DB state to before applying overlays.
+    anchor_hash: B256,
+    /// Optional overlay source (lazy or immediate).
+    overlay_source: Option<OverlaySource<N>>,
+    /// Changeset cache handle for retrieving trie changesets
+    changeset_cache: ChangesetCache,
+    /// Metrics for tracking provider operations
+    metrics: OverlayStateProviderMetrics,
+}
+
+impl<N: NodePrimitives> OverlayBuilder<N> {
+    /// Create a new overlay builder.
+    pub fn new(anchor_hash: B256, changeset_cache: ChangesetCache) -> Self {
+        Self {
+            anchor_hash,
+            overlay_source: None,
+            changeset_cache,
+            metrics: OverlayStateProviderMetrics::default(),
+        }
+    }
+
+    /// Set the overlay source (lazy or immediate).
+    ///
+    /// This overlay will be applied on top of any reverts applied via `anchor_hash`.
+    pub(super) fn with_overlay_source(mut self, source: Option<OverlaySource<N>>) -> Self {
+        if let Some(OverlaySource::Lazy(lazy_overlay)) = source.as_ref() {
+            self.assert_lazy_overlay_anchor(lazy_overlay);
+        }
+        self.overlay_source = source;
+        self
+    }
+
+    fn assert_lazy_overlay_anchor(&self, lazy_overlay: &LazyOverlay<N>) {
+        let Some(lazy_overlay_anchor) = lazy_overlay.anchor_hash() else { return };
+        assert!(
+            lazy_overlay_anchor == self.anchor_hash,
+            "LazyOverlay's anchor ({}) != OverlayBuilder's anchor ({})",
+            lazy_overlay_anchor,
+            self.anchor_hash,
+        );
+    }
+
+    /// Set a lazy overlay that will be computed on first access.
+    ///
+    /// Panics if the [`LazyOverlay`]'s anchor hash does not match [`Self`]'s `anchor_hash`.
+    pub fn with_lazy_overlay(mut self, lazy_overlay: Option<LazyOverlay<N>>) -> Self {
+        if let Some(lazy_overlay) = lazy_overlay.as_ref() {
+            self.assert_lazy_overlay_anchor(lazy_overlay);
+        }
+        self.overlay_source = lazy_overlay.map(OverlaySource::Lazy);
+        self
+    }
+
+    /// Set the hashed state overlay.
+    pub fn with_hashed_state_overlay(
+        mut self,
+        hashed_state_overlay: Option<Arc<HashedPostStateSorted>>,
+    ) -> Self {
+        if let Some(state) = hashed_state_overlay {
+            self.overlay_source = Some(OverlaySource::Immediate {
+                trie: Arc::new(TrieUpdatesSorted::default()),
+                state,
+            });
+        }
+        self
+    }
+
+    /// Extends the existing hashed state overlay with the given [`HashedPostStateSorted`].
+    ///
+    /// If no overlay exists, creates a new immediate overlay with the given state.
+    /// If a lazy overlay exists, it is resolved first then extended.
+    pub fn with_extended_hashed_state_overlay(mut self, other: HashedPostStateSorted) -> Self {
+        match &mut self.overlay_source {
+            Some(OverlaySource::Immediate { state, .. }) => {
+                Arc::make_mut(state).extend_ref_and_sort(&other);
+            }
+            Some(OverlaySource::Lazy(overlay)) => {
+                // Resolve lazy overlay and convert to immediate with extension
+                let (trie, mut state) = overlay.as_overlay(self.anchor_hash);
+                Arc::make_mut(&mut state).extend_ref_and_sort(&other);
+                self.overlay_source = Some(OverlaySource::Immediate { trie, state });
+            }
+            None => {
+                self.overlay_source = Some(OverlaySource::Immediate {
+                    trie: Arc::new(TrieUpdatesSorted::default()),
+                    state: Arc::new(other),
+                });
+            }
+        }
+        self
+    }
+
+    /// Resolves the effective overlay (trie updates, hashed state).
+    ///
+    /// If an overlay source is set, it is resolved (blocking if lazy).
+    /// Otherwise, returns empty defaults.
+    fn resolve_overlays(
+        &self,
+        anchor_hash: BlockHash,
+    ) -> ProviderResult<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>)> {
+        match &self.overlay_source {
+            Some(OverlaySource::Lazy(lazy_overlay)) => Ok(lazy_overlay.as_overlay(anchor_hash)),
+            Some(OverlaySource::Immediate { trie, state }) => {
+                if anchor_hash != self.anchor_hash {
+                    return Err(ProviderError::other(std::io::Error::other(format!(
+                        "anchor_hash {anchor_hash} doesn't match OverlayBuilder's configured anchor ({})",
+                        self.anchor_hash
+                    ))))
+                }
+                Ok((Arc::clone(trie), Arc::clone(state)))
+            }
+            None => Ok((
+                Arc::new(TrieUpdatesSorted::default()),
+                Arc::new(HashedPostStateSorted::default()),
+            )),
+        }
+    }
+
+    /// Returns the block number for [`Self`]'s `anchor_hash` field.
+    fn get_block_number<Provider>(&self, provider: &Provider) -> ProviderResult<BlockNumber>
+    where
+        Provider: BlockNumReader,
+    {
+        provider
+            .convert_hash_or_number(self.anchor_hash.into())?
+            .ok_or(ProviderError::BlockHashNotFound(self.anchor_hash))
+    }
+
+    /// Returns the block which is at the tip of the DB, i.e. the block which the state tables of
+    /// the DB are currently synced to.
+    fn get_db_tip_block<Provider>(&self, provider: &Provider) -> ProviderResult<BlockNumHash>
+    where
+        Provider: StageCheckpointReader + BlockNumReader,
+    {
+        let block_number = provider
+            .get_stage_checkpoint(StageId::Finish)?
+            .as_ref()
+            .map(|chk| chk.block_number)
+            .ok_or_else(|| ProviderError::InsufficientChangesets {
+                requested: 0,
+                available: 0..=0,
+            })?;
+        let hash = provider
+            .convert_number(block_number.into())?
+            .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;
+        Ok(BlockNumHash::new(block_number, hash))
+    }
+
+    /// Returns whether or not it is required to collect reverts, and validates that there are
+    /// sufficient changesets to revert to the requested block number if so.
+    ///
+    /// Takes into account both the stage checkpoint and the prune checkpoint to determine the
+    /// available data range.
+    fn reverts_required<Provider>(
+        &self,
+        provider: &Provider,
+        db_tip_block: BlockNumHash,
+    ) -> ProviderResult<Option<RangeInclusive<BlockNumber>>>
+    where
+        Provider: BlockNumReader + PruneCheckpointReader,
+    {
+        // If the anchor is the DB tip then there won't be any reverts necessary.
+        if db_tip_block.hash == self.anchor_hash {
+            return Ok(None)
+        }
+
+        // If the DB tip has moved forward into the `LazyOverlay` then we still don't need to
+        // revert, the `LazyOverlay` will generate a new in-memory overlay using only the relevant
+        // blocks data.
+        if let Some(OverlaySource::Lazy(lazy_overlay)) = &self.overlay_source &&
+            lazy_overlay.has_anchor_hash(db_tip_block.hash)
+        {
+            return Ok(None)
+        }
+
+        let anchor_number = self.get_block_number(provider)?;
+
+        // Check account history prune checkpoint to determine the lower bound of available data.
+        // The prune checkpoint's block_number is the highest pruned block, so data is available
+        // starting from the next block.
+        let prune_checkpoint = provider.get_prune_checkpoint(PruneSegment::AccountHistory)?;
+        let lower_bound = prune_checkpoint
+            .and_then(|chk| chk.block_number)
+            .map(|block_number| block_number + 1)
+            .unwrap_or_default();
+
+        let available_range = lower_bound..=db_tip_block.number;
+
+        // Check if the requested block is within the available range
+        if !available_range.contains(&anchor_number) {
+            return Err(ProviderError::InsufficientChangesets {
+                requested: anchor_number,
+                available: available_range,
+            });
+        }
+
+        Ok(Some(anchor_number + 1..=db_tip_block.number))
+    }
+
+    /// Calculates a new [`Overlay`] given a transaction and the current db tip.
+    #[instrument(
+        level = "debug",
+        target = "providers::state::overlay",
+        skip_all,
+        fields(?db_tip_block, anchor_hash = ?self.anchor_hash)
+    )]
+    fn calculate_overlay<Provider>(
+        &self,
+        provider: &Provider,
+        db_tip_block: BlockNumHash,
+    ) -> ProviderResult<Overlay>
+    where
+        Provider: ChangeSetReader
+            + StorageChangeSetReader
+            + DBProvider
+            + BlockNumReader
+            + StageCheckpointReader
+            + PruneCheckpointReader
+            + StorageSettingsCache,
+    {
+        //
+        // Set up variables we'll use for recording metrics. There's two different code-paths here,
+        // and we want to make sure both record metrics, so we do metrics recording after.
+        let retrieve_trie_reverts_duration;
+        let retrieve_hashed_state_reverts_duration;
+        let trie_updates_total_len;
+        let hashed_state_updates_total_len;
+
+        // Collect any reverts which are required to bring the DB view back to the anchor hash.
+        let (trie_updates, hashed_post_state) = if let Some(revert_blocks) =
+            self.reverts_required(provider, db_tip_block)?
+        {
+            debug!(
+                target: "providers::state::overlay",
+                ?revert_blocks,
+                "Collecting trie reverts for overlay state provider"
+            );
+
+            // Collect trie reverts using changeset cache
+            let mut trie_reverts = {
+                let _guard =
+                    debug_span!(target: "providers::state::overlay", "retrieving_trie_reverts")
+                        .entered();
+
+                let start = Instant::now();
+
+                // Use changeset cache to retrieve and accumulate reverts to restore state after
+                // from_block
+                let accumulated_reverts =
+                    self.changeset_cache.get_or_compute_range(provider, revert_blocks.clone())?;
+
+                retrieve_trie_reverts_duration = start.elapsed();
+                accumulated_reverts
+            };
+
+            // Collect state reverts
+            let mut hashed_state_reverts = {
+                let _guard = debug_span!(target: "providers::state::overlay", "retrieving_hashed_state_reverts").entered();
+
+                let start = Instant::now();
+                let res = reth_trie_db::from_reverts_auto(provider, revert_blocks)?;
+                retrieve_hashed_state_reverts_duration = start.elapsed();
+                res
+            };
+
+            // Resolve overlays (lazy or immediate) and extend reverts with them.
+            // If reverts are empty, use overlays directly to avoid cloning.
+            let (overlay_trie, overlay_state) = self.resolve_overlays(self.anchor_hash)?;
+
+            let trie_updates = if trie_reverts.is_empty() {
+                overlay_trie
+            } else if !overlay_trie.is_empty() {
+                trie_reverts.extend_ref_and_sort(&overlay_trie);
+                Arc::new(trie_reverts)
+            } else {
+                Arc::new(trie_reverts)
+            };
+
+            let hashed_state_updates = if hashed_state_reverts.is_empty() {
+                overlay_state
+            } else if !overlay_state.is_empty() {
+                hashed_state_reverts.extend_ref_and_sort(&overlay_state);
+                Arc::new(hashed_state_reverts)
+            } else {
+                Arc::new(hashed_state_reverts)
+            };
+
+            trie_updates_total_len = trie_updates.total_len();
+            hashed_state_updates_total_len = hashed_state_updates.total_len();
+
+            debug!(
+                target: "providers::state::overlay",
+                num_trie_updates = ?trie_updates_total_len,
+                num_state_updates = ?hashed_state_updates_total_len,
+                "Reverted to target block",
+            );
+
+            (trie_updates, hashed_state_updates)
+        } else {
+            // If no reverts are needed then we can assume that the db tip is the anchor hash or
+            // overlaps with the `LazyOverlay`. Use overlays directly.
+            let (trie_updates, hashed_state) = self.resolve_overlays(db_tip_block.hash)?;
+
+            retrieve_trie_reverts_duration = Duration::ZERO;
+            retrieve_hashed_state_reverts_duration = Duration::ZERO;
+            trie_updates_total_len = trie_updates.total_len();
+            hashed_state_updates_total_len = hashed_state.total_len();
+
+            (trie_updates, hashed_state)
+        };
+
+        // Record metrics
+        self.metrics
+            .retrieve_trie_reverts_duration
+            .record(retrieve_trie_reverts_duration.as_secs_f64());
+        self.metrics
+            .retrieve_hashed_state_reverts_duration
+            .record(retrieve_hashed_state_reverts_duration.as_secs_f64());
+        self.metrics.trie_updates_size.record(trie_updates_total_len as f64);
+        self.metrics.hashed_state_size.record(hashed_state_updates_total_len as f64);
+
+        Ok(Overlay { trie_updates, hashed_post_state })
+    }
+
+    /// Builds the effective overlay for the given provider.
+    #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
+    pub(super) fn build_overlay<Provider>(&self, provider: &Provider) -> ProviderResult<Overlay>
+    where
+        Provider: StageCheckpointReader
+            + PruneCheckpointReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + DBProvider
+            + BlockNumReader
+            + StorageSettingsCache,
+    {
+        let db_tip_block = self.get_db_tip_block(provider)?;
+        self.calculate_overlay(provider, db_tip_block)
+    }
+}
+
+/// Factory for creating overlay state providers with optional reverts and overlays.
+///
+/// This factory allows building an `OverlayStateProvider` whose DB state has been reverted to a
+/// particular block, and/or with additional overlay information added on top.
+#[derive(Debug, Clone)]
+pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
+    /// The underlying database provider factory
+    factory: F,
+    /// Overlay builder containing the configuration and overlay calculation logic.
+    overlay_builder: OverlayBuilder<N>,
+    /// A cache which maps `db_tip -> Overlay`. If the db tip changes during usage of the factory
+    /// then a new entry will get added to this, but in most cases only one entry is present.
+    overlay_cache: Arc<DashMap<BlockHash, Overlay>>,
+}
+
+impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
+    /// Create a new overlay state provider factory
+    pub fn new(factory: F, overlay_builder: OverlayBuilder<N>) -> Self {
+        Self { factory, overlay_builder, overlay_cache: Default::default() }
+    }
+
+    /// Set a lazy overlay that will be computed on first access.
+    pub fn with_lazy_overlay(mut self, lazy_overlay: Option<LazyOverlay<N>>) -> Self {
+        self.overlay_builder = self.overlay_builder.with_lazy_overlay(lazy_overlay);
+        self.overlay_cache = Default::default();
+        self
+    }
+
+    /// Set the hashed state overlay.
+    pub fn with_hashed_state_overlay(
+        mut self,
+        hashed_state_overlay: Option<Arc<HashedPostStateSorted>>,
+    ) -> Self {
+        self.overlay_builder = self.overlay_builder.with_hashed_state_overlay(hashed_state_overlay);
+        self.overlay_cache = Default::default();
+        self
+    }
+
+    /// Extends the existing hashed state overlay with the given [`HashedPostStateSorted`].
+    pub fn with_extended_hashed_state_overlay(mut self, other: HashedPostStateSorted) -> Self {
+        self.overlay_builder = self.overlay_builder.with_extended_hashed_state_overlay(other);
+        self.overlay_cache = Default::default();
+        self
+    }
+
+    /// Fetches an [`Overlay`] from the cache based on the current db tip block. If there is no
+    /// cached value then this calculates the [`Overlay`] and populates the cache.
+    #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
+    fn get_overlay<Provider>(&self, provider: &Provider) -> ProviderResult<Overlay>
+    where
+        Provider: StageCheckpointReader
+            + PruneCheckpointReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + DBProvider
+            + BlockNumReader
+            + StorageSettingsCache,
+    {
+        let db_tip_block = self.overlay_builder.get_db_tip_block(provider)?;
+
+        let overlay = match self.overlay_cache.entry(db_tip_block.hash) {
+            dashmap::Entry::Occupied(entry) => entry.get().clone(),
+            dashmap::Entry::Vacant(entry) => {
+                self.overlay_builder.metrics.overlay_cache_misses.increment(1);
+                let overlay = self.overlay_builder.build_overlay(provider)?;
+                entry.insert(overlay.clone());
+                overlay
+            }
+        };
+
+        Ok(overlay)
+    }
+}
+
+impl<F, N> DatabaseProviderROFactory for OverlayStateProviderFactory<F, N>
+where
+    N: NodePrimitives,
+    F: DatabaseProviderFactory,
+    F::Provider: StageCheckpointReader
+        + PruneCheckpointReader
+        + DBProvider
+        + BlockNumReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + StorageSettingsCache,
+{
+    type Provider = OverlayStateProvider<F::Provider>;
+
+    /// Create a read-only [`OverlayStateProvider`].
+    #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
+    fn database_provider_ro(&self) -> ProviderResult<OverlayStateProvider<F::Provider>> {
+        let overall_start = Instant::now();
+
+        // Get a read-only provider
+        let provider = {
+            let start = Instant::now();
+            let res = self.factory.database_provider_ro()?;
+            self.overlay_builder.metrics.create_provider_duration.record(start.elapsed());
+            res
+        };
+
+        let Overlay { trie_updates, hashed_post_state } = self.get_overlay(&provider)?;
+
+        let is_v2 = provider.cached_storage_settings().is_v2();
+        self.overlay_builder.metrics.database_provider_ro_duration.record(overall_start.elapsed());
+        Ok(OverlayStateProvider::new(provider, trie_updates, hashed_post_state, is_v2))
+    }
+}
+
+/// State provider with in-memory overlay from trie updates and hashed post state.
+///
+/// This provider uses in-memory trie updates and hashed post state as an overlay
+/// on top of a database provider, implementing [`TrieCursorFactory`] and [`HashedCursorFactory`]
+/// using the in-memory overlay factories.
+#[derive(Debug)]
+pub struct OverlayStateProvider<Provider: DBProvider> {
+    provider: Provider,
+    trie_updates: Arc<TrieUpdatesSorted>,
+    hashed_post_state: Arc<HashedPostStateSorted>,
+    is_v2: bool,
+}
+
+impl<Provider> OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+{
+    /// Create new overlay state provider. The `Provider` must be cloneable, which generally means
+    /// it should be wrapped in an `Arc`.
+    pub const fn new(
+        provider: Provider,
+        trie_updates: Arc<TrieUpdatesSorted>,
+        hashed_post_state: Arc<HashedPostStateSorted>,
+        is_v2: bool,
+    ) -> Self {
+        Self { provider, trie_updates, hashed_post_state, is_v2 }
+    }
+}
+
+impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+    Provider::Tx: DbTx,
+{
+    type AccountTrieCursor<'a>
+        = InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>
+    where
+        Self: 'a;
+
+    type StorageTrieCursor<'a>
+        = InMemoryTrieCursor<'a, Box<dyn TrieStorageCursor + Send + 'a>>
+    where
+        Self: 'a;
+
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
+        let tx = self.provider.tx_ref();
+        let trie_updates = self.trie_updates.as_ref();
+        let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
+            Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
+                tx.cursor_read::<PackedAccountsTrie>()?,
+            ))
+        } else {
+            Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
+                tx.cursor_read::<tables::AccountsTrie>()?,
+            ))
+        };
+        Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
+        let tx = self.provider.tx_ref();
+        let trie_updates = self.trie_updates.as_ref();
+        let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
+            Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
+                tx.cursor_dup_read::<PackedStoragesTrie>()?,
+                hashed_address,
+            ))
+        } else {
+            Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
+                tx.cursor_dup_read::<tables::StoragesTrie>()?,
+                hashed_address,
+            ))
+        };
+        Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
+    }
+}
+
+impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+{
+    type AccountCursor<'a>
+        = <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        &'a Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::AccountCursor<'a>
+    where
+        Self: 'a;
+
+    type StorageCursor<'a>
+        = <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        &'a Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::StorageCursor<'a>
+    where
+        Self: 'a;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(self.provider.tx_ref());
+        let hashed_cursor_factory =
+            HashedPostStateCursorFactory::new(db_hashed_cursor_factory, &self.hashed_post_state);
+        hashed_cursor_factory.hashed_account_cursor()
+    }
+
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(self.provider.tx_ref());
+        let hashed_cursor_factory =
+            HashedPostStateCursorFactory::new(db_hashed_cursor_factory, &self.hashed_post_state);
+        hashed_cursor_factory.hashed_storage_cursor(hashed_address)
+    }
+}

--- a/patches/reth-provider/src/providers/static_file/jar.rs
+++ b/patches/reth-provider/src/providers/static_file/jar.rs
@@ -1,0 +1,396 @@
+use super::{
+    metrics::{StaticFileProviderMetrics, StaticFileProviderOperation},
+    LoadedJarRef,
+};
+use crate::{
+    to_range, BlockHashReader, BlockNumReader, HeaderProvider, ReceiptProvider,
+    TransactionsProvider,
+};
+use alloy_consensus::transaction::TransactionMeta;
+use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use reth_chainspec::ChainInfo;
+use reth_db::static_file::{
+    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TransactionMask,
+    TransactionSenderMask,
+};
+use reth_db_api::table::{Decompress, Value};
+use reth_node_types::NodePrimitives;
+use reth_primitives_traits::{SealedHeader, SignedTransaction};
+use reth_static_file_types::ChangesetOffset;
+use reth_storage_api::range_size_hint;
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
+use std::{
+    fmt::Debug,
+    ops::{Deref, RangeBounds, RangeInclusive},
+    sync::Arc,
+};
+/// Provider over a specific `NippyJar` and range.
+#[derive(Debug)]
+pub struct StaticFileJarProvider<'a, N> {
+    /// Main static file segment
+    jar: LoadedJarRef<'a>,
+    /// Another kind of static file segment to help query data from the main one.
+    auxiliary_jar: Option<Box<Self>>,
+    /// Metrics for the static files.
+    metrics: Option<Arc<StaticFileProviderMetrics>>,
+    /// Node primitives
+    _pd: std::marker::PhantomData<N>,
+}
+
+impl<'a, N: NodePrimitives> Deref for StaticFileJarProvider<'a, N> {
+    type Target = LoadedJarRef<'a>;
+    fn deref(&self) -> &Self::Target {
+        &self.jar
+    }
+}
+
+impl<'a, N: NodePrimitives> From<LoadedJarRef<'a>> for StaticFileJarProvider<'a, N> {
+    fn from(value: LoadedJarRef<'a>) -> Self {
+        StaticFileJarProvider {
+            jar: value,
+            auxiliary_jar: None,
+            metrics: None,
+            _pd: Default::default(),
+        }
+    }
+}
+
+impl<'a, N: NodePrimitives> StaticFileJarProvider<'a, N> {
+    /// Provides a cursor for more granular data access.
+    pub fn cursor<'b>(&'b self) -> ProviderResult<StaticFileCursor<'a>>
+    where
+        'b: 'a,
+    {
+        let result = StaticFileCursor::new(self.value(), self.mmap_handle())?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                self.segment(),
+                StaticFileProviderOperation::InitCursor,
+                None,
+            );
+        }
+
+        Ok(result)
+    }
+
+    /// Adds a new auxiliary static file to help query data from the main one
+    pub fn with_auxiliary(mut self, auxiliary_jar: Self) -> Self {
+        self.auxiliary_jar = Some(Box::new(auxiliary_jar));
+        self
+    }
+
+    /// Enables metrics on the provider.
+    pub fn with_metrics(mut self, metrics: Arc<StaticFileProviderMetrics>) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    /// Returns the total size of the data and offsets files (from the in-memory mmap).
+    pub fn size(&self) -> usize {
+        self.jar.value().size()
+    }
+
+    /// Reads a changeset offset from the sidecar file for a given block.
+    ///
+    /// Returns `None` if:
+    /// - The segment is not change-based
+    /// - The block is not in the block range
+    /// - The sidecar file doesn't exist
+    pub fn read_changeset_offset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Option<ChangesetOffset>> {
+        let header = self.user_header();
+        if !header.segment().is_change_based() {
+            return Ok(None);
+        }
+
+        let Some(index) = header.changeset_offset_index(block_number) else {
+            return Ok(None);
+        };
+
+        if let Some(reader) = self.jar.value().csoff_reader() {
+            reader.get(index).map_err(ProviderError::other)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Reads all changeset offsets from the sidecar file.
+    ///
+    /// Returns `None` if:
+    /// - The segment is not change-based
+    /// - The sidecar file doesn't exist
+    pub fn read_changeset_offsets(&self) -> ProviderResult<Option<Vec<ChangesetOffset>>> {
+        let header = self.user_header();
+        if !header.segment().is_change_based() {
+            return Ok(None);
+        }
+
+        let len = header.changeset_offsets_len();
+        if len == 0 {
+            return Ok(Some(Vec::new()));
+        }
+
+        if let Some(reader) = self.jar.value().csoff_reader() {
+            let offsets = reader.get_range(0, len).map_err(ProviderError::other)?;
+            Ok(Some(offsets))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileJarProvider<'_, N> {
+    type Header = N::BlockHeader;
+
+    fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        Ok(self
+            .cursor()?
+            .get_two::<HeaderWithHashMask<Self::Header>>((&block_hash).into())?
+            .filter(|(_, hash)| hash == &block_hash)
+            .map(|(header, _)| header))
+    }
+
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+        self.cursor()?.get_one::<HeaderMask<Self::Header>>(num.into())
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
+        let mut cursor = self.cursor()?;
+        let mut headers = Vec::with_capacity(range_size_hint(&range).unwrap_or(1024));
+
+        for num in to_range(range) {
+            if let Some(header) = cursor.get_one::<HeaderMask<Self::Header>>(num.into())? {
+                headers.push(header);
+            }
+        }
+
+        Ok(headers)
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        Ok(self
+            .cursor()?
+            .get_two::<HeaderWithHashMask<Self::Header>>(number.into())?
+            .map(|(header, hash)| SealedHeader::new(header, hash)))
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        mut predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        let mut cursor = self.cursor()?;
+        let mut headers = Vec::with_capacity(range_size_hint(&range).unwrap_or(1024));
+
+        for number in to_range(range) {
+            if let Some((header, hash)) =
+                cursor.get_two::<HeaderWithHashMask<Self::Header>>(number.into())?
+            {
+                let sealed = SealedHeader::new(header, hash);
+                if !predicate(&sealed) {
+                    break
+                }
+                headers.push(sealed);
+            }
+        }
+        Ok(headers)
+    }
+}
+
+impl<N: NodePrimitives> BlockHashReader for StaticFileJarProvider<'_, N> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.cursor()?.get_one::<BlockHashMask>(number.into())
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        let mut cursor = self.cursor()?;
+        let mut hashes = Vec::with_capacity((end - start) as usize);
+
+        for number in start..end {
+            if let Some(hash) = cursor.get_one::<BlockHashMask>(number.into())? {
+                hashes.push(hash)
+            }
+        }
+        Ok(hashes)
+    }
+}
+
+impl<N: NodePrimitives> BlockNumReader for StaticFileJarProvider<'_, N> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        // Information on live database
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        // Information on live database
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        // Information on live database
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        let mut cursor = self.cursor()?;
+
+        Ok(cursor
+            .get_one::<BlockHashMask>((&hash).into())?
+            .and_then(|res| (res == hash).then(|| cursor.number()).flatten()))
+    }
+}
+
+impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsProvider
+    for StaticFileJarProvider<'_, N>
+{
+    type Transaction = N::SignedTx;
+
+    fn transaction_id(&self, hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        let mut cursor = self.cursor()?;
+
+        Ok(cursor
+            .get_one::<TransactionMask<Self::Transaction>>((&hash).into())?
+            .and_then(|res| (res.trie_hash() == hash).then(|| cursor.number()).flatten()))
+    }
+
+    fn transaction_by_id(&self, num: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        self.cursor()?.get_one::<TransactionMask<Self::Transaction>>(num.into())
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        num: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        self.cursor()?.get_one::<TransactionMask<Self::Transaction>>(num.into())
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        self.cursor()?.get_one::<TransactionMask<Self::Transaction>>((&hash).into())
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        _hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        // Information required on indexing table [`tables::TransactionBlocks`]
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn transactions_by_block(
+        &self,
+        _block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        // Related to indexing tables. Live database should get the tx_range and call static file
+        // provider with `transactions_by_tx_range` instead.
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        // Related to indexing tables. Live database should get the tx_range and call static file
+        // provider with `transactions_by_tx_range` instead.
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        let mut cursor = self.cursor()?;
+        let mut txs = Vec::with_capacity(range_size_hint(&range).unwrap_or(1024));
+
+        for num in to_range(range) {
+            if let Some(tx) = cursor.get_one::<TransactionMask<Self::Transaction>>(num.into())? {
+                txs.push(tx)
+            }
+        }
+        Ok(txs)
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        let mut cursor = self.cursor()?;
+        let mut senders = Vec::with_capacity(range_size_hint(&range).unwrap_or(1024));
+
+        for num in to_range(range) {
+            if let Some(tx) = cursor.get_one::<TransactionSenderMask>(num.into())? {
+                senders.push(tx)
+            }
+        }
+        Ok(senders)
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        self.cursor()?.get_one::<TransactionSenderMask>(id.into())
+    }
+}
+
+impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction, Receipt: Decompress>>
+    ReceiptProvider for StaticFileJarProvider<'_, N>
+{
+    type Receipt = N::Receipt;
+
+    fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+        self.cursor()?.get_one::<ReceiptMask<Self::Receipt>>(num.into())
+    }
+
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+        if let Some(tx_static_file) = &self.auxiliary_jar &&
+            let Some(num) = tx_static_file.transaction_id(hash)?
+        {
+            return self.receipt(num)
+        }
+        Ok(None)
+    }
+
+    fn receipts_by_block(
+        &self,
+        _block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        // Related to indexing tables. StaticFile should get the tx_range and call static file
+        // provider with `receipt()` instead for each
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Receipt>> {
+        let mut cursor = self.cursor()?;
+        let mut receipts = Vec::with_capacity(range_size_hint(&range).unwrap_or(1024));
+
+        for num in to_range(range) {
+            if let Some(tx) = cursor.get_one::<ReceiptMask<Self::Receipt>>(num.into())? {
+                receipts.push(tx)
+            }
+        }
+        Ok(receipts)
+    }
+
+    fn receipts_by_block_range(
+        &self,
+        _block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+        // Related to indexing tables. StaticFile should get the tx_range and call static file
+        // provider with `receipt()` instead for each
+        Err(ProviderError::UnsupportedProvider)
+    }
+}

--- a/patches/reth-provider/src/providers/static_file/manager.rs
+++ b/patches/reth-provider/src/providers/static_file/manager.rs
@@ -1,0 +1,3148 @@
+use super::{
+    metrics::StaticFileProviderMetrics, writer::StaticFileWriters, LoadedJar,
+    StaticFileJarProvider, StaticFileProviderRW, StaticFileProviderRWRefMut,
+};
+use crate::{
+    changeset_walker::{StaticFileAccountChangesetWalker, StaticFileStorageChangesetWalker},
+    to_range, BlockHashReader, BlockNumReader, BlockReader, BlockSource, EitherWriter,
+    EitherWriterDestination, HeaderProvider, ReceiptProvider, StageCheckpointReader, StatsReader,
+    TransactionVariant, TransactionsProvider, TransactionsProviderExt,
+};
+use alloy_consensus::{transaction::TransactionMeta, Header};
+use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
+use alloy_primitives::{b256, keccak256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+
+use parking_lot::RwLock;
+use reth_chain_state::ExecutedBlock;
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, NamedChain};
+use reth_db::{
+    lockfile::StorageLock,
+    static_file::{
+        iter_static_files, BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask,
+        StaticFileCursor, StorageChangesetMask, TransactionMask, TransactionSenderMask,
+    },
+};
+use reth_db_api::{
+    cursor::DbCursorRO,
+    models::{AccountBeforeTx, BlockNumberAddress, StorageBeforeTx, StoredBlockBodyIndices},
+    table::{Decompress, Table, Value},
+    tables,
+    transaction::DbTx,
+};
+use reth_ethereum_primitives::{Receipt, TransactionSigned};
+use reth_nippy_jar::{NippyJar, NippyJarChecker};
+use reth_node_types::NodePrimitives;
+use reth_primitives_traits::{
+    dashmap::DashMap, AlloyBlockHeader as _, BlockBody as _, RecoveredBlock, SealedHeader,
+    SignedTransaction, StorageEntry,
+};
+use reth_prune_types::PruneSegment;
+use reth_stages_types::PipelineTarget;
+use reth_static_file_types::{
+    find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive, StaticFileMap,
+    StaticFileSegment, DEFAULT_BLOCKS_PER_STATIC_FILE,
+};
+use reth_storage_api::{
+    BlockBodyIndicesProvider, ChangeSetReader, DBProvider, PruneCheckpointReader,
+    StorageChangeSetReader, StorageSettingsCache,
+};
+use reth_storage_errors::provider::{ProviderError, ProviderResult, StaticFileWriterError};
+use std::{
+    collections::BTreeMap,
+    fmt::Debug,
+    ops::{Bound, Deref, Range, RangeBounds, RangeInclusive},
+    path::{Path, PathBuf},
+    sync::{atomic::AtomicU64, mpsc, Arc},
+};
+use tracing::{debug, info, info_span, instrument, trace, warn};
+
+/// Alias type for a map that can be queried for block or transaction ranges. It uses `u64` to
+/// represent either a block or a transaction number end of a static file range.
+type SegmentRanges = BTreeMap<u64, SegmentRangeInclusive>;
+
+/// Access mode on a static file provider. RO/RW.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum StaticFileAccess {
+    /// Read-only access.
+    #[default]
+    RO,
+    /// Read-write access.
+    RW,
+}
+
+impl StaticFileAccess {
+    /// Returns `true` if read-only access.
+    pub const fn is_read_only(&self) -> bool {
+        matches!(self, Self::RO)
+    }
+
+    /// Returns `true` if read-write access.
+    pub const fn is_read_write(&self) -> bool {
+        matches!(self, Self::RW)
+    }
+}
+
+/// Context for static file block writes.
+///
+/// Contains target segments and pruning configuration.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StaticFileWriteCtx {
+    /// Whether transaction senders should be written to static files.
+    pub write_senders: bool,
+    /// Whether receipts should be written to static files.
+    pub write_receipts: bool,
+    /// Whether account changesets should be written to static files.
+    pub write_account_changesets: bool,
+    /// Whether storage changesets should be written to static files.
+    pub write_storage_changesets: bool,
+    /// The current chain tip block number (for pruning).
+    pub tip: BlockNumber,
+    /// The prune mode for receipts, if any.
+    pub receipts_prune_mode: Option<reth_prune_types::PruneMode>,
+    /// Whether receipts are prunable (based on storage settings and prune distance).
+    pub receipts_prunable: bool,
+}
+
+/// [`StaticFileProvider`] manages all existing [`StaticFileJarProvider`].
+///
+/// "Static files" contain immutable chain history data, such as:
+///  - transactions
+///  - headers
+///  - receipts
+///
+/// This provider type is responsible for reading and writing to static files.
+#[derive(Debug)]
+pub struct StaticFileProvider<N>(pub(crate) Arc<StaticFileProviderInner<N>>);
+
+impl<N> Clone for StaticFileProvider<N> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+/// Builder for [`StaticFileProvider`] that allows configuration before initialization.
+#[derive(Debug)]
+pub struct StaticFileProviderBuilder<P> {
+    access: StaticFileAccess,
+    use_metrics: bool,
+    blocks_per_file: StaticFileMap<u64>,
+    path: P,
+    genesis_block_number: u64,
+}
+
+impl<P: AsRef<Path>> StaticFileProviderBuilder<P> {
+    /// Creates a new builder with read-write access.
+    pub fn read_write(path: P) -> Self {
+        Self {
+            path,
+            access: StaticFileAccess::RW,
+            blocks_per_file: Default::default(),
+            use_metrics: false,
+            genesis_block_number: 0,
+        }
+    }
+
+    /// Creates a new builder with read-only access.
+    pub fn read_only(path: P) -> Self {
+        Self {
+            path,
+            access: StaticFileAccess::RO,
+            blocks_per_file: Default::default(),
+            use_metrics: false,
+            genesis_block_number: 0,
+        }
+    }
+
+    /// Set custom blocks per file for specific segments.
+    ///
+    /// Each static file segment is stored across multiple files, and each of these files contains
+    /// up to the specified number of blocks of data. When the file gets full, a new file is
+    /// created with the new block range.
+    ///
+    /// This setting affects the size of each static file, and can be set per segment.
+    ///
+    /// If it is changed for an existing node, existing static files will not be affected and will
+    /// be finished with the old blocks per file setting, but new static files will use the new
+    /// setting.
+    pub fn with_blocks_per_file_for_segments(
+        mut self,
+        segments: &<StaticFileMap<u64> as Deref>::Target,
+    ) -> Self {
+        for (segment, &blocks_per_file) in segments {
+            self.blocks_per_file.insert(segment, blocks_per_file);
+        }
+        self
+    }
+
+    /// Set a custom number of blocks per file for all segments.
+    pub fn with_blocks_per_file(mut self, blocks_per_file: u64) -> Self {
+        for segment in StaticFileSegment::iter() {
+            self.blocks_per_file.insert(segment, blocks_per_file);
+        }
+        self
+    }
+
+    /// Set a custom number of blocks per file for a specific segment.
+    pub fn with_blocks_per_file_for_segment(
+        mut self,
+        segment: StaticFileSegment,
+        blocks_per_file: u64,
+    ) -> Self {
+        self.blocks_per_file.insert(segment, blocks_per_file);
+        self
+    }
+
+    /// Enables metrics on the [`StaticFileProvider`].
+    pub const fn with_metrics(mut self) -> Self {
+        self.use_metrics = true;
+        self
+    }
+
+    /// Sets the genesis block number for the [`StaticFileProvider`].
+    ///
+    /// This configures the genesis block number, which is used to determine the starting point
+    /// for block indexing and querying operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `genesis_block_number` - The block number of the genesis block.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Self` to allow method chaining.
+    pub const fn with_genesis_block_number(mut self, genesis_block_number: u64) -> Self {
+        self.genesis_block_number = genesis_block_number;
+        self
+    }
+
+    /// Builds the final [`StaticFileProvider`] and initializes the index.
+    pub fn build<N: NodePrimitives>(self) -> ProviderResult<StaticFileProvider<N>> {
+        let mut provider = StaticFileProviderInner::new(self.path, self.access)?;
+        if self.use_metrics {
+            provider.metrics = Some(Arc::new(StaticFileProviderMetrics::default()));
+        }
+
+        for (segment, blocks_per_file) in *self.blocks_per_file {
+            provider.blocks_per_file.insert(segment, blocks_per_file);
+        }
+        provider.genesis_block_number = self.genesis_block_number;
+
+        let provider = StaticFileProvider(Arc::new(provider));
+        provider.initialize_index()?;
+        Ok(provider)
+    }
+}
+
+impl<N: NodePrimitives> StaticFileProvider<N> {
+    /// Creates a new [`StaticFileProvider`] with the given [`StaticFileAccess`].
+    fn new(path: impl AsRef<Path>, access: StaticFileAccess) -> ProviderResult<Self> {
+        let provider = Self(Arc::new(StaticFileProviderInner::new(path, access)?));
+        provider.initialize_index()?;
+        Ok(provider)
+    }
+}
+
+impl<N: NodePrimitives> StaticFileProvider<N> {
+    /// Creates a new [`StaticFileProvider`] with read-only access.
+    ///
+    /// The caller is responsible for calling [`StaticFileProvider::initialize_index`] when
+    /// underlying data changes.
+    pub fn read_only(path: impl AsRef<Path>) -> ProviderResult<Self> {
+        Self::new(path, StaticFileAccess::RO)
+    }
+
+    /// Creates a new [`StaticFileProvider`] with read-write access.
+    pub fn read_write(path: impl AsRef<Path>) -> ProviderResult<Self> {
+        Self::new(path, StaticFileAccess::RW)
+    }
+}
+
+impl<N: NodePrimitives> Deref for StaticFileProvider<N> {
+    type Target = StaticFileProviderInner<N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// [`StaticFileProviderInner`] manages all existing [`StaticFileJarProvider`].
+#[derive(Debug)]
+pub struct StaticFileProviderInner<N> {
+    /// Maintains a map which allows for concurrent access to different `NippyJars`, over different
+    /// segments and ranges.
+    map: DashMap<(BlockNumber, StaticFileSegment), LoadedJar>,
+    /// Indexes per segment.
+    indexes: RwLock<StaticFileMap<StaticFileSegmentIndex>>,
+    /// This is an additional index that tracks the expired height, this will track the highest
+    /// block number that has been expired (missing). The first, non expired block is
+    /// `expired_history_height + 1`.
+    ///
+    /// This is effectively the transaction range that has been expired:
+    /// [`StaticFileProvider::delete_segment_below_block`] and mirrors
+    /// `static_files_min_block[transactions] - blocks_per_file`.
+    ///
+    /// This additional tracker exists for more efficient lookups because the node must be aware of
+    /// the expired height.
+    earliest_history_height: AtomicU64,
+    /// Directory where `static_files` are located
+    path: PathBuf,
+    /// Maintains a writer set of [`StaticFileSegment`].
+    writers: StaticFileWriters<N>,
+    /// Metrics for the static files.
+    metrics: Option<Arc<StaticFileProviderMetrics>>,
+    /// Access rights of the provider.
+    access: StaticFileAccess,
+    /// Number of blocks per file, per segment.
+    blocks_per_file: StaticFileMap<u64>,
+    /// Write lock for when access is [`StaticFileAccess::RW`].
+    _lock_file: Option<StorageLock>,
+    /// Genesis block number, default is 0;
+    genesis_block_number: u64,
+}
+
+impl<N: NodePrimitives> StaticFileProviderInner<N> {
+    /// Creates a new [`StaticFileProviderInner`].
+    fn new(path: impl AsRef<Path>, access: StaticFileAccess) -> ProviderResult<Self> {
+        let _lock_file = if access.is_read_write() {
+            StorageLock::try_acquire(path.as_ref()).map_err(ProviderError::other)?.into()
+        } else {
+            None
+        };
+
+        let mut blocks_per_file = StaticFileMap::default();
+        for segment in StaticFileSegment::iter() {
+            blocks_per_file.insert(segment, DEFAULT_BLOCKS_PER_STATIC_FILE);
+        }
+
+        let provider = Self {
+            map: Default::default(),
+            indexes: Default::default(),
+            writers: Default::default(),
+            earliest_history_height: Default::default(),
+            path: path.as_ref().to_path_buf(),
+            metrics: None,
+            access,
+            blocks_per_file,
+            _lock_file,
+            genesis_block_number: 0,
+        };
+
+        Ok(provider)
+    }
+
+    pub const fn is_read_only(&self) -> bool {
+        self.access.is_read_only()
+    }
+
+    /// Each static file has a fixed number of blocks. This gives out the range where the requested
+    /// block is positioned.
+    ///
+    /// If the specified block falls into one of the ranges of already initialized static files,
+    /// this function will return that range.
+    ///
+    /// If no matching file exists, this function will derive a new range from the end of the last
+    /// existing file, if any.
+    pub fn find_fixed_range_with_block_index(
+        &self,
+        segment: StaticFileSegment,
+        block_index: Option<&SegmentRanges>,
+        block: BlockNumber,
+    ) -> SegmentRangeInclusive {
+        let blocks_per_file =
+            self.blocks_per_file.get(segment).copied().unwrap_or(DEFAULT_BLOCKS_PER_STATIC_FILE);
+
+        if let Some(block_index) = block_index {
+            // Find first block range that contains the requested block
+            if let Some((_, range)) = block_index.iter().find(|(max_block, _)| block <= **max_block)
+            {
+                // Found matching range for an existing file using block index
+                return *range;
+            } else if let Some((_, range)) = block_index.last_key_value() {
+                // Didn't find matching range for an existing file, derive a new range from the end
+                // of the last existing file range.
+                //
+                // `block` is always higher than `range.end()` here, because we iterated over all
+                // `block_index` ranges above and didn't find one that contains our block
+                let blocks_after_last_range = block - range.end();
+                let segments_to_skip = (blocks_after_last_range - 1) / blocks_per_file;
+                let start = range.end() + 1 + segments_to_skip * blocks_per_file;
+                return SegmentRangeInclusive::new(start, start + blocks_per_file - 1);
+            }
+        }
+        // No block index is available, derive a new range using the fixed number of blocks,
+        // starting from the beginning.
+        find_fixed_range(block, blocks_per_file)
+    }
+
+    /// Each static file has a fixed number of blocks. This gives out the range where the requested
+    /// block is positioned.
+    ///
+    /// If the specified block falls into one of the ranges of already initialized static files,
+    /// this function will return that range.
+    ///
+    /// If no matching file exists, this function will derive a new range from the end of the last
+    /// existing file, if any.
+    ///
+    /// This function will block indefinitely if a write lock for
+    /// [`Self::indexes`] is already acquired. In that case, use
+    /// [`Self::find_fixed_range_with_block_index`].
+    pub fn find_fixed_range(
+        &self,
+        segment: StaticFileSegment,
+        block: BlockNumber,
+    ) -> SegmentRangeInclusive {
+        self.find_fixed_range_with_block_index(
+            segment,
+            self.indexes.read().get(segment).map(|index| &index.expected_block_ranges_by_max_block),
+            block,
+        )
+    }
+
+    /// Get genesis block number
+    pub const fn genesis_block_number(&self) -> u64 {
+        self.genesis_block_number
+    }
+}
+
+impl<N: NodePrimitives> StaticFileProvider<N> {
+    /// Reports metrics for the static files.
+    ///
+    /// This uses the in-memory index to get file sizes from mmap handles instead of reading
+    /// filesystem metadata.
+    pub fn report_metrics(&self) -> ProviderResult<()> {
+        let Some(metrics) = &self.metrics else { return Ok(()) };
+
+        let static_files = iter_static_files(&self.path).map_err(ProviderError::other)?;
+        for (segment, headers) in &*static_files {
+            let mut entries = 0;
+            let mut size = 0;
+
+            for (block_range, _) in headers {
+                let fixed_block_range = self.find_fixed_range(segment, block_range.start());
+                let jar_provider = self
+                    .get_segment_provider_for_range(segment, || Some(fixed_block_range), None)?
+                    .ok_or_else(|| {
+                        ProviderError::MissingStaticFileBlock(segment, block_range.start())
+                    })?;
+
+                entries += jar_provider.rows();
+                size += jar_provider.size() as u64;
+            }
+
+            metrics.record_segment(segment, size, headers.len(), entries);
+        }
+
+        Ok(())
+    }
+
+    /// Writes headers for all blocks to the static file segment.
+    #[instrument(level = "debug", target = "providers::static_file", skip_all)]
+    fn write_headers(
+        w: &mut StaticFileProviderRWRefMut<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+    ) -> ProviderResult<()> {
+        for block in blocks {
+            let b = block.recovered_block();
+            w.append_header(b.header(), &b.hash())?;
+        }
+        Ok(())
+    }
+
+    /// Writes transactions for all blocks to the static file segment.
+    #[instrument(level = "debug", target = "providers::static_file", skip_all)]
+    fn write_transactions(
+        w: &mut StaticFileProviderRWRefMut<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+        tx_nums: &[TxNumber],
+    ) -> ProviderResult<()> {
+        for (block, &first_tx) in blocks.iter().zip(tx_nums) {
+            let b = block.recovered_block();
+            w.increment_block(b.number())?;
+            for (i, tx) in b.body().transactions().iter().enumerate() {
+                w.append_transaction(first_tx + i as u64, tx)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Writes transaction senders for all blocks to the static file segment.
+    #[instrument(level = "debug", target = "providers::static_file", skip_all)]
+    fn write_transaction_senders(
+        w: &mut StaticFileProviderRWRefMut<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+        tx_nums: &[TxNumber],
+    ) -> ProviderResult<()> {
+        for (block, &first_tx) in blocks.iter().zip(tx_nums) {
+            let b = block.recovered_block();
+            w.increment_block(b.number())?;
+            for (i, sender) in b.senders_iter().enumerate() {
+                w.append_transaction_sender(first_tx + i as u64, sender)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Writes receipts for all blocks to the static file segment.
+    #[instrument(level = "debug", target = "providers::static_file", skip_all)]
+    fn write_receipts(
+        w: &mut StaticFileProviderRWRefMut<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+        tx_nums: &[TxNumber],
+        ctx: &StaticFileWriteCtx,
+    ) -> ProviderResult<()> {
+        for (block, &first_tx) in blocks.iter().zip(tx_nums) {
+            let block_number = block.recovered_block().number();
+            w.increment_block(block_number)?;
+
+            // skip writing receipts if pruning configuration requires us to.
+            if ctx.receipts_prunable &&
+                ctx.receipts_prune_mode
+                    .is_some_and(|mode| mode.should_prune(block_number, ctx.tip))
+            {
+                continue
+            }
+
+            for (i, receipt) in block.execution_outcome().receipts.iter().enumerate() {
+                w.append_receipt(first_tx + i as u64, receipt)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Writes account changesets for all blocks to the static file segment.
+    #[instrument(level = "debug", target = "providers::static_file", skip_all)]
+    fn write_account_changesets(
+        w: &mut StaticFileProviderRWRefMut<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+    ) -> ProviderResult<()> {
+        for block in blocks {
+            let block_number = block.recovered_block().number();
+            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+
+            let changeset: Vec<_> = reverts
+                .accounts
+                .into_iter()
+                .flatten()
+                .map(|(address, info)| AccountBeforeTx { address, info: info.map(Into::into) })
+                .collect();
+            w.append_account_changeset(changeset, block_number)?;
+        }
+        Ok(())
+    }
+
+    /// Writes storage changesets for all blocks to the static file segment.
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn write_storage_changesets(
+        w: &mut StaticFileProviderRWRefMut<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+    ) -> ProviderResult<()> {
+        for block in blocks {
+            let block_number = block.recovered_block().number();
+            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+
+            let changeset: Vec<_> = reverts
+                .storage
+                .into_iter()
+                .flatten()
+                .flat_map(|revert| {
+                    revert.storage_revert.into_iter().map(move |(key, revert_to_slot)| {
+                        StorageBeforeTx {
+                            address: revert.address,
+                            key: B256::from(key.to_be_bytes()),
+                            value: revert_to_slot.to_previous_value(),
+                        }
+                    })
+                })
+                .collect();
+            w.append_storage_changeset(changeset, block_number)?;
+        }
+        Ok(())
+    }
+
+    /// Writes to a static file segment using the provided closure.
+    ///
+    /// The closure receives a mutable reference to the segment writer. After the closure completes,
+    /// `sync_all()` is called to flush writes to disk.
+    #[instrument(level = "debug", target = "providers::static_file", skip_all, fields(?segment))]
+    fn write_segment<F>(
+        &self,
+        segment: StaticFileSegment,
+        first_block_number: BlockNumber,
+        f: F,
+    ) -> ProviderResult<()>
+    where
+        F: FnOnce(&mut StaticFileProviderRWRefMut<'_, N>) -> ProviderResult<()>,
+    {
+        let mut w = self.get_writer(first_block_number, segment)?;
+        f(&mut w)?;
+        w.sync_all()
+    }
+
+    /// Writes all static file data for multiple blocks in parallel per-segment.
+    ///
+    /// This spawns tasks on the storage thread pool for each segment type and each task calls
+    /// `sync_all()` on its writer when done.
+    #[instrument(level = "debug", target = "providers::static_file", skip_all)]
+    pub fn write_blocks_data(
+        &self,
+        blocks: &[ExecutedBlock<N>],
+        tx_nums: &[TxNumber],
+        ctx: StaticFileWriteCtx,
+        runtime: &reth_tasks::Runtime,
+    ) -> ProviderResult<()> {
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        let first_block_number = blocks[0].recovered_block().number();
+
+        let mut r_headers = None;
+        let mut r_txs = None;
+        let mut r_senders = None;
+        let mut r_receipts = None;
+        let mut r_account_changesets = None;
+        let mut r_storage_changesets = None;
+
+        // Propagate tracing context into rayon-spawned threads so that per-segment
+        // write spans appear as children of write_blocks_data in traces.
+        let span = tracing::Span::current();
+        runtime.storage_pool().in_place_scope(|s| {
+            s.spawn(|_| {
+                let _guard = span.enter();
+                r_headers =
+                    Some(self.write_segment(StaticFileSegment::Headers, first_block_number, |w| {
+                        Self::write_headers(w, blocks)
+                    }));
+            });
+
+            s.spawn(|_| {
+                let _guard = span.enter();
+                r_txs = Some(self.write_segment(
+                    StaticFileSegment::Transactions,
+                    first_block_number,
+                    |w| Self::write_transactions(w, blocks, tx_nums),
+                ));
+            });
+
+            if ctx.write_senders {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    r_senders = Some(self.write_segment(
+                        StaticFileSegment::TransactionSenders,
+                        first_block_number,
+                        |w| Self::write_transaction_senders(w, blocks, tx_nums),
+                    ));
+                });
+            }
+
+            if ctx.write_receipts {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    r_receipts = Some(self.write_segment(
+                        StaticFileSegment::Receipts,
+                        first_block_number,
+                        |w| Self::write_receipts(w, blocks, tx_nums, &ctx),
+                    ));
+                });
+            }
+
+            if ctx.write_account_changesets {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    r_account_changesets = Some(self.write_segment(
+                        StaticFileSegment::AccountChangeSets,
+                        first_block_number,
+                        |w| Self::write_account_changesets(w, blocks),
+                    ));
+                });
+            }
+
+            if ctx.write_storage_changesets {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    r_storage_changesets = Some(self.write_segment(
+                        StaticFileSegment::StorageChangeSets,
+                        first_block_number,
+                        |w| Self::write_storage_changesets(w, blocks),
+                    ));
+                });
+            }
+        });
+
+        r_headers.ok_or(StaticFileWriterError::ThreadPanic("headers"))??;
+        r_txs.ok_or(StaticFileWriterError::ThreadPanic("transactions"))??;
+        if ctx.write_senders {
+            r_senders.ok_or(StaticFileWriterError::ThreadPanic("senders"))??;
+        }
+        if ctx.write_receipts {
+            r_receipts.ok_or(StaticFileWriterError::ThreadPanic("receipts"))??;
+        }
+        if ctx.write_account_changesets {
+            r_account_changesets
+                .ok_or(StaticFileWriterError::ThreadPanic("account_changesets"))??;
+        }
+        if ctx.write_storage_changesets {
+            r_storage_changesets
+                .ok_or(StaticFileWriterError::ThreadPanic("storage_changesets"))??;
+        }
+        Ok(())
+    }
+
+    /// Gets the [`StaticFileJarProvider`] of the requested segment and start index that can be
+    /// either block or transaction.
+    pub fn get_segment_provider(
+        &self,
+        segment: StaticFileSegment,
+        number: u64,
+    ) -> ProviderResult<StaticFileJarProvider<'_, N>> {
+        if segment.is_block_or_change_based() {
+            self.get_segment_provider_for_block(segment, number, None)
+        } else {
+            self.get_segment_provider_for_transaction(segment, number, None)
+        }
+    }
+
+    /// Gets the [`StaticFileJarProvider`] of the requested segment and start index that can be
+    /// either block or transaction.
+    ///
+    /// If the segment is not found, returns [`None`].
+    pub fn get_maybe_segment_provider(
+        &self,
+        segment: StaticFileSegment,
+        number: u64,
+    ) -> ProviderResult<Option<StaticFileJarProvider<'_, N>>> {
+        let provider = if segment.is_block_or_change_based() {
+            self.get_segment_provider_for_block(segment, number, None)
+        } else {
+            self.get_segment_provider_for_transaction(segment, number, None)
+        };
+
+        match provider {
+            Ok(provider) => Ok(Some(provider)),
+            Err(
+                ProviderError::MissingStaticFileBlock(_, _) |
+                ProviderError::MissingStaticFileTx(_, _),
+            ) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Gets the [`StaticFileJarProvider`] of the requested segment and block.
+    pub fn get_segment_provider_for_block(
+        &self,
+        segment: StaticFileSegment,
+        block: BlockNumber,
+        path: Option<&Path>,
+    ) -> ProviderResult<StaticFileJarProvider<'_, N>> {
+        self.get_segment_provider_for_range(
+            segment,
+            || self.get_segment_ranges_from_block(segment, block),
+            path,
+        )?
+        .ok_or(ProviderError::MissingStaticFileBlock(segment, block))
+    }
+
+    /// Gets the [`StaticFileJarProvider`] of the requested segment and transaction.
+    pub fn get_segment_provider_for_transaction(
+        &self,
+        segment: StaticFileSegment,
+        tx: TxNumber,
+        path: Option<&Path>,
+    ) -> ProviderResult<StaticFileJarProvider<'_, N>> {
+        self.get_segment_provider_for_range(
+            segment,
+            || self.get_segment_ranges_from_transaction(segment, tx),
+            path,
+        )?
+        .ok_or(ProviderError::MissingStaticFileTx(segment, tx))
+    }
+
+    /// Gets the [`StaticFileJarProvider`] of the requested segment and block or transaction.
+    ///
+    /// `fn_range` should make sure the range goes through `find_fixed_range`.
+    pub fn get_segment_provider_for_range(
+        &self,
+        segment: StaticFileSegment,
+        fn_range: impl Fn() -> Option<SegmentRangeInclusive>,
+        path: Option<&Path>,
+    ) -> ProviderResult<Option<StaticFileJarProvider<'_, N>>> {
+        // If we have a path, then get the block range from its name.
+        // Otherwise, check `self.available_static_files`
+        let block_range = match path {
+            Some(path) => StaticFileSegment::parse_filename(
+                &path
+                    .file_name()
+                    .ok_or_else(|| {
+                        ProviderError::MissingStaticFileSegmentPath(segment, path.to_path_buf())
+                    })?
+                    .to_string_lossy(),
+            )
+            .and_then(|(parsed_segment, block_range)| {
+                if parsed_segment == segment {
+                    return Some(block_range);
+                }
+                None
+            }),
+            None => fn_range(),
+        };
+
+        // Return cached `LoadedJar` or insert it for the first time, and then, return it.
+        if let Some(block_range) = block_range {
+            return Ok(Some(self.get_or_create_jar_provider(segment, &block_range)?));
+        }
+
+        Ok(None)
+    }
+
+    /// Gets the [`StaticFileJarProvider`] of the requested path.
+    pub fn get_segment_provider_for_path(
+        &self,
+        path: &Path,
+    ) -> ProviderResult<Option<StaticFileJarProvider<'_, N>>> {
+        StaticFileSegment::parse_filename(
+            &path
+                .file_name()
+                .ok_or_else(|| ProviderError::MissingStaticFilePath(path.to_path_buf()))?
+                .to_string_lossy(),
+        )
+        .map(|(segment, block_range)| self.get_or_create_jar_provider(segment, &block_range))
+        .transpose()
+    }
+
+    /// Given a segment and block range it removes the cached provider from the map.
+    ///
+    /// CAUTION: cached provider should be dropped before calling this or IT WILL deadlock.
+    pub fn remove_cached_provider(
+        &self,
+        segment: StaticFileSegment,
+        fixed_block_range_end: BlockNumber,
+    ) {
+        self.map.remove(&(fixed_block_range_end, segment));
+    }
+
+    /// This handles history expiry by deleting all static files for the given segment below the
+    /// given block.
+    ///
+    /// For example if block is 1M and the blocks per file are 500K this will delete all individual
+    /// files below 1M, so 0-499K and 500K-999K.
+    ///
+    /// This will not delete the file that contains the block itself, because files can only be
+    /// removed entirely.
+    ///
+    /// # Safety
+    ///
+    /// This method will never delete the highest static file for the segment, even if the
+    /// requested block is higher than the highest block in static files. This ensures we always
+    /// maintain at least one static file if any exist.
+    ///
+    /// Returns a list of `SegmentHeader`s from the deleted jars.
+    pub fn delete_segment_below_block(
+        &self,
+        segment: StaticFileSegment,
+        block: BlockNumber,
+    ) -> ProviderResult<Vec<SegmentHeader>> {
+        // Nothing to delete if block is 0.
+        if block == 0 {
+            return Ok(Vec::new());
+        }
+
+        let highest_block = self.get_highest_static_file_block(segment);
+        let mut deleted_headers = Vec::new();
+
+        loop {
+            let Some(block_height) = self.get_lowest_range_end(segment) else {
+                return Ok(deleted_headers);
+            };
+
+            // Stop if we've reached the target block or the highest static file
+            if block_height >= block || Some(block_height) == highest_block {
+                return Ok(deleted_headers);
+            }
+
+            debug!(
+                target: "providers::static_file",
+                ?segment,
+                ?block_height,
+                "Deleting static file below block"
+            );
+
+            // now we need to wipe the static file, this will take care of updating the index and
+            // advance the lowest tracked block height for the segment.
+            let header = self.delete_jar(segment, block_height).inspect_err(|err| {
+                warn!( target: "providers::static_file", ?segment, %block_height, ?err, "Failed to delete static file below block")
+            })?;
+
+            deleted_headers.push(header);
+        }
+    }
+
+    /// Given a segment and block, it deletes the jar and all files from the respective block range.
+    ///
+    /// CAUTION: destructive. Deletes files on disk.
+    ///
+    /// This will re-initialize the index after deletion, so all files are tracked.
+    ///
+    /// Returns the `SegmentHeader` of the deleted jar.
+    pub fn delete_jar(
+        &self,
+        segment: StaticFileSegment,
+        block: BlockNumber,
+    ) -> ProviderResult<SegmentHeader> {
+        let fixed_block_range = self.find_fixed_range(segment, block);
+        let key = (fixed_block_range.end(), segment);
+        let file = self.path.join(segment.filename(&fixed_block_range));
+        let jar = if let Some((_, jar)) = self.map.remove(&key) {
+            jar.jar
+        } else {
+            debug!(
+                target: "providers::static_file",
+                ?file,
+                ?fixed_block_range,
+                ?block,
+                "Loading static file jar for deletion"
+            );
+            NippyJar::<SegmentHeader>::load(&file).map_err(ProviderError::other)?
+        };
+
+        let header = jar.user_header().clone();
+
+        // Delete the sidecar file for changeset segments before deleting the main jar
+        if segment.is_change_based() {
+            let csoff_path = file.with_extension("csoff");
+            if csoff_path.exists() {
+                std::fs::remove_file(&csoff_path).map_err(ProviderError::other)?;
+            }
+        }
+
+        jar.delete().map_err(ProviderError::other)?;
+
+        // SAFETY: this is currently necessary to ensure that certain indexes like
+        // `static_files_min_block` have the correct values after pruning.
+        self.initialize_index()?;
+
+        Ok(header)
+    }
+
+    /// Deletes ALL static file jars for the given segment, including the highest one.
+    ///
+    /// CAUTION: destructive. Deletes all files on disk for this segment.
+    ///
+    /// This is used for `PruneMode::Full` where all data should be removed.
+    ///
+    /// Returns a list of `SegmentHeader`s from the deleted jars.
+    pub fn delete_segment(&self, segment: StaticFileSegment) -> ProviderResult<Vec<SegmentHeader>> {
+        let mut deleted_headers = Vec::new();
+
+        while let Some(block_height) = self.get_highest_static_file_block(segment) {
+            debug!(
+                target: "providers::static_file",
+                ?segment,
+                ?block_height,
+                "Deleting static file jar"
+            );
+
+            let header = self.delete_jar(segment, block_height).inspect_err(|err| {
+                warn!(target: "providers::static_file", ?segment, %block_height, ?err, "Failed to delete static file jar")
+            })?;
+
+            deleted_headers.push(header);
+        }
+
+        Ok(deleted_headers)
+    }
+
+    /// Given a segment and block range it returns a cached
+    /// [`StaticFileJarProvider`]. TODO(joshie): we should check the size and pop N if there's too
+    /// many.
+    fn get_or_create_jar_provider(
+        &self,
+        segment: StaticFileSegment,
+        fixed_block_range: &SegmentRangeInclusive,
+    ) -> ProviderResult<StaticFileJarProvider<'_, N>> {
+        let key = (fixed_block_range.end(), segment);
+
+        // Avoid using `entry` directly to avoid a write lock in the common case.
+        trace!(target: "providers::static_file", ?segment, ?fixed_block_range, "Getting provider");
+        let mut provider: StaticFileJarProvider<'_, N> = if let Some(jar) = self.map.get(&key) {
+            trace!(target: "providers::static_file", ?segment, ?fixed_block_range, "Jar found in cache");
+            jar.into()
+        } else {
+            trace!(target: "providers::static_file", ?segment, ?fixed_block_range, "Creating jar from scratch");
+            let path = self.path.join(segment.filename(fixed_block_range));
+            let jar = NippyJar::load(&path).map_err(ProviderError::other)?;
+            self.map.entry(key).insert(LoadedJar::new(jar)?).downgrade().into()
+        };
+
+        if let Some(metrics) = &self.metrics {
+            provider = provider.with_metrics(metrics.clone());
+        }
+        Ok(provider)
+    }
+
+    /// Gets a static file segment's block range from the provider inner block
+    /// index.
+    fn get_segment_ranges_from_block(
+        &self,
+        segment: StaticFileSegment,
+        block: u64,
+    ) -> Option<SegmentRangeInclusive> {
+        let indexes = self.indexes.read();
+        let index = indexes.get(segment)?;
+
+        (index.max_block >= block).then(|| {
+            self.find_fixed_range_with_block_index(
+                segment,
+                Some(&index.expected_block_ranges_by_max_block),
+                block,
+            )
+        })
+    }
+
+    /// Gets a static file segment's fixed block range from the provider inner
+    /// transaction index.
+    fn get_segment_ranges_from_transaction(
+        &self,
+        segment: StaticFileSegment,
+        tx: u64,
+    ) -> Option<SegmentRangeInclusive> {
+        let indexes = self.indexes.read();
+        let index = indexes.get(segment)?;
+        let available_block_ranges_by_max_tx = index.available_block_ranges_by_max_tx.as_ref()?;
+
+        // It's more probable that the request comes from a newer tx height, so we iterate
+        // the static_files in reverse.
+        let mut static_files_rev_iter = available_block_ranges_by_max_tx.iter().rev().peekable();
+
+        while let Some((tx_end, block_range)) = static_files_rev_iter.next() {
+            if tx > *tx_end {
+                // request tx is higher than highest static file tx
+                return None;
+            }
+            let tx_start = static_files_rev_iter.peek().map(|(tx_end, _)| *tx_end + 1).unwrap_or(0);
+            if tx_start <= tx {
+                return Some(self.find_fixed_range_with_block_index(
+                    segment,
+                    Some(&index.expected_block_ranges_by_max_block),
+                    block_range.end(),
+                ));
+            }
+        }
+        None
+    }
+
+    /// Updates the inner transaction and block indexes alongside the internal cached providers in
+    /// `self.map`.
+    ///
+    /// Any entry higher than `segment_max_block` will be deleted from the previous structures.
+    ///
+    /// If `segment_max_block` is None it means there's no static file for this segment.
+    pub fn update_index(
+        &self,
+        segment: StaticFileSegment,
+        segment_max_block: Option<BlockNumber>,
+    ) -> ProviderResult<()> {
+        debug!(
+            target: "providers::static_file",
+            ?segment,
+            ?segment_max_block,
+            "Updating provider index"
+        );
+        let mut indexes = self.indexes.write();
+
+        match segment_max_block {
+            Some(segment_max_block) => {
+                let fixed_range = self.find_fixed_range_with_block_index(
+                    segment,
+                    indexes.get(segment).map(|index| &index.expected_block_ranges_by_max_block),
+                    segment_max_block,
+                );
+
+                let jar = NippyJar::<SegmentHeader>::load(
+                    &self.path.join(segment.filename(&fixed_range)),
+                )
+                .map_err(ProviderError::other)?;
+
+                let index = indexes
+                    .entry(segment)
+                    .and_modify(|index| {
+                        // Update max block
+                        index.max_block = segment_max_block;
+
+                        // Update expected block range index
+
+                        // Remove all expected block ranges that are less than the new max block
+                        index
+                            .expected_block_ranges_by_max_block
+                            .retain(|_, block_range| block_range.start() < fixed_range.start());
+                        // Insert new expected block range
+                        index
+                            .expected_block_ranges_by_max_block
+                            .insert(fixed_range.end(), fixed_range);
+                    })
+                    .or_insert_with(|| StaticFileSegmentIndex {
+                        min_block_range: None,
+                        max_block: segment_max_block,
+                        expected_block_ranges_by_max_block: BTreeMap::from([(
+                            fixed_range.end(),
+                            fixed_range,
+                        )]),
+                        available_block_ranges_by_max_tx: None,
+                    });
+
+                // Update min_block to track the lowest block range of the segment.
+                // This is initially set by initialize_index() on node startup, but must be updated
+                // as the file grows to prevent stale values.
+                //
+                // Without this update, min_block can remain at genesis (e.g. Some([0..=0]) or None)
+                // even after syncing to higher blocks (e.g. [0..=100]). A stale
+                // min_block causes get_lowest_static_file_block() to return the
+                // wrong end value, which breaks pruning logic that relies on it for
+                // safety checks.
+                //
+                // Example progression:
+                // 1. Node starts, initialize_index() sets min_block = [0..=0]
+                // 2. Sync to block 100, this update sets min_block = [0..=100]
+                // 3. Pruner calls get_lowest_static_file_block() -> returns 100 (correct). Without
+                //    this update, it would incorrectly return 0 (stale)
+                if let Some(current_block_range) = jar.user_header().block_range() {
+                    if let Some(min_block_range) = index.min_block_range.as_mut() {
+                        // delete_jar WILL ALWAYS re-initialize all indexes, so we are always
+                        // sure that current_min is always the lowest.
+                        if current_block_range.start() == min_block_range.start() {
+                            *min_block_range = current_block_range;
+                        }
+                    } else {
+                        index.min_block_range = Some(current_block_range);
+                    }
+                }
+
+                // Updates the tx index by first removing all entries which have a higher
+                // block_start than our current static file.
+                if let Some(tx_range) = jar.user_header().tx_range() {
+                    // Current block range has the same block start as `fixed_range``, but block end
+                    // might be different if we are still filling this static file.
+                    if let Some(current_block_range) = jar.user_header().block_range() {
+                        let tx_end = tx_range.end();
+
+                        // Considering that `update_index` is called when we either append/truncate,
+                        // we are sure that we are handling the latest data
+                        // points.
+                        //
+                        // Here we remove every entry of the index that has a block start higher or
+                        // equal than our current one. This is important in the case
+                        // that we prune a lot of rows resulting in a file (and thus
+                        // a higher block range) deletion.
+                        if let Some(index) = index.available_block_ranges_by_max_tx.as_mut() {
+                            index
+                                .retain(|_, block_range| block_range.start() < fixed_range.start());
+                            index.insert(tx_end, current_block_range);
+                        } else {
+                            index.available_block_ranges_by_max_tx =
+                                Some(BTreeMap::from([(tx_end, current_block_range)]));
+                        }
+                    }
+                } else if segment.is_tx_based() {
+                    // The unwinded file has no more transactions/receipts. However, the highest
+                    // block is within this files' block range. We only retain
+                    // entries with block ranges before the current one.
+                    if let Some(index) = index.available_block_ranges_by_max_tx.as_mut() {
+                        index.retain(|_, block_range| block_range.start() < fixed_range.start());
+                    }
+
+                    // If the index is empty, just remove it.
+                    index.available_block_ranges_by_max_tx.take_if(|index| index.is_empty());
+                }
+
+                // Update the cached provider.
+                debug!(target: "providers::static_file", ?segment, "Inserting updated jar into cache");
+                self.map.insert((fixed_range.end(), segment), LoadedJar::new(jar)?);
+
+                // Delete any cached provider that no longer has an associated jar.
+                debug!(target: "providers::static_file", ?segment, "Cleaning up jar map");
+                self.map.retain(|(end, seg), _| !(*seg == segment && *end > fixed_range.end()));
+            }
+            None => {
+                debug!(target: "providers::static_file", ?segment, "Removing segment from index");
+                indexes.remove(segment);
+            }
+        };
+
+        debug!(target: "providers::static_file", ?segment, "Updated provider index");
+        Ok(())
+    }
+
+    /// Initializes the inner transaction and block index
+    pub fn initialize_index(&self) -> ProviderResult<()> {
+        let mut indexes = self.indexes.write();
+        indexes.clear();
+
+        for (segment, headers) in &*iter_static_files(&self.path).map_err(ProviderError::other)? {
+            // Update first and last block for each segment
+            //
+            // It's safe to call `expect` here, because every segment has at least one header
+            // associated with it.
+            let min_block_range = Some(headers.first().expect("headers are not empty").0);
+            let max_block = headers.last().expect("headers are not empty").0.end();
+
+            let mut expected_block_ranges_by_max_block = BTreeMap::default();
+            let mut available_block_ranges_by_max_tx = None;
+
+            for (block_range, header) in headers {
+                // Update max expected block -> expected_block_range index
+                expected_block_ranges_by_max_block
+                    .insert(header.expected_block_end(), header.expected_block_range());
+
+                // Update max tx -> block_range index
+                if let Some(tx_range) = header.tx_range() {
+                    let tx_end = tx_range.end();
+
+                    available_block_ranges_by_max_tx
+                        .get_or_insert_with(BTreeMap::default)
+                        .insert(tx_end, *block_range);
+                }
+            }
+
+            indexes.insert(
+                segment,
+                StaticFileSegmentIndex {
+                    min_block_range,
+                    max_block,
+                    expected_block_ranges_by_max_block,
+                    available_block_ranges_by_max_tx,
+                },
+            );
+        }
+
+        // If this is a re-initialization, we need to clear this as well
+        self.map.clear();
+
+        // initialize the expired history height to the lowest static file block
+        if let Some(lowest_range) =
+            indexes.get(StaticFileSegment::Transactions).and_then(|index| index.min_block_range)
+        {
+            // the earliest height is the lowest available block number
+            self.earliest_history_height
+                .store(lowest_range.start(), std::sync::atomic::Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
+    /// Ensures that any broken invariants which cannot be healed on the spot return a pipeline
+    /// target to unwind to.
+    ///
+    /// Two types of consistency checks are done for:
+    ///
+    /// 1) When a static file fails to commit but the underlying data was changed.
+    /// 2) When a static file was committed, but the required database transaction was not.
+    ///
+    /// For 1) it can self-heal if `self.access.is_read_only()` is set to `false`. Otherwise, it
+    /// will return an error.
+    /// For 2) the invariants below are checked, and if broken, might require a pipeline unwind
+    /// to heal.
+    ///
+    /// For each static file segment:
+    /// * the corresponding database table should overlap or have continuity in their keys
+    ///   ([`TxNumber`] or [`BlockNumber`]).
+    /// * its highest block should match the stage checkpoint block number if it's equal or higher
+    ///   than the corresponding database table last entry.
+    ///
+    /// Returns a [`Option`] of [`PipelineTarget::Unwind`] if any healing is further required.
+    ///
+    /// WARNING: No static file writer should be held before calling this function, otherwise it
+    /// will deadlock.
+    #[instrument(skip(self, provider), fields(read_only = self.is_read_only()))]
+    pub fn check_consistency<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<PipelineTarget>>
+    where
+        Provider: DBProvider
+            + BlockReader
+            + StageCheckpointReader
+            + PruneCheckpointReader
+            + ChainSpecProvider
+            + StorageSettingsCache,
+        N: NodePrimitives<Receipt: Value, BlockHeader: Value, SignedTx: Value>,
+    {
+        // OVM historical import is broken and does not work with this check. It's importing
+        // duplicated receipts resulting in having more receipts than the expected transaction
+        // range.
+        //
+        // If we detect an OVM import was done (block #1 <https://optimistic.etherscan.io/block/1>), skip it.
+        // More on [#11099](https://github.com/paradigmxyz/reth/pull/11099).
+        if provider.chain_spec().is_optimism() &&
+            reth_chainspec::Chain::optimism_mainnet() == provider.chain_spec().chain_id()
+        {
+            // check whether we have the first OVM block: <https://optimistic.etherscan.io/block/0xbee7192e575af30420cae0c7776304ac196077ee72b048970549e4f08e875453>
+            const OVM_HEADER_1_HASH: B256 =
+                b256!("0xbee7192e575af30420cae0c7776304ac196077ee72b048970549e4f08e875453");
+            if provider.block_number(OVM_HEADER_1_HASH)?.is_some() {
+                info!(target: "reth::cli",
+                    "Skipping storage verification for OP mainnet, expected inconsistency in OVM chain"
+                );
+                return Ok(None);
+            }
+        }
+
+        info!(target: "reth::cli", "Verifying storage consistency.");
+
+        let mut unwind_target: Option<BlockNumber> = None;
+
+        let mut update_unwind_target = |new_target| {
+            unwind_target =
+                unwind_target.map(|current| current.min(new_target)).or(Some(new_target));
+        };
+
+        for segment in self.segments_to_check(provider) {
+            let span = info_span!(
+                "Checking consistency for segment",
+                ?segment,
+                initial_highest_block = tracing::field::Empty,
+                highest_block = tracing::field::Empty,
+                highest_tx = tracing::field::Empty,
+            );
+            let _guard = span.enter();
+
+            debug!(target: "reth::providers::static_file", "Checking consistency for segment");
+
+            // Heal file-level inconsistencies and get before/after highest block
+            let (initial_highest_block, mut highest_block) = self.maybe_heal_segment(segment)?;
+            span.record("initial_highest_block", initial_highest_block);
+            span.record("highest_block", highest_block);
+
+            // Only applies to block-based static files. (Headers)
+            //
+            // The updated `highest_block` may have decreased if we healed from a pruning
+            // interruption.
+            if initial_highest_block != highest_block {
+                info!(
+                    target: "reth::providers::static_file",
+                    unwind_target = highest_block,
+                    "Setting unwind target."
+                );
+                update_unwind_target(highest_block.unwrap_or_default());
+            }
+
+            // Only applies to transaction-based static files. (Receipts & Transactions)
+            //
+            // Make sure the last transaction matches the last block from its indices, since a heal
+            // from a pruning interruption might have decreased the number of transactions without
+            // being able to update the last block of the static file segment.
+            let highest_tx = self.get_highest_static_file_tx(segment);
+            span.record("highest_tx", highest_tx);
+            debug!(target: "reth::providers::static_file", "Checking tx index segment");
+
+            if let Some(highest_tx) = highest_tx {
+                let mut last_block = highest_block.unwrap_or_default();
+                debug!(target: "reth::providers::static_file", last_block, highest_tx, "Verifying last transaction matches last block indices");
+                loop {
+                    let Some(indices) = provider.block_body_indices(last_block)? else {
+                        debug!(target: "reth::providers::static_file", last_block, "Block body indices not found, static files ahead of database");
+                        // If the block body indices can not be found, then it means that static
+                        // files is ahead of database, and the `ensure_invariants` check will fix
+                        // it by comparing with stage checkpoints.
+                        break
+                    };
+
+                    debug!(target: "reth::providers::static_file", last_block, last_tx_num = indices.last_tx_num(), "Found block body indices");
+
+                    if indices.last_tx_num() <= highest_tx {
+                        break
+                    }
+
+                    if last_block == 0 {
+                        debug!(target: "reth::providers::static_file", "Reached block 0 in verification loop");
+                        break
+                    }
+
+                    last_block -= 1;
+
+                    info!(
+                        target: "reth::providers::static_file",
+                        highest_block = self.get_highest_static_file_block(segment),
+                        unwind_target = last_block,
+                        "Setting unwind target."
+                    );
+                    span.record("highest_block", last_block);
+                    highest_block = Some(last_block);
+                    update_unwind_target(last_block);
+                }
+            }
+
+            debug!(target: "reth::providers::static_file", "Ensuring invariants for segment");
+
+            match self.ensure_invariants_for(provider, segment, highest_tx, highest_block)? {
+                Some(unwind) => {
+                    debug!(target: "reth::providers::static_file", unwind_target=unwind, "Invariants check returned unwind target");
+                    update_unwind_target(unwind);
+                }
+                None => {
+                    debug!(target: "reth::providers::static_file", "Invariants check completed, no unwind needed")
+                }
+            }
+        }
+
+        Ok(unwind_target.map(PipelineTarget::Unwind))
+    }
+
+    /// Heals file-level (`NippyJar`) inconsistencies for eligible static file
+    /// segments.
+    ///
+    /// Call before [`Self::check_consistency`] so files are internally
+    /// consistent.
+    ///
+    /// Uses the same segment-skip logic as [`Self::check_consistency`], but
+    /// does not compare with database checkpoints or prune against them.
+    pub fn check_file_consistency<Provider>(&self, provider: &Provider) -> ProviderResult<()>
+    where
+        Provider: DBProvider + ChainSpecProvider + StorageSettingsCache + PruneCheckpointReader,
+    {
+        info!(target: "reth::cli", "Healing static file inconsistencies.");
+
+        for segment in self.segments_to_check(provider) {
+            let _guard = info_span!("healing_static_file_segment", ?segment).entered();
+            let _ = self.maybe_heal_segment(segment)?;
+        }
+
+        Ok(())
+    }
+
+    /// Returns the static file segments that should be checked/healed for this provider.
+    fn segments_to_check<'a, Provider>(
+        &'a self,
+        provider: &'a Provider,
+    ) -> impl Iterator<Item = StaticFileSegment> + 'a
+    where
+        Provider: DBProvider + ChainSpecProvider + StorageSettingsCache + PruneCheckpointReader,
+    {
+        StaticFileSegment::iter()
+            .filter(move |segment| self.should_check_segment(provider, *segment))
+    }
+
+    /// True if the given segment should be checked/healed for this provider.
+    fn should_check_segment<Provider>(
+        &self,
+        provider: &Provider,
+        segment: StaticFileSegment,
+    ) -> bool
+    where
+        Provider: DBProvider + ChainSpecProvider + StorageSettingsCache + PruneCheckpointReader,
+    {
+        match segment {
+            StaticFileSegment::Headers | StaticFileSegment::Transactions => true,
+            StaticFileSegment::Receipts => {
+                if EitherWriter::receipts_destination(provider).is_database() {
+                    // Old pruned nodes (including full node) do not store receipts as static
+                    // files.
+                    debug!(target: "reth::providers::static_file", ?segment, "Skipping receipts segment: receipts stored in database");
+                    return false;
+                }
+
+                if NamedChain::Gnosis == provider.chain_spec().chain_id() ||
+                    NamedChain::Chiado == provider.chain_spec().chain_id()
+                {
+                    // Gnosis and Chiado's historical import is broken and does not work with
+                    // this check. They are importing receipts along
+                    // with importing headers/bodies.
+                    debug!(target: "reth::providers::static_file", ?segment, "Skipping receipts segment: broken historical import for gnosis/chiado");
+                    return false;
+                }
+
+                true
+            }
+            StaticFileSegment::TransactionSenders => {
+                if EitherWriterDestination::senders(provider).is_database() {
+                    debug!(target: "reth::providers::static_file", ?segment, "Skipping senders segment: senders stored in database");
+                    return false;
+                }
+
+                if Self::is_segment_fully_pruned(provider, PruneSegment::SenderRecovery) {
+                    debug!(target: "reth::providers::static_file", ?segment, "Skipping senders segment: fully pruned");
+                    return false;
+                }
+
+                true
+            }
+            StaticFileSegment::AccountChangeSets => {
+                if EitherWriter::account_changesets_destination(provider).is_database() {
+                    debug!(target: "reth::providers::static_file", ?segment, "Skipping account changesets segment: changesets stored in database");
+                    return false;
+                }
+                true
+            }
+            StaticFileSegment::StorageChangeSets => {
+                if EitherWriter::storage_changesets_destination(provider).is_database() {
+                    debug!(target: "reth::providers::static_file", ?segment, "Skipping storage changesets segment: changesets stored in database");
+                    return false
+                }
+                true
+            }
+        }
+    }
+
+    /// Returns `true` if the given prune segment has a checkpoint with
+    /// [`reth_prune_types::PruneMode::Full`], indicating all data for this segment has been
+    /// intentionally deleted.
+    fn is_segment_fully_pruned<Provider>(provider: &Provider, segment: PruneSegment) -> bool
+    where
+        Provider: PruneCheckpointReader,
+    {
+        provider
+            .get_prune_checkpoint(segment)
+            .ok()
+            .flatten()
+            .is_some_and(|checkpoint| checkpoint.prune_mode.is_full())
+    }
+
+    /// Checks consistency of the latest static file segment and throws an
+    /// error if at fault.
+    ///
+    /// Read-only.
+    fn check_segment_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()> {
+        debug!(target: "reth::providers::static_file", "Checking segment consistency");
+        if let Some(latest_block) = self.get_highest_static_file_block(segment) {
+            let file_path = self
+                .directory()
+                .join(segment.filename(&self.find_fixed_range(segment, latest_block)));
+            debug!(target: "reth::providers::static_file", ?file_path, latest_block, "Loading NippyJar for consistency check");
+
+            let jar = NippyJar::<SegmentHeader>::load(&file_path).map_err(ProviderError::other)?;
+            debug!(target: "reth::providers::static_file", "NippyJar loaded, checking consistency");
+
+            NippyJarChecker::new(jar).check_consistency().map_err(ProviderError::other)?;
+            debug!(target: "reth::providers::static_file", "NippyJar consistency check passed");
+        } else {
+            debug!(target: "reth::providers::static_file", "No static file block found, skipping consistency check");
+        }
+        Ok(())
+    }
+
+    /// Attempts to heal file-level (`NippyJar`) inconsistencies for a single static file segment.
+    ///
+    /// Returns the highest block before and after healing, which can be used to detect
+    /// if healing from a pruning interruption decreased the highest block.
+    ///
+    /// File consistency is broken if:
+    ///
+    /// * appending data was interrupted before a config commit, then data file will be truncated
+    ///   according to the config.
+    ///
+    /// * pruning data was interrupted before a config commit, then we have deleted data that we are
+    ///   expected to still have. We need to check the Database and unwind everything accordingly.
+    ///
+    /// **Note:** In read-only mode, this will return an error if a consistency issue is detected,
+    /// since healing requires write access.
+    fn maybe_heal_segment(
+        &self,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<(Option<BlockNumber>, Option<BlockNumber>)> {
+        let initial_highest_block = self.get_highest_static_file_block(segment);
+        debug!(target: "reth::providers::static_file", ?initial_highest_block, "Initial highest block for segment");
+
+        if self.access.is_read_only() {
+            // Read-only mode: cannot modify files, so just validate consistency and error if
+            // broken.
+            debug!(target: "reth::providers::static_file", "Checking segment consistency (read-only)");
+            self.check_segment_consistency(segment)?;
+        } else {
+            // Writable mode: fetching the writer will automatically heal any file-level
+            // inconsistency by truncating data to match the last committed config.
+            debug!(target: "reth::providers::static_file", "Fetching latest writer which might heal any potential inconsistency");
+            self.latest_writer(segment)?;
+        }
+
+        // The updated `highest_block` may have decreased if we healed from a
+        // pruning interruption.
+        let highest_block = self.get_highest_static_file_block(segment);
+
+        Ok((initial_highest_block, highest_block))
+    }
+
+    /// Ensure invariants for each corresponding table and static file segment.
+    fn ensure_invariants_for<Provider>(
+        &self,
+        provider: &Provider,
+        segment: StaticFileSegment,
+        highest_tx: Option<u64>,
+        highest_block: Option<BlockNumber>,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        N: NodePrimitives<Receipt: Value, BlockHeader: Value, SignedTx: Value>,
+    {
+        match segment {
+            StaticFileSegment::Headers => self
+                .ensure_invariants::<_, tables::Headers<N::BlockHeader>>(
+                    provider,
+                    segment,
+                    highest_block,
+                    highest_block,
+                ),
+            StaticFileSegment::Transactions => self
+                .ensure_invariants::<_, tables::Transactions<N::SignedTx>>(
+                    provider,
+                    segment,
+                    highest_tx,
+                    highest_block,
+                ),
+            StaticFileSegment::Receipts => self
+                .ensure_invariants::<_, tables::Receipts<N::Receipt>>(
+                    provider,
+                    segment,
+                    highest_tx,
+                    highest_block,
+                ),
+            StaticFileSegment::TransactionSenders => self
+                .ensure_invariants::<_, tables::TransactionSenders>(
+                    provider,
+                    segment,
+                    highest_tx,
+                    highest_block,
+                ),
+            StaticFileSegment::AccountChangeSets => self
+                .ensure_invariants::<_, tables::AccountChangeSets>(
+                    provider,
+                    segment,
+                    highest_tx,
+                    highest_block,
+                ),
+            StaticFileSegment::StorageChangeSets => self
+                .ensure_changeset_invariants_by_block::<_, tables::StorageChangeSets, _>(
+                    provider,
+                    segment,
+                    highest_block,
+                    |key| key.block_number(),
+                ),
+        }
+    }
+
+    /// Check invariants for each corresponding table and static file segment:
+    ///
+    /// * the corresponding database table should overlap or have continuity in their keys
+    ///   ([`TxNumber`] or [`BlockNumber`]).
+    /// * its highest block should match the stage checkpoint block number if it's equal or higher
+    ///   than the corresponding database table last entry.
+    ///   * If the checkpoint block is higher, then request a pipeline unwind to the static file
+    ///     block. This is expressed by returning [`Some`] with the requested pipeline unwind
+    ///     target.
+    ///   * If the checkpoint block is lower, then heal by removing rows from the static file. In
+    ///     this case, the rows will be removed and [`None`] will be returned.
+    ///
+    /// * If the database tables overlap with static files and have contiguous keys, or the
+    ///   checkpoint block matches the highest static files block, then [`None`] will be returned.
+    #[instrument(skip(self, provider, segment), fields(table = T::NAME))]
+    fn ensure_invariants<Provider, T: Table<Key = u64>>(
+        &self,
+        provider: &Provider,
+        segment: StaticFileSegment,
+        highest_static_file_entry: Option<u64>,
+        highest_static_file_block: Option<BlockNumber>,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider + BlockReader + StageCheckpointReader,
+    {
+        debug!(target: "reth::providers::static_file", "Ensuring invariants");
+        let mut db_cursor = provider.tx_ref().cursor_read::<T>()?;
+
+        if let Some((db_first_entry, _)) = db_cursor.first()? {
+            debug!(target: "reth::providers::static_file", db_first_entry, "Found first database entry");
+            if let (Some(highest_entry), Some(highest_block)) =
+                (highest_static_file_entry, highest_static_file_block)
+            {
+                // If there is a gap between the entry found in static file and
+                // database, then we have most likely lost static file data and need to unwind so we
+                // can load it again
+                if !(db_first_entry <= highest_entry || highest_entry + 1 == db_first_entry) {
+                    info!(
+                        target: "reth::providers::static_file",
+                        ?db_first_entry,
+                        ?highest_entry,
+                        unwind_target = highest_block,
+                        "Setting unwind target."
+                    );
+                    return Ok(Some(highest_block));
+                }
+            }
+
+            if let Some((db_last_entry, _)) = db_cursor.last()? &&
+                highest_static_file_entry
+                    .is_none_or(|highest_entry| db_last_entry > highest_entry)
+            {
+                debug!(target: "reth::providers::static_file", db_last_entry, "Database has entries beyond static files, no unwind needed");
+                return Ok(None)
+            }
+        } else {
+            debug!(target: "reth::providers::static_file", "No database entries found");
+        }
+
+        let highest_static_file_entry = highest_static_file_entry.unwrap_or_default();
+        let highest_static_file_block = highest_static_file_block.unwrap_or_default();
+
+        // If static file entry is ahead of the database entries, then ensure the checkpoint block
+        // number matches.
+        let stage_id = segment.to_stage_id();
+        let checkpoint_block_number =
+            provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
+        debug!(target: "reth::providers::static_file", ?stage_id, checkpoint_block_number, "Retrieved stage checkpoint");
+
+        // If the checkpoint is ahead, then we lost static file data. May be data corruption.
+        if checkpoint_block_number > highest_static_file_block {
+            info!(
+                target: "reth::providers::static_file",
+                checkpoint_block_number,
+                unwind_target = highest_static_file_block,
+                "Setting unwind target."
+            );
+            return Ok(Some(highest_static_file_block));
+        }
+
+        // If the checkpoint is ahead, or matches, then nothing to do.
+        if checkpoint_block_number >= highest_static_file_block {
+            debug!(target: "reth::providers::static_file", "Invariants ensured, returning None");
+            return Ok(None);
+        }
+
+        // If the checkpoint is behind, then we failed to do a database commit
+        // **but committed** to static files on executing a stage, or the
+        // reverse on unwinding a stage.
+        //
+        // All we need to do is to prune the extra static file rows.
+        info!(
+            target: "reth::providers",
+            from = highest_static_file_block,
+            to = checkpoint_block_number,
+            "Unwinding static file segment."
+        );
+        let mut writer = self.latest_writer(segment)?;
+
+        match segment {
+            StaticFileSegment::Headers => {
+                let prune_count = highest_static_file_block - checkpoint_block_number;
+                debug!(target: "reth::providers::static_file", prune_count, "Pruning headers");
+                // TODO(joshie): is_block_meta
+                writer.prune_headers(prune_count)?;
+            }
+            StaticFileSegment::Transactions |
+            StaticFileSegment::Receipts |
+            StaticFileSegment::TransactionSenders => {
+                if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
+                    let number = highest_static_file_entry - block.last_tx_num();
+                    debug!(target: "reth::providers::static_file", prune_count = number, checkpoint_block_number, "Pruning transaction based segment");
+
+                    match segment {
+                        StaticFileSegment::Transactions => {
+                            writer.prune_transactions(number, checkpoint_block_number)?
+                        }
+                        StaticFileSegment::Receipts => {
+                            writer.prune_receipts(number, checkpoint_block_number)?
+                        }
+                        StaticFileSegment::TransactionSenders => {
+                            writer.prune_transaction_senders(number, checkpoint_block_number)?
+                        }
+                        StaticFileSegment::Headers |
+                        StaticFileSegment::AccountChangeSets |
+                        StaticFileSegment::StorageChangeSets => {
+                            unreachable!()
+                        }
+                    }
+                } else {
+                    debug!(target: "reth::providers::static_file", checkpoint_block_number, "No block body indices found for checkpoint block");
+                }
+            }
+            StaticFileSegment::AccountChangeSets => {
+                writer.prune_account_changesets(checkpoint_block_number)?;
+            }
+            StaticFileSegment::StorageChangeSets => {
+                writer.prune_storage_changesets(checkpoint_block_number)?;
+            }
+        }
+
+        debug!(target: "reth::providers::static_file", "Committing writer after pruning");
+        writer.commit()?;
+        debug!(target: "reth::providers::static_file", "Writer committed successfully");
+
+        debug!(target: "reth::providers::static_file", "Invariants ensured, returning None");
+        Ok(None)
+    }
+
+    fn ensure_changeset_invariants_by_block<Provider, T, F>(
+        &self,
+        provider: &Provider,
+        segment: StaticFileSegment,
+        highest_static_file_block: Option<BlockNumber>,
+        block_from_key: F,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        T: Table,
+        F: Fn(&T::Key) -> BlockNumber,
+    {
+        debug!(
+            target: "reth::providers::static_file",
+            ?segment,
+            ?highest_static_file_block,
+            "Ensuring changeset invariants"
+        );
+        let mut db_cursor = provider.tx_ref().cursor_read::<T>()?;
+
+        if let Some((db_first_key, _)) = db_cursor.first()? {
+            let db_first_block = block_from_key(&db_first_key);
+            if let Some(highest_block) = highest_static_file_block &&
+                !(db_first_block <= highest_block || highest_block + 1 == db_first_block)
+            {
+                info!(
+                    target: "reth::providers::static_file",
+                    ?db_first_block,
+                    ?highest_block,
+                    unwind_target = highest_block,
+                    ?segment,
+                    "Setting unwind target."
+                );
+                return Ok(Some(highest_block))
+            }
+
+            if let Some((db_last_key, _)) = db_cursor.last()? &&
+                highest_static_file_block
+                    .is_none_or(|highest_block| block_from_key(&db_last_key) > highest_block)
+            {
+                debug!(
+                    target: "reth::providers::static_file",
+                    ?segment,
+                    "Database has entries beyond static files, no unwind needed"
+                );
+                return Ok(None)
+            }
+        } else {
+            debug!(target: "reth::providers::static_file", ?segment, "No database entries found");
+        }
+
+        let highest_static_file_block = highest_static_file_block.unwrap_or_default();
+
+        let stage_id = segment.to_stage_id();
+        let checkpoint_block_number =
+            provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
+
+        if checkpoint_block_number > highest_static_file_block {
+            info!(
+                target: "reth::providers::static_file",
+                checkpoint_block_number,
+                unwind_target = highest_static_file_block,
+                ?segment,
+                "Setting unwind target."
+            );
+            return Ok(Some(highest_static_file_block))
+        }
+
+        if checkpoint_block_number < highest_static_file_block {
+            info!(
+                target: "reth::providers",
+                ?segment,
+                from = highest_static_file_block,
+                to = checkpoint_block_number,
+                "Unwinding static file segment."
+            );
+            let mut writer = self.latest_writer(segment)?;
+            match segment {
+                StaticFileSegment::AccountChangeSets => {
+                    writer.prune_account_changesets(checkpoint_block_number)?;
+                }
+                StaticFileSegment::StorageChangeSets => {
+                    writer.prune_storage_changesets(checkpoint_block_number)?;
+                }
+                _ => unreachable!("invalid segment for changeset invariants"),
+            }
+            writer.commit()?;
+        }
+
+        Ok(None)
+    }
+
+    /// Returns the earliest available block number that has not been expired and is still
+    /// available.
+    ///
+    /// This means that the highest expired block (or expired block height) is
+    /// `earliest_history_height.saturating_sub(1)`.
+    ///
+    /// Returns `0` if no history has been expired.
+    pub fn earliest_history_height(&self) -> BlockNumber {
+        self.earliest_history_height.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Gets the lowest static file's block range if it exists for a static file segment.
+    ///
+    /// If there is nothing on disk for the given segment, this will return [`None`].
+    pub fn get_lowest_range(&self, segment: StaticFileSegment) -> Option<SegmentRangeInclusive> {
+        self.indexes.read().get(segment).and_then(|index| index.min_block_range)
+    }
+
+    /// Gets the lowest static file's block range start if it exists for a static file segment.
+    ///
+    /// For example if the lowest static file has blocks 0-499, this will return 0.
+    ///
+    /// If there is nothing on disk for the given segment, this will return [`None`].
+    pub fn get_lowest_range_start(&self, segment: StaticFileSegment) -> Option<BlockNumber> {
+        self.get_lowest_range(segment).map(|range| range.start())
+    }
+
+    /// Gets the lowest static file's block range end if it exists for a static file segment.
+    ///
+    /// For example if the static file has blocks 0-499, this will return 499.
+    ///
+    /// If there is nothing on disk for the given segment, this will return [`None`].
+    pub fn get_lowest_range_end(&self, segment: StaticFileSegment) -> Option<BlockNumber> {
+        self.get_lowest_range(segment).map(|range| range.end())
+    }
+
+    /// Gets the highest static file's block height if it exists for a static file segment.
+    ///
+    /// If there is nothing on disk for the given segment, this will return [`None`].
+    pub fn get_highest_static_file_block(&self, segment: StaticFileSegment) -> Option<BlockNumber> {
+        self.indexes.read().get(segment).map(|index| index.max_block)
+    }
+
+    /// Converts a range to a bounded `RangeInclusive` capped to the highest static file block.
+    ///
+    /// This is necessary because static file iteration beyond the tip would loop forever:
+    /// blocks beyond the static file tip return `Ok(empty)` which is indistinguishable from
+    /// blocks with no changes. We cap the end to the highest available block regardless of
+    /// whether the input was unbounded or an explicit large value like `BlockNumber::MAX`.
+    fn bound_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        segment: StaticFileSegment,
+    ) -> RangeInclusive<BlockNumber> {
+        let highest_block = self.get_highest_static_file_block(segment).unwrap_or(0);
+
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n.saturating_add(1),
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(&n) => n.min(highest_block),
+            Bound::Excluded(&n) => n.saturating_sub(1).min(highest_block),
+            Bound::Unbounded => highest_block,
+        };
+
+        start..=end
+    }
+
+    /// Gets the highest static file transaction.
+    ///
+    /// If there is nothing on disk for the given segment, this will return [`None`].
+    pub fn get_highest_static_file_tx(&self, segment: StaticFileSegment) -> Option<TxNumber> {
+        self.indexes
+            .read()
+            .get(segment)
+            .and_then(|index| index.available_block_ranges_by_max_tx.as_ref())
+            .and_then(|index| index.last_key_value().map(|(last_tx, _)| *last_tx))
+    }
+
+    /// Gets the highest static file block for all segments.
+    pub fn get_highest_static_files(&self) -> HighestStaticFiles {
+        HighestStaticFiles {
+            receipts: self.get_highest_static_file_block(StaticFileSegment::Receipts),
+        }
+    }
+
+    /// Iterates through segment `static_files` in reverse order, executing a function until it
+    /// returns some object. Useful for finding objects by [`TxHash`] or [`BlockHash`].
+    pub fn find_static_file<T>(
+        &self,
+        segment: StaticFileSegment,
+        func: impl Fn(StaticFileJarProvider<'_, N>) -> ProviderResult<Option<T>>,
+    ) -> ProviderResult<Option<T>> {
+        if let Some(ranges) =
+            self.indexes.read().get(segment).map(|index| &index.expected_block_ranges_by_max_block)
+        {
+            // Iterate through all ranges in reverse order (highest to lowest)
+            for range in ranges.values().rev() {
+                if let Some(res) = func(self.get_or_create_jar_provider(segment, range)?)? {
+                    return Ok(Some(res));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Fetches data within a specified range across multiple static files.
+    ///
+    /// This function iteratively retrieves data using `get_fn` for each item in the given range.
+    /// It continues fetching until the end of the range is reached or the provided `predicate`
+    /// returns false.
+    pub fn fetch_range_with_predicate<T, F, P>(
+        &self,
+        segment: StaticFileSegment,
+        range: Range<u64>,
+        mut get_fn: F,
+        mut predicate: P,
+    ) -> ProviderResult<Vec<T>>
+    where
+        F: FnMut(&mut StaticFileCursor<'_>, u64) -> ProviderResult<Option<T>>,
+        P: FnMut(&T) -> bool,
+    {
+        let mut result = Vec::with_capacity((range.end - range.start).min(100) as usize);
+
+        /// Resolves to the provider for the given block or transaction number.
+        ///
+        /// If the static file is missing, the `result` is returned.
+        macro_rules! get_provider {
+            ($number:expr) => {{
+                match self.get_segment_provider(segment, $number) {
+                    Ok(provider) => provider,
+                    Err(
+                        ProviderError::MissingStaticFileBlock(_, _) |
+                        ProviderError::MissingStaticFileTx(_, _),
+                    ) => return Ok(result),
+                    Err(err) => return Err(err),
+                }
+            }};
+        }
+
+        let mut provider = get_provider!(range.start);
+        let mut cursor = provider.cursor()?;
+
+        // advances number in range
+        'outer: for number in range {
+            // The `retrying` flag ensures a single retry attempt per `number`. If `get_fn` fails to
+            // access data in two different static files, it halts further attempts by returning
+            // an error, effectively preventing infinite retry loops.
+            let mut retrying = false;
+
+            // advances static files if `get_fn` returns None
+            'inner: loop {
+                match get_fn(&mut cursor, number)? {
+                    Some(res) => {
+                        if !predicate(&res) {
+                            break 'outer;
+                        }
+                        result.push(res);
+                        break 'inner;
+                    }
+                    None => {
+                        if retrying {
+                            return Ok(result);
+                        }
+                        // There is a very small chance of hitting a deadlock if two consecutive
+                        // static files share the same bucket in the
+                        // internal dashmap and we don't drop the current provider
+                        // before requesting the next one.
+                        drop(cursor);
+                        drop(provider);
+                        provider = get_provider!(number);
+                        cursor = provider.cursor()?;
+                        retrying = true;
+                    }
+                }
+            }
+        }
+
+        result.shrink_to_fit();
+
+        Ok(result)
+    }
+
+    /// Fetches data within a specified range across multiple static files.
+    ///
+    /// Returns an iterator over the data. Yields [`None`] if the data for the specified number is
+    /// not found.
+    pub fn fetch_range_iter<'a, T, F>(
+        &'a self,
+        segment: StaticFileSegment,
+        range: Range<u64>,
+        get_fn: F,
+    ) -> ProviderResult<impl Iterator<Item = ProviderResult<Option<T>>> + 'a>
+    where
+        F: Fn(&mut StaticFileCursor<'_>, u64) -> ProviderResult<Option<T>> + 'a,
+        T: std::fmt::Debug,
+    {
+        let mut provider = self.get_maybe_segment_provider(segment, range.start)?;
+        Ok(range.map(move |number| {
+            match provider
+                .as_ref()
+                .map(|provider| get_fn(&mut provider.cursor()?, number))
+                .and_then(|result| result.transpose())
+            {
+                Some(result) => result.map(Some),
+                None => {
+                    // There is a very small chance of hitting a deadlock if two consecutive
+                    // static files share the same bucket in the internal dashmap and we don't drop
+                    // the current provider before requesting the next one.
+                    provider.take();
+                    provider = self.get_maybe_segment_provider(segment, number)?;
+                    provider
+                        .as_ref()
+                        .map(|provider| get_fn(&mut provider.cursor()?, number))
+                        .and_then(|result| result.transpose())
+                        .transpose()
+                }
+            }
+        }))
+    }
+
+    /// Returns directory where `static_files` are located.
+    pub fn directory(&self) -> &Path {
+        &self.path
+    }
+
+    /// Retrieves data from the database or static file, wherever it's available.
+    ///
+    /// # Arguments
+    /// * `segment` - The segment of the static file to check against.
+    /// * `index_key` - Requested index key, usually a block or transaction number.
+    /// * `fetch_from_static_file` - A closure that defines how to fetch the data from the static
+    ///   file provider.
+    /// * `fetch_from_database` - A closure that defines how to fetch the data from the database
+    ///   when the static file doesn't contain the required data or is not available.
+    pub fn get_with_static_file_or_database<T, FS, FD>(
+        &self,
+        segment: StaticFileSegment,
+        number: u64,
+        fetch_from_static_file: FS,
+        fetch_from_database: FD,
+    ) -> ProviderResult<Option<T>>
+    where
+        FS: Fn(&Self) -> ProviderResult<Option<T>>,
+        FD: Fn() -> ProviderResult<Option<T>>,
+    {
+        // If there is, check the maximum block or transaction number of the segment.
+        let static_file_upper_bound = if segment.is_block_or_change_based() {
+            self.get_highest_static_file_block(segment)
+        } else {
+            self.get_highest_static_file_tx(segment)
+        };
+
+        if static_file_upper_bound
+            .is_some_and(|static_file_upper_bound| static_file_upper_bound >= number)
+        {
+            return fetch_from_static_file(self);
+        }
+        fetch_from_database()
+    }
+
+    /// Gets data within a specified range, potentially spanning different `static_files` and
+    /// database.
+    ///
+    /// # Arguments
+    /// * `segment` - The segment of the static file to query.
+    /// * `block_or_tx_range` - The range of data to fetch.
+    /// * `fetch_from_static_file` - A function to fetch data from the `static_file`.
+    /// * `fetch_from_database` - A function to fetch data from the database.
+    /// * `predicate` - A function used to evaluate each item in the fetched data. Fetching is
+    ///   terminated when this function returns false, thereby filtering the data based on the
+    ///   provided condition.
+    pub fn get_range_with_static_file_or_database<T, P, FS, FD>(
+        &self,
+        segment: StaticFileSegment,
+        mut block_or_tx_range: Range<u64>,
+        fetch_from_static_file: FS,
+        mut fetch_from_database: FD,
+        mut predicate: P,
+    ) -> ProviderResult<Vec<T>>
+    where
+        FS: Fn(&Self, Range<u64>, &mut P) -> ProviderResult<Vec<T>>,
+        FD: FnMut(Range<u64>, P) -> ProviderResult<Vec<T>>,
+        P: FnMut(&T) -> bool,
+    {
+        let mut data = Vec::new();
+
+        // If there is, check the maximum block or transaction number of the segment.
+        if let Some(static_file_upper_bound) = if segment.is_block_or_change_based() {
+            self.get_highest_static_file_block(segment)
+        } else {
+            self.get_highest_static_file_tx(segment)
+        } && block_or_tx_range.start <= static_file_upper_bound
+        {
+            let end = block_or_tx_range.end.min(static_file_upper_bound + 1);
+            data.extend(fetch_from_static_file(
+                self,
+                block_or_tx_range.start..end,
+                &mut predicate,
+            )?);
+            block_or_tx_range.start = end;
+        }
+
+        if block_or_tx_range.end > block_or_tx_range.start {
+            data.extend(fetch_from_database(block_or_tx_range, predicate)?)
+        }
+
+        Ok(data)
+    }
+
+    /// Returns static files directory
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns transaction index
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn tx_index(&self, segment: StaticFileSegment) -> Option<SegmentRanges> {
+        self.indexes
+            .read()
+            .get(segment)
+            .and_then(|index| index.available_block_ranges_by_max_tx.as_ref())
+            .cloned()
+    }
+
+    /// Returns expected block index
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn expected_block_index(&self, segment: StaticFileSegment) -> Option<SegmentRanges> {
+        self.indexes
+            .read()
+            .get(segment)
+            .map(|index| &index.expected_block_ranges_by_max_block)
+            .cloned()
+    }
+}
+
+#[derive(Debug)]
+struct StaticFileSegmentIndex {
+    /// Min static file block range.
+    ///
+    /// This index is initialized on launch to keep track of the lowest, non-expired static file
+    /// per segment and gets updated on [`StaticFileProvider::update_index`].
+    ///
+    /// This tracks the lowest static file per segment together with the block range in that
+    /// file. E.g. static file is batched in 500k block intervals then the lowest static file
+    /// is [0..499K], and the block range is start = 0, end = 499K.
+    ///
+    /// This index is mainly used for history expiry, which targets transactions, e.g. pre-merge
+    /// history expiry would lead to removing all static files below the merge height.
+    min_block_range: Option<SegmentRangeInclusive>,
+    /// Max static file block.
+    max_block: u64,
+    /// Expected static file block ranges indexed by max expected blocks.
+    ///
+    /// For example, a static file for expected block range `0..=499_000` may have only block range
+    /// `0..=1000` contained in it, as it's not fully filled yet. This index maps the max expected
+    /// block to the expected range, i.e. block `499_000` to block range `0..=499_000`.
+    expected_block_ranges_by_max_block: SegmentRanges,
+    /// Available on disk static file block ranges indexed by max transactions.
+    ///
+    /// For example, a static file for block range `0..=499_000` may only have block range
+    /// `0..=1000` and transaction range `0..=2000` contained in it. This index maps the max
+    /// available transaction to the available block range, i.e. transaction `2000` to block range
+    /// `0..=1000`.
+    available_block_ranges_by_max_tx: Option<SegmentRanges>,
+}
+
+/// Helper trait to manage different [`StaticFileProviderRW`] of an `Arc<StaticFileProvider`
+pub trait StaticFileWriter {
+    /// The primitives type used by the static file provider.
+    type Primitives: Send + Sync + 'static;
+
+    /// Returns a mutable reference to a [`StaticFileProviderRW`] of a [`StaticFileSegment`].
+    fn get_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>>;
+
+    /// Returns a mutable reference to a [`StaticFileProviderRW`] of the latest
+    /// [`StaticFileSegment`].
+    fn latest_writer(
+        &self,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>>;
+
+    /// Commits all changes of all [`StaticFileProviderRW`] of all [`StaticFileSegment`].
+    fn commit(&self) -> ProviderResult<()>;
+
+    /// Returns `true` if the static file provider has unwind queued.
+    fn has_unwind_queued(&self) -> bool;
+
+    /// Finalizes all static file writers by committing their configuration to disk.
+    ///
+    /// Returns an error if prune is queued (use [`Self::commit`] instead).
+    fn finalize(&self) -> ProviderResult<()>;
+}
+
+impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
+    type Primitives = N;
+
+    fn get_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        if self.access.is_read_only() {
+            return Err(ProviderError::ReadOnlyStaticFileAccess);
+        }
+
+        trace!(target: "providers::static_file", ?block, ?segment, "Getting static file writer.");
+        self.writers.get_or_create(segment, || {
+            StaticFileProviderRW::new(segment, block, Arc::downgrade(&self.0), self.metrics.clone())
+        })
+    }
+
+    fn latest_writer(
+        &self,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        let genesis_number = self.0.as_ref().genesis_block_number();
+        self.get_writer(
+            self.get_highest_static_file_block(segment).unwrap_or(genesis_number),
+            segment,
+        )
+    }
+
+    fn commit(&self) -> ProviderResult<()> {
+        self.writers.commit()
+    }
+
+    fn has_unwind_queued(&self) -> bool {
+        self.writers.has_unwind_queued()
+    }
+
+    fn finalize(&self) -> ProviderResult<()> {
+        self.writers.finalize()
+    }
+}
+
+impl<N: NodePrimitives> ChangeSetReader for StaticFileProvider<N> {
+    fn account_block_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<reth_db::models::AccountBeforeTx>> {
+        let provider = match self.get_segment_provider_for_block(
+            StaticFileSegment::AccountChangeSets,
+            block_number,
+            None,
+        ) {
+            Ok(provider) => provider,
+            Err(ProviderError::MissingStaticFileBlock(_, _)) => return Ok(Vec::new()),
+            Err(err) => return Err(err),
+        };
+
+        if let Some(offset) = provider.read_changeset_offset(block_number)? {
+            let mut cursor = provider.cursor()?;
+            let mut changeset = Vec::with_capacity(offset.num_changes() as usize);
+
+            for i in offset.changeset_range() {
+                if let Some(change) =
+                    cursor.get_one::<reth_db::static_file::AccountChangesetMask>(i.into())?
+                {
+                    changeset.push(change)
+                }
+            }
+            Ok(changeset)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn get_account_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+    ) -> ProviderResult<Option<reth_db::models::AccountBeforeTx>> {
+        let provider = match self.get_segment_provider_for_block(
+            StaticFileSegment::AccountChangeSets,
+            block_number,
+            None,
+        ) {
+            Ok(provider) => provider,
+            Err(ProviderError::MissingStaticFileBlock(_, _)) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+
+        let Some(offset) = provider.read_changeset_offset(block_number)? else {
+            return Ok(None);
+        };
+
+        let mut cursor = provider.cursor()?;
+        let range = offset.changeset_range();
+        let mut low = range.start;
+        let mut high = range.end;
+
+        while low < high {
+            let mid = low + (high - low) / 2;
+            if let Some(change) =
+                cursor.get_one::<reth_db::static_file::AccountChangesetMask>(mid.into())?
+            {
+                if change.address < address {
+                    low = mid + 1;
+                } else {
+                    high = mid;
+                }
+            } else {
+                // This is not expected but means we are out of the range / file somehow, and can't
+                // continue
+                debug!(
+                    target: "providers::static_file",
+                    ?low,
+                    ?mid,
+                    ?high,
+                    ?range,
+                    ?block_number,
+                    ?address,
+                    "Cannot continue binary search for account changeset fetch"
+                );
+                low = range.end;
+                break;
+            }
+        }
+
+        if low < range.end &&
+            let Some(change) = cursor
+                .get_one::<reth_db::static_file::AccountChangesetMask>(low.into())?
+                .filter(|change| change.address == address)
+        {
+            return Ok(Some(change));
+        }
+
+        Ok(None)
+    }
+
+    fn account_changesets_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumber, reth_db::models::AccountBeforeTx)>> {
+        let range = self.bound_range(range, StaticFileSegment::AccountChangeSets);
+        self.walk_account_changeset_range(range).collect()
+    }
+}
+
+impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
+    fn storage_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        let provider = match self.get_segment_provider_for_block(
+            StaticFileSegment::StorageChangeSets,
+            block_number,
+            None,
+        ) {
+            Ok(provider) => provider,
+            Err(ProviderError::MissingStaticFileBlock(_, _)) => return Ok(Vec::new()),
+            Err(err) => return Err(err),
+        };
+
+        if let Some(offset) = provider.read_changeset_offset(block_number)? {
+            let mut cursor = provider.cursor()?;
+            let mut changeset = Vec::with_capacity(offset.num_changes() as usize);
+
+            for i in offset.changeset_range() {
+                if let Some(change) = cursor.get_one::<StorageChangesetMask>(i.into())? {
+                    let block_address = BlockNumberAddress((block_number, change.address));
+                    let entry = StorageEntry { key: change.key, value: change.value };
+                    changeset.push((block_address, entry));
+                }
+            }
+            Ok(changeset)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn get_storage_before_block(
+        &self,
+        block_number: BlockNumber,
+        address: Address,
+        storage_key: B256,
+    ) -> ProviderResult<Option<StorageEntry>> {
+        let provider = match self.get_segment_provider_for_block(
+            StaticFileSegment::StorageChangeSets,
+            block_number,
+            None,
+        ) {
+            Ok(provider) => provider,
+            Err(ProviderError::MissingStaticFileBlock(_, _)) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+
+        let Some(offset) = provider.read_changeset_offset(block_number)? else {
+            return Ok(None);
+        };
+
+        let mut cursor = provider.cursor()?;
+        let range = offset.changeset_range();
+        let mut low = range.start;
+        let mut high = range.end;
+
+        while low < high {
+            let mid = low + (high - low) / 2;
+            if let Some(change) = cursor.get_one::<StorageChangesetMask>(mid.into())? {
+                match (change.address, change.key).cmp(&(address, storage_key)) {
+                    std::cmp::Ordering::Less => low = mid + 1,
+                    _ => high = mid,
+                }
+            } else {
+                debug!(
+                    target: "providers::static_file",
+                    ?low,
+                    ?mid,
+                    ?high,
+                    ?range,
+                    ?block_number,
+                    ?address,
+                    ?storage_key,
+                    "Cannot continue binary search for storage changeset fetch"
+                );
+                low = range.end;
+                break;
+            }
+        }
+
+        if low < range.end &&
+            let Some(change) = cursor
+                .get_one::<StorageChangesetMask>(low.into())?
+                .filter(|change| change.address == address && change.key == storage_key)
+        {
+            return Ok(Some(StorageEntry { key: change.key, value: change.value }));
+        }
+
+        Ok(None)
+    }
+
+    fn storage_changesets_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        let range = self.bound_range(range, StaticFileSegment::StorageChangeSets);
+        self.walk_storage_changeset_range(range).collect()
+    }
+}
+
+impl<N: NodePrimitives> StaticFileProvider<N> {
+    /// Creates an iterator for walking through account changesets in the specified block range.
+    ///
+    /// This returns a lazy iterator that fetches changesets block by block to avoid loading
+    /// everything into memory at once.
+    ///
+    /// Accepts any range type that implements `RangeBounds<BlockNumber>`, including:
+    /// - `Range<BlockNumber>` (e.g., `0..100`)
+    /// - `RangeInclusive<BlockNumber>` (e.g., `0..=99`)
+    /// - `RangeFrom<BlockNumber>` (e.g., `0..`) - iterates until exhausted
+    pub fn walk_account_changeset_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> StaticFileAccountChangesetWalker<Self> {
+        StaticFileAccountChangesetWalker::new(self.clone(), range)
+    }
+
+    /// Creates an iterator for walking through storage changesets in the specified block range.
+    pub fn walk_storage_changeset_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> StaticFileStorageChangesetWalker<Self> {
+        StaticFileStorageChangesetWalker::new(self.clone(), range)
+    }
+}
+
+impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileProvider<N> {
+    type Header = N::BlockHeader;
+
+    fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        self.find_static_file(StaticFileSegment::Headers, |jar_provider| {
+            Ok(jar_provider
+                .cursor()?
+                .get_two::<HeaderWithHashMask<Self::Header>>((&block_hash).into())?
+                .and_then(|(header, hash)| {
+                    if hash == block_hash {
+                        return Some(header);
+                    }
+                    None
+                }))
+        })
+    }
+
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+        self.get_segment_provider_for_block(StaticFileSegment::Headers, num, None)
+            .and_then(|provider| provider.header_by_number(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileBlock(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
+        self.fetch_range_with_predicate(
+            StaticFileSegment::Headers,
+            to_range(range),
+            |cursor, number| cursor.get_one::<HeaderMask<Self::Header>>(number.into()),
+            |_| true,
+        )
+    }
+
+    fn sealed_header(
+        &self,
+        num: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        self.get_segment_provider_for_block(StaticFileSegment::Headers, num, None)
+            .and_then(|provider| provider.sealed_header(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileBlock(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        self.fetch_range_with_predicate(
+            StaticFileSegment::Headers,
+            to_range(range),
+            |cursor, number| {
+                Ok(cursor
+                    .get_two::<HeaderWithHashMask<Self::Header>>(number.into())?
+                    .map(|(header, hash)| SealedHeader::new(header, hash)))
+            },
+            predicate,
+        )
+    }
+}
+
+impl<N: NodePrimitives> BlockHashReader for StaticFileProvider<N> {
+    fn block_hash(&self, num: u64) -> ProviderResult<Option<B256>> {
+        self.get_segment_provider_for_block(StaticFileSegment::Headers, num, None)
+            .and_then(|provider| provider.block_hash(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileBlock(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.fetch_range_with_predicate(
+            StaticFileSegment::Headers,
+            start..end,
+            |cursor, number| cursor.get_one::<BlockHashMask>(number.into()),
+            |_| true,
+        )
+    }
+}
+
+impl<N: NodePrimitives<SignedTx: Value + SignedTransaction, Receipt: Value>> ReceiptProvider
+    for StaticFileProvider<N>
+{
+    type Receipt = N::Receipt;
+
+    fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+        self.get_segment_provider_for_transaction(StaticFileSegment::Receipts, num, None)
+            .and_then(|provider| provider.receipt(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileTx(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+        if let Some(num) = self.transaction_id(hash)? {
+            return self.receipt(num);
+        }
+        Ok(None)
+    }
+
+    fn receipts_by_block(
+        &self,
+        _block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        unreachable!()
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Receipt>> {
+        self.fetch_range_with_predicate(
+            StaticFileSegment::Receipts,
+            to_range(range),
+            |cursor, number| cursor.get_one::<ReceiptMask<Self::Receipt>>(number.into()),
+            |_| true,
+        )
+    }
+
+    fn receipts_by_block_range(
+        &self,
+        _block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl<N: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>> TransactionsProviderExt
+    for StaticFileProvider<N>
+{
+    fn transaction_hashes_by_range(
+        &self,
+        tx_range: Range<TxNumber>,
+    ) -> ProviderResult<Vec<(TxHash, TxNumber)>> {
+        let tx_range_size = (tx_range.end - tx_range.start) as usize;
+
+        // Transactions are different size, so chunks will not all take the same processing time. If
+        // chunks are too big, there will be idle threads waiting for work. Choosing an
+        // arbitrary smaller value to make sure it doesn't happen.
+        let chunk_size = 100;
+
+        // iterator over the chunks
+        let chunks = tx_range
+            .clone()
+            .step_by(chunk_size)
+            .map(|start| start..std::cmp::min(start + chunk_size as u64, tx_range.end));
+        let mut channels = Vec::with_capacity(tx_range_size.div_ceil(chunk_size));
+
+        for chunk_range in chunks {
+            let (channel_tx, channel_rx) = mpsc::channel();
+            channels.push(channel_rx);
+
+            let manager = self.clone();
+
+            // Spawn the task onto the global rayon pool
+            // This task will send the results through the channel after it has calculated
+            // the hash.
+            rayon::spawn(move || {
+                let mut rlp_buf = Vec::with_capacity(128);
+                let _ = manager.fetch_range_with_predicate(
+                    StaticFileSegment::Transactions,
+                    chunk_range,
+                    |cursor, number| {
+                        Ok(cursor
+                            .get_one::<TransactionMask<Self::Transaction>>(number.into())?
+                            .map(|transaction| {
+                                rlp_buf.clear();
+                                let _ = channel_tx
+                                    .send(calculate_hash((number, transaction), &mut rlp_buf));
+                            }))
+                    },
+                    |_| true,
+                );
+            });
+        }
+
+        let mut tx_list = Vec::with_capacity(tx_range_size);
+
+        // Iterate over channels and append the tx hashes unsorted
+        for channel in channels {
+            while let Ok(tx) = channel.recv() {
+                let (tx_hash, tx_id) = tx.map_err(|boxed| *boxed)?;
+                tx_list.push((tx_hash, tx_id));
+            }
+        }
+
+        Ok(tx_list)
+    }
+}
+
+impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsProvider
+    for StaticFileProvider<N>
+{
+    type Transaction = N::SignedTx;
+
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        self.find_static_file(StaticFileSegment::Transactions, |jar_provider| {
+            let mut cursor = jar_provider.cursor()?;
+            if cursor
+                .get_one::<TransactionMask<Self::Transaction>>((&tx_hash).into())?
+                .and_then(|tx| (tx.trie_hash() == tx_hash).then_some(tx))
+                .is_some()
+            {
+                Ok(cursor.number())
+            } else {
+                Ok(None)
+            }
+        })
+    }
+
+    fn transaction_by_id(&self, num: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        self.get_segment_provider_for_transaction(StaticFileSegment::Transactions, num, None)
+            .and_then(|provider| provider.transaction_by_id(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileTx(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        num: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        self.get_segment_provider_for_transaction(StaticFileSegment::Transactions, num, None)
+            .and_then(|provider| provider.transaction_by_id_unhashed(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileTx(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        self.find_static_file(StaticFileSegment::Transactions, |jar_provider| {
+            Ok(jar_provider
+                .cursor()?
+                .get_one::<TransactionMask<Self::Transaction>>((&hash).into())?
+                .and_then(|tx| (tx.trie_hash() == hash).then_some(tx)))
+        })
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        _hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn transactions_by_block(
+        &self,
+        _block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        self.fetch_range_with_predicate(
+            StaticFileSegment::Transactions,
+            to_range(range),
+            |cursor, number| cursor.get_one::<TransactionMask<Self::Transaction>>(number.into()),
+            |_| true,
+        )
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        self.fetch_range_with_predicate(
+            StaticFileSegment::TransactionSenders,
+            to_range(range),
+            |cursor, number| cursor.get_one::<TransactionSenderMask>(number.into()),
+            |_| true,
+        )
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        self.get_segment_provider_for_transaction(StaticFileSegment::TransactionSenders, id, None)
+            .and_then(|provider| provider.transaction_sender(id))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileTx(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+}
+
+impl<N: NodePrimitives> BlockNumReader for StaticFileProvider<N> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        Ok(self.get_highest_static_file_block(StaticFileSegment::Headers).unwrap_or_default())
+    }
+
+    fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+/* Cannot be successfully implemented but must exist for trait requirements */
+
+impl<N: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>> BlockReader
+    for StaticFileProvider<N>
+{
+    type Block = N::Block;
+
+    fn find_block_by_hash(
+        &self,
+        _hash: B256,
+        _source: BlockSource,
+    ) -> ProviderResult<Option<Self::Block>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn pending_block_and_receipts(
+        &self,
+    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<Self::Receipt>)>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn recovered_block(
+        &self,
+        _id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn sealed_block_with_senders(
+        &self,
+        _id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_with_senders_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn recovered_block_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_by_transaction_id(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileProvider<N> {
+    fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_body_indices_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl<N: NodePrimitives> StatsReader for StaticFileProvider<N> {
+    fn count_entries<T: Table>(&self) -> ProviderResult<usize> {
+        match T::NAME {
+            tables::CanonicalHeaders::NAME |
+            tables::Headers::<Header>::NAME |
+            tables::HeaderTerminalDifficulties::NAME => Ok(self
+                .get_highest_static_file_block(StaticFileSegment::Headers)
+                .map(|block| block + 1)
+                .unwrap_or_default()
+                as usize),
+            tables::Receipts::<Receipt>::NAME => Ok(self
+                .get_highest_static_file_tx(StaticFileSegment::Receipts)
+                .map(|receipts| receipts + 1)
+                .unwrap_or_default() as usize),
+            tables::Transactions::<TransactionSigned>::NAME => Ok(self
+                .get_highest_static_file_tx(StaticFileSegment::Transactions)
+                .map(|txs| txs + 1)
+                .unwrap_or_default()
+                as usize),
+            tables::TransactionSenders::NAME => Ok(self
+                .get_highest_static_file_tx(StaticFileSegment::TransactionSenders)
+                .map(|txs| txs + 1)
+                .unwrap_or_default() as usize),
+            _ => Err(ProviderError::UnsupportedProvider),
+        }
+    }
+}
+
+/// Calculates the tx hash for the given transaction and its id.
+#[inline]
+fn calculate_hash<T>(
+    entry: (TxNumber, T),
+    rlp_buf: &mut Vec<u8>,
+) -> Result<(B256, TxNumber), Box<ProviderError>>
+where
+    T: Encodable2718,
+{
+    let (tx_id, tx) = entry;
+    tx.encode_2718(rlp_buf);
+    Ok((keccak256(rlp_buf), tx_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use reth_chain_state::EthPrimitives;
+    use reth_db::test_utils::create_test_static_files_dir;
+    use reth_static_file_types::{SegmentRangeInclusive, StaticFileSegment};
+
+    use crate::{providers::StaticFileProvider, StaticFileProviderBuilder};
+
+    #[test]
+    fn test_find_fixed_range_with_block_index() -> eyre::Result<()> {
+        let (static_dir, _) = create_test_static_files_dir();
+        let sf_rw: StaticFileProvider<EthPrimitives> =
+            StaticFileProviderBuilder::read_write(&static_dir).with_blocks_per_file(100).build()?;
+
+        let segment = StaticFileSegment::Headers;
+
+        // Test with None - should use default behavior
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, None, 0),
+            SegmentRangeInclusive::new(0, 99)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, None, 250),
+            SegmentRangeInclusive::new(200, 299)
+        );
+
+        // Test with empty index - should fall back to default behavior
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&BTreeMap::new()), 150),
+            SegmentRangeInclusive::new(100, 199)
+        );
+
+        // Create block index with existing ranges
+        let block_index = BTreeMap::from_iter([
+            (99, SegmentRangeInclusive::new(0, 99)),
+            (199, SegmentRangeInclusive::new(100, 199)),
+            (299, SegmentRangeInclusive::new(200, 299)),
+        ]);
+
+        // Test blocks within existing ranges - should return the matching range
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 0),
+            SegmentRangeInclusive::new(0, 99)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 50),
+            SegmentRangeInclusive::new(0, 99)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 99),
+            SegmentRangeInclusive::new(0, 99)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 100),
+            SegmentRangeInclusive::new(100, 199)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 150),
+            SegmentRangeInclusive::new(100, 199)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 199),
+            SegmentRangeInclusive::new(100, 199)
+        );
+
+        // Test blocks beyond existing ranges - should derive new ranges from the last range
+        // Block 300 is exactly one segment after the last range
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 300),
+            SegmentRangeInclusive::new(300, 399)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 350),
+            SegmentRangeInclusive::new(300, 399)
+        );
+
+        // Block 500 skips one segment (300-399)
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 500),
+            SegmentRangeInclusive::new(500, 599)
+        );
+
+        // Block 1000 skips many segments
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&block_index), 1000),
+            SegmentRangeInclusive::new(1000, 1099)
+        );
+
+        // Test with block index having different sizes than blocks_per_file setting
+        // This simulates the scenario where blocks_per_file was changed between runs
+        let mixed_size_index = BTreeMap::from_iter([
+            (49, SegmentRangeInclusive::new(0, 49)),     // 50 blocks
+            (149, SegmentRangeInclusive::new(50, 149)),  // 100 blocks
+            (349, SegmentRangeInclusive::new(150, 349)), // 200 blocks
+        ]);
+
+        // Blocks within existing ranges should return those ranges regardless of size
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&mixed_size_index), 25),
+            SegmentRangeInclusive::new(0, 49)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&mixed_size_index), 100),
+            SegmentRangeInclusive::new(50, 149)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&mixed_size_index), 200),
+            SegmentRangeInclusive::new(150, 349)
+        );
+
+        // Block after the last range should derive using current blocks_per_file (100)
+        // from the end of the last range (349)
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&mixed_size_index), 350),
+            SegmentRangeInclusive::new(350, 449)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&mixed_size_index), 450),
+            SegmentRangeInclusive::new(450, 549)
+        );
+        assert_eq!(
+            sf_rw.find_fixed_range_with_block_index(segment, Some(&mixed_size_index), 550),
+            SegmentRangeInclusive::new(550, 649)
+        );
+
+        Ok(())
+    }
+}

--- a/patches/reth-provider/src/providers/static_file/metrics.rs
+++ b/patches/reth-provider/src/providers/static_file/metrics.rs
@@ -1,0 +1,151 @@
+use std::{collections::HashMap, time::Duration};
+
+use itertools::Itertools;
+use metrics::{Counter, Gauge, Histogram};
+use reth_metrics::Metrics;
+use reth_static_file_types::{StaticFileMap, StaticFileSegment};
+use strum::{EnumIter, IntoEnumIterator};
+
+/// Metrics for the static file provider.
+#[derive(Debug)]
+pub struct StaticFileProviderMetrics {
+    segments: StaticFileMap<StaticFileSegmentMetrics>,
+    segment_operations: HashMap<
+        (StaticFileSegment, StaticFileProviderOperation),
+        StaticFileProviderOperationMetrics,
+    >,
+}
+
+impl Default for StaticFileProviderMetrics {
+    fn default() -> Self {
+        Self {
+            segments: Box::new(
+                StaticFileSegment::iter()
+                    .map(|segment| {
+                        (
+                            segment,
+                            StaticFileSegmentMetrics::new_with_labels(&[(
+                                "segment",
+                                segment.as_str(),
+                            )]),
+                        )
+                    })
+                    .collect(),
+            ),
+            segment_operations: StaticFileSegment::iter()
+                .cartesian_product(StaticFileProviderOperation::iter())
+                .map(|(segment, operation)| {
+                    (
+                        (segment, operation),
+                        StaticFileProviderOperationMetrics::new_with_labels(&[
+                            ("segment", segment.as_str()),
+                            ("operation", operation.as_str()),
+                        ]),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl StaticFileProviderMetrics {
+    pub(crate) fn record_segment(
+        &self,
+        segment: StaticFileSegment,
+        size: u64,
+        files: usize,
+        entries: usize,
+    ) {
+        self.segments.get(segment).expect("segment metrics should exist").size.set(size as f64);
+        self.segments.get(segment).expect("segment metrics should exist").files.set(files as f64);
+        self.segments
+            .get(segment)
+            .expect("segment metrics should exist")
+            .entries
+            .set(entries as f64);
+    }
+
+    pub(crate) fn record_segment_operation(
+        &self,
+        segment: StaticFileSegment,
+        operation: StaticFileProviderOperation,
+        duration: Option<Duration>,
+    ) {
+        let segment_operation = self
+            .segment_operations
+            .get(&(segment, operation))
+            .expect("segment operation metrics should exist");
+
+        segment_operation.calls_total.increment(1);
+
+        if let Some(duration) = duration {
+            segment_operation.write_duration_seconds.record(duration.as_secs_f64());
+        }
+    }
+
+    pub(crate) fn record_segment_operations(
+        &self,
+        segment: StaticFileSegment,
+        operation: StaticFileProviderOperation,
+        count: u64,
+        duration: Option<Duration>,
+    ) {
+        self.segment_operations
+            .get(&(segment, operation))
+            .expect("segment operation metrics should exist")
+            .calls_total
+            .increment(count);
+
+        if let Some(duration) = duration {
+            self.segment_operations
+                .get(&(segment, operation))
+                .expect("segment operation metrics should exist")
+                .write_duration_seconds
+                .record(duration.as_secs_f64() / count as f64);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
+pub(crate) enum StaticFileProviderOperation {
+    InitCursor,
+    OpenWriter,
+    Append,
+    Prune,
+    IncrementBlock,
+    CommitWriter,
+}
+
+impl StaticFileProviderOperation {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::InitCursor => "init-cursor",
+            Self::OpenWriter => "open-writer",
+            Self::Append => "append",
+            Self::Prune => "prune",
+            Self::IncrementBlock => "increment-block",
+            Self::CommitWriter => "commit-writer",
+        }
+    }
+}
+
+/// Metrics for a specific static file segment.
+#[derive(Metrics)]
+#[metrics(scope = "static_files.segment")]
+pub(crate) struct StaticFileSegmentMetrics {
+    /// The size of a static file segment
+    size: Gauge,
+    /// The number of files for a static file segment
+    files: Gauge,
+    /// The number of entries for a static file segment
+    entries: Gauge,
+}
+
+#[derive(Metrics)]
+#[metrics(scope = "static_files.jar_provider")]
+pub(crate) struct StaticFileProviderOperationMetrics {
+    /// Total number of static file jar provider operations made.
+    calls_total: Counter,
+    /// The time it took to execute the static file jar provider operation that writes data.
+    write_duration_seconds: Histogram,
+}

--- a/patches/reth-provider/src/providers/static_file/mod.rs
+++ b/patches/reth-provider/src/providers/static_file/mod.rs
@@ -1,0 +1,1420 @@
+mod manager;
+pub use manager::{
+    StaticFileAccess, StaticFileProvider, StaticFileProviderBuilder, StaticFileWriteCtx,
+    StaticFileWriter,
+};
+
+mod jar;
+pub use jar::StaticFileJarProvider;
+
+mod writer;
+pub use writer::{StaticFileProviderRW, StaticFileProviderRWRefMut};
+
+mod metrics;
+
+#[cfg(test)]
+mod writer_tests;
+
+use reth_nippy_jar::NippyJar;
+use reth_static_file_types::{ChangesetOffsetReader, SegmentHeader, StaticFileSegment};
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
+use std::{io, ops::Deref, sync::Arc};
+
+/// Alias type for each specific `NippyJar`.
+type LoadedJarRef<'a> =
+    reth_primitives_traits::dashmap::mapref::one::Ref<'a, (u64, StaticFileSegment), LoadedJar>;
+
+/// Helper type to reuse an associated static file mmap handle on created cursors.
+#[derive(Debug)]
+pub struct LoadedJar {
+    jar: NippyJar<SegmentHeader>,
+    mmap_handle: Arc<reth_nippy_jar::DataReader>,
+    csoff_reader: Option<ChangesetOffsetReader>,
+}
+
+impl LoadedJar {
+    fn new(jar: NippyJar<SegmentHeader>) -> ProviderResult<Self> {
+        match jar.open_data_reader() {
+            Ok(data_reader) => {
+                let mmap_handle = Arc::new(data_reader);
+
+                let csoff_reader = if jar.user_header().segment().is_change_based() {
+                    let csoff_path = jar.data_path().with_extension("csoff");
+                    let len = jar.user_header().changeset_offsets_len();
+                    match ChangesetOffsetReader::new(&csoff_path, len) {
+                        Ok(reader) => Some(reader),
+                        Err(err) if err.kind() == io::ErrorKind::NotFound && len == 0 => None,
+                        Err(err) => return Err(ProviderError::other(err)),
+                    }
+                } else {
+                    None
+                };
+
+                Ok(Self { jar, mmap_handle, csoff_reader })
+            }
+            Err(e) => Err(ProviderError::other(e)),
+        }
+    }
+
+    /// Returns a clone of the mmap handle that can be used to instantiate a cursor.
+    fn mmap_handle(&self) -> Arc<reth_nippy_jar::DataReader> {
+        self.mmap_handle.clone()
+    }
+
+    const fn segment(&self) -> StaticFileSegment {
+        self.jar.user_header().segment()
+    }
+
+    /// Returns the total size of the data and offsets files (from the in-memory mmap).
+    fn size(&self) -> usize {
+        self.mmap_handle.size() + self.mmap_handle.offsets_size()
+    }
+
+    /// Returns a reference to the cached changeset offset reader.
+    const fn csoff_reader(&self) -> Option<&ChangesetOffsetReader> {
+        self.csoff_reader.as_ref()
+    }
+}
+
+impl Deref for LoadedJar {
+    type Target = NippyJar<SegmentHeader>;
+    fn deref(&self) -> &Self::Target {
+        &self.jar
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        providers::static_file::manager::StaticFileProviderBuilder,
+        test_utils::create_test_provider_factory, HeaderProvider, StaticFileProviderFactory,
+    };
+    use alloy_consensus::{Header, SignableTransaction, Transaction, TxLegacy};
+    use alloy_primitives::{Address, BlockHash, Signature, TxNumber, B256, U160, U256};
+    use rand::seq::SliceRandom;
+    use reth_db::{
+        models::{AccountBeforeTx, StorageBeforeTx},
+        test_utils::create_test_static_files_dir,
+    };
+    use reth_db_api::{transaction::DbTxMut, CanonicalHeaders, HeaderNumbers, Headers};
+    use reth_ethereum_primitives::{EthPrimitives, Receipt, TransactionSigned};
+    use reth_primitives_traits::Account;
+    use reth_static_file_types::{
+        find_fixed_range, SegmentRangeInclusive, DEFAULT_BLOCKS_PER_STATIC_FILE,
+    };
+    use reth_storage_api::{
+        ChangeSetReader, ReceiptProvider, StorageChangeSetReader, TransactionsProvider,
+    };
+    use reth_testing_utils::generators::{self, random_header_range};
+    use std::{collections::BTreeMap, fmt::Debug, fs, ops::Range, path::Path};
+
+    fn assert_eyre<T: PartialEq + Debug>(got: T, expected: T, msg: &str) -> eyre::Result<()> {
+        if got != expected {
+            eyre::bail!("{msg} | got: {got:?} expected: {expected:?}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_static_files() {
+        // Ranges
+        let row_count = 100u64;
+        let range = 0..=(row_count - 1);
+
+        // Data sources
+        let factory = create_test_provider_factory();
+        let static_files_path = tempfile::tempdir().unwrap();
+        let static_file = static_files_path.path().join(
+            StaticFileSegment::Headers
+                .filename(&find_fixed_range(*range.end(), DEFAULT_BLOCKS_PER_STATIC_FILE)),
+        );
+
+        // Setup data
+        let mut headers = random_header_range(
+            &mut generators::rng(),
+            *range.start()..(*range.end() + 1),
+            B256::random(),
+        );
+
+        let mut provider_rw = factory.provider_rw().unwrap();
+        let tx = provider_rw.tx_mut();
+        for header in headers.clone() {
+            let hash = header.hash();
+
+            tx.put::<CanonicalHeaders>(header.number, hash).unwrap();
+            tx.put::<Headers>(header.number, header.clone_header()).unwrap();
+            tx.put::<HeaderNumbers>(hash, header.number).unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        // Create StaticFile
+        {
+            let manager = factory.static_file_provider();
+            let mut writer = manager.latest_writer(StaticFileSegment::Headers).unwrap();
+
+            for header in headers.clone() {
+                let hash = header.hash();
+                writer.append_header(&header.unseal(), &hash).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        // Use providers to query Header data and compare if it matches
+        {
+            let db_provider = factory.provider().unwrap();
+            let manager = db_provider.static_file_provider();
+            let jar_provider = manager
+                .get_segment_provider_for_block(StaticFileSegment::Headers, 0, Some(&static_file))
+                .unwrap();
+
+            assert!(!headers.is_empty());
+
+            // Shuffled for chaos.
+            headers.shuffle(&mut generators::rng());
+
+            for header in headers {
+                let header_hash = header.hash();
+                let header = header.unseal();
+
+                // Compare Header
+                assert_eq!(header, db_provider.header(header_hash).unwrap().unwrap());
+                assert_eq!(header, jar_provider.header_by_number(header.number).unwrap().unwrap());
+            }
+        }
+    }
+
+    #[test]
+    fn test_header_truncation() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let blocks_per_file = 10; // Number of headers per file
+        let files_per_range = 3; // Number of files per range (data/conf/offset files)
+        let file_set_count = 3; // Number of sets of files to create
+        let initial_file_count = files_per_range * file_set_count;
+        let tip = blocks_per_file * file_set_count - 1; // Initial highest block (29 in this case)
+
+        // [ Headers Creation and Commit ]
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(blocks_per_file)
+                    .build()
+                    .expect("Failed to build static file provider");
+
+            let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers).unwrap();
+
+            // Append headers from 0 to the tip (29) and commit
+            let mut header = Header::default();
+            for num in 0..=tip {
+                header.number = num;
+                header_writer.append_header(&header, &BlockHash::default()).unwrap();
+            }
+            header_writer.commit().unwrap();
+        }
+
+        // Helper function to prune headers and validate truncation results
+        fn prune_and_validate(
+            writer: &mut StaticFileProviderRWRefMut<'_, EthPrimitives>,
+            sf_rw: &StaticFileProvider<EthPrimitives>,
+            static_dir: impl AsRef<Path>,
+            prune_count: u64,
+            expected_tip: Option<u64>,
+            expected_file_count: u64,
+        ) -> eyre::Result<()> {
+            writer.prune_headers(prune_count)?;
+            writer.commit()?;
+
+            // Validate the highest block after pruning
+            assert_eyre(
+                sf_rw.get_highest_static_file_block(StaticFileSegment::Headers),
+                expected_tip,
+                "block mismatch",
+            )?;
+
+            if let Some(id) = expected_tip {
+                assert_eyre(
+                    sf_rw.header_by_number(id)?.map(|h| h.number),
+                    expected_tip,
+                    "header mismatch",
+                )?;
+            }
+
+            // Validate the number of files remaining in the directory
+            assert_eyre(
+                count_files_without_lockfile(static_dir)?,
+                expected_file_count as usize,
+                "file count mismatch",
+            )?;
+
+            Ok(())
+        }
+
+        // [ Test Cases ]
+        type PruneCount = u64;
+        type ExpectedTip = u64;
+        type ExpectedFileCount = u64;
+        let mut tmp_tip = tip;
+        let test_cases: Vec<(PruneCount, Option<ExpectedTip>, ExpectedFileCount)> = vec![
+            // Case 0: Pruning 1 header
+            {
+                tmp_tip -= 1;
+                (1, Some(tmp_tip), initial_file_count)
+            },
+            // Case 1: Pruning remaining rows from file should result in its deletion
+            {
+                tmp_tip -= blocks_per_file - 1;
+                (blocks_per_file - 1, Some(tmp_tip), initial_file_count - files_per_range)
+            },
+            // Case 2: Pruning more headers than a single file has (tip reduced by
+            // blocks_per_file + 1) should result in a file set deletion
+            {
+                tmp_tip -= blocks_per_file + 1;
+                (blocks_per_file + 1, Some(tmp_tip), initial_file_count - files_per_range * 2)
+            },
+            // Case 3: Pruning all remaining headers from the file except the genesis header
+            {
+                (
+                    tmp_tip,
+                    Some(0),         // Only genesis block remains
+                    files_per_range, // The file set with block 0 should remain
+                )
+            },
+            // Case 4: Pruning the genesis header (should not delete the file set with block 0)
+            {
+                (
+                    1,
+                    None,            // No blocks left
+                    files_per_range, // The file set with block 0 remains
+                )
+            },
+        ];
+
+        // Test cases execution
+        {
+            let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(blocks_per_file)
+                .build()
+                .expect("Failed to build static file provider");
+
+            assert_eq!(sf_rw.get_highest_static_file_block(StaticFileSegment::Headers), Some(tip));
+            assert_eq!(
+                count_files_without_lockfile(static_dir.as_ref()).unwrap(),
+                initial_file_count as usize
+            );
+
+            let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers).unwrap();
+
+            for (case, (prune_count, expected_tip, expected_file_count)) in
+                test_cases.into_iter().enumerate()
+            {
+                prune_and_validate(
+                    &mut header_writer,
+                    &sf_rw,
+                    &static_dir,
+                    prune_count,
+                    expected_tip,
+                    expected_file_count,
+                )
+                .map_err(|err| eyre::eyre!("Test case {case}: {err}"))
+                .unwrap();
+            }
+        }
+    }
+
+    /// 3 block ranges are built
+    ///
+    /// for `blocks_per_file = 10`:
+    /// * `0..=9` : except genesis, every block has a tx/receipt
+    /// * `10..=19`: no txs/receipts
+    /// * `20..=29`: only one tx/receipt
+    fn setup_tx_based_scenario(
+        sf_rw: &StaticFileProvider<EthPrimitives>,
+        segment: StaticFileSegment,
+        blocks_per_file: u64,
+    ) {
+        fn setup_block_ranges(
+            writer: &mut StaticFileProviderRWRefMut<'_, EthPrimitives>,
+            sf_rw: &StaticFileProvider<EthPrimitives>,
+            segment: StaticFileSegment,
+            block_range: &Range<u64>,
+            mut tx_count: u64,
+            next_tx_num: &mut u64,
+        ) {
+            let mut receipt = Receipt::default();
+            let mut tx = TxLegacy::default();
+
+            for block in block_range.clone() {
+                writer.increment_block(block).unwrap();
+
+                // Append transaction/receipt if there's still a transaction count to append
+                if tx_count > 0 {
+                    match segment {
+                        StaticFileSegment::Headers |
+                        StaticFileSegment::AccountChangeSets |
+                        StaticFileSegment::StorageChangeSets => {
+                            panic!("non tx based segment")
+                        }
+                        StaticFileSegment::Transactions => {
+                            // Used as ID for validation
+                            tx.nonce = *next_tx_num;
+                            let tx: TransactionSigned =
+                                tx.clone().into_signed(Signature::test_signature()).into();
+                            writer.append_transaction(*next_tx_num, &tx).unwrap();
+                        }
+                        StaticFileSegment::Receipts => {
+                            // Used as ID for validation
+                            receipt.cumulative_gas_used = *next_tx_num;
+                            writer.append_receipt(*next_tx_num, &receipt).unwrap();
+                        }
+                        StaticFileSegment::TransactionSenders => {
+                            // Used as ID for validation
+                            let sender = Address::from(U160::from(*next_tx_num));
+                            writer.append_transaction_sender(*next_tx_num, &sender).unwrap();
+                        }
+                    }
+                    *next_tx_num += 1;
+                    tx_count -= 1;
+                }
+            }
+            writer.commit().unwrap();
+
+            // Calculate expected values based on the range and transactions
+            let expected_block = block_range.end - 1;
+            let expected_tx = if tx_count == 0 { *next_tx_num - 1 } else { *next_tx_num };
+
+            // Perform assertions after processing the blocks
+            assert_eq!(sf_rw.get_highest_static_file_block(segment), Some(expected_block),);
+            assert_eq!(sf_rw.get_highest_static_file_tx(segment), Some(expected_tx),);
+        }
+
+        // Define the block ranges and transaction counts as vectors
+        let block_ranges = [
+            0..blocks_per_file,
+            blocks_per_file..blocks_per_file * 2,
+            blocks_per_file * 2..blocks_per_file * 3,
+        ];
+
+        let tx_counts = [
+            blocks_per_file - 1, // First range: tx per block except genesis
+            0,                   // Second range: no transactions
+            1,                   // Third range: 1 transaction in the second block
+        ];
+
+        let mut writer = sf_rw.latest_writer(segment).unwrap();
+        let mut next_tx_num = 0;
+
+        // Loop through setup scenarios
+        for (block_range, tx_count) in block_ranges.iter().zip(tx_counts.iter()) {
+            setup_block_ranges(
+                &mut writer,
+                sf_rw,
+                segment,
+                block_range,
+                *tx_count,
+                &mut next_tx_num,
+            );
+        }
+
+        // Ensure that scenario was properly setup
+        let expected_tx_ranges = vec![
+            Some(SegmentRangeInclusive::new(0, 8)),
+            None,
+            Some(SegmentRangeInclusive::new(9, 9)),
+        ];
+
+        block_ranges.iter().zip(expected_tx_ranges).for_each(|(block_range, expected_tx_range)| {
+            assert_eq!(
+                sf_rw
+                    .get_segment_provider_for_block(segment, block_range.start, None)
+                    .unwrap()
+                    .user_header()
+                    .tx_range(),
+                expected_tx_range
+            );
+        });
+
+        // Ensure transaction index
+        let expected_tx_index = BTreeMap::from([
+            (8, SegmentRangeInclusive::new(0, 9)),
+            (9, SegmentRangeInclusive::new(20, 29)),
+        ]);
+        assert_eq!(
+            sf_rw.tx_index(segment),
+            (!expected_tx_index.is_empty()).then_some(expected_tx_index),
+            "tx index mismatch",
+        );
+    }
+
+    #[test]
+    fn test_tx_based_truncation() {
+        let segments = [StaticFileSegment::Transactions, StaticFileSegment::Receipts];
+        let blocks_per_file = 10; // Number of blocks per file
+        let files_per_range = 3; // Number of files per range (data/conf/offset files)
+        let file_set_count = 3; // Number of sets of files to create
+        let initial_file_count = files_per_range * file_set_count;
+
+        #[expect(clippy::too_many_arguments)]
+        fn prune_and_validate(
+            sf_rw: &StaticFileProvider<EthPrimitives>,
+            static_dir: impl AsRef<Path>,
+            segment: StaticFileSegment,
+            prune_count: u64,
+            last_block: u64,
+            expected_tx_tip: Option<u64>,
+            expected_file_count: i32,
+            expected_tx_index: BTreeMap<TxNumber, SegmentRangeInclusive>,
+        ) -> eyre::Result<()> {
+            let mut writer = sf_rw.latest_writer(segment)?;
+
+            // Prune transactions or receipts based on the segment type
+            match segment {
+                StaticFileSegment::Headers |
+                StaticFileSegment::AccountChangeSets |
+                StaticFileSegment::StorageChangeSets => {
+                    panic!("non tx based segment")
+                }
+                StaticFileSegment::Transactions => {
+                    writer.prune_transactions(prune_count, last_block)?
+                }
+                StaticFileSegment::Receipts => writer.prune_receipts(prune_count, last_block)?,
+                StaticFileSegment::TransactionSenders => {
+                    writer.prune_transaction_senders(prune_count, last_block)?
+                }
+            }
+            writer.commit()?;
+
+            // Verify the highest block and transaction tips
+            assert_eyre(
+                sf_rw.get_highest_static_file_block(segment),
+                Some(last_block),
+                "block mismatch",
+            )?;
+            assert_eyre(sf_rw.get_highest_static_file_tx(segment), expected_tx_tip, "tx mismatch")?;
+
+            // Verify that transactions and receipts are returned correctly. Uses
+            // cumulative_gas_used & nonce as ids.
+            if let Some(id) = expected_tx_tip {
+                match segment {
+                    StaticFileSegment::Headers |
+                    StaticFileSegment::AccountChangeSets |
+                    StaticFileSegment::StorageChangeSets => {
+                        panic!("non tx based segment")
+                    }
+                    StaticFileSegment::Transactions => assert_eyre(
+                        expected_tx_tip,
+                        sf_rw.transaction_by_id(id)?.map(|t| t.nonce()),
+                        "tx mismatch",
+                    )?,
+                    StaticFileSegment::Receipts => assert_eyre(
+                        expected_tx_tip,
+                        sf_rw.receipt(id)?.map(|r| r.cumulative_gas_used),
+                        "receipt mismatch",
+                    )?,
+                    StaticFileSegment::TransactionSenders => assert_eyre(
+                        expected_tx_tip,
+                        sf_rw
+                            .transaction_sender(id)?
+                            .map(|s| u64::try_from(U160::from_be_bytes(s.0.into())).unwrap()),
+                        "sender mismatch",
+                    )?,
+                }
+            }
+
+            // Ensure the file count has reduced as expected
+            assert_eyre(
+                count_files_without_lockfile(static_dir)?,
+                expected_file_count as usize,
+                "file count mismatch",
+            )?;
+
+            // Ensure that the inner tx index (max_tx -> block range) is as expected
+            assert_eyre(
+                sf_rw.tx_index(segment).map(|index| index.iter().map(|(k, v)| (*k, *v)).collect()),
+                (!expected_tx_index.is_empty()).then_some(expected_tx_index),
+                "tx index mismatch",
+            )?;
+
+            Ok(())
+        }
+
+        for segment in segments {
+            let (static_dir, _) = create_test_static_files_dir();
+
+            let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(blocks_per_file)
+                .build()
+                .expect("Failed to build static file provider");
+
+            setup_tx_based_scenario(&sf_rw, segment, blocks_per_file);
+
+            let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(blocks_per_file)
+                .build()
+                .expect("Failed to build static file provider");
+            let highest_tx = sf_rw.get_highest_static_file_tx(segment).unwrap();
+
+            // Test cases
+            // [prune_count, last_block, expected_tx_tip, expected_file_count, expected_tx_index)
+            let test_cases = vec![
+                // Case 0: 20..=29 has only one tx. Prune the only tx of the block range.
+                // It ensures that the file is not deleted even though there are no rows, since the
+                // `last_block` which is passed to the prune method is the first
+                // block of the range.
+                (
+                    1,
+                    blocks_per_file * 2,
+                    Some(highest_tx - 1),
+                    initial_file_count,
+                    BTreeMap::from([(highest_tx - 1, SegmentRangeInclusive::new(0, 9))]),
+                ),
+                // Case 1: 10..=19 has no txs. There are no txes in the whole block range, but want
+                // to unwind to block 9. Ensures that the 20..=29 and 10..=19 files
+                // are deleted.
+                (
+                    0,
+                    blocks_per_file - 1,
+                    Some(highest_tx - 1),
+                    files_per_range,
+                    BTreeMap::from([(highest_tx - 1, SegmentRangeInclusive::new(0, 9))]),
+                ),
+                // Case 2: Prune most txs up to block 1.
+                (
+                    highest_tx - 1,
+                    1,
+                    Some(0),
+                    files_per_range,
+                    BTreeMap::from([(0, SegmentRangeInclusive::new(0, 1))]),
+                ),
+                // Case 3: Prune remaining tx and ensure that file is not deleted.
+                (1, 0, None, files_per_range, BTreeMap::from([])),
+            ];
+
+            // Loop through test cases
+            for (
+                case,
+                (prune_count, last_block, expected_tx_tip, expected_file_count, expected_tx_index),
+            ) in test_cases.into_iter().enumerate()
+            {
+                prune_and_validate(
+                    &sf_rw,
+                    &static_dir,
+                    segment,
+                    prune_count,
+                    last_block,
+                    expected_tx_tip,
+                    expected_file_count,
+                    expected_tx_index,
+                )
+                .map_err(|err| eyre::eyre!("Test case {case}: {err}"))
+                .unwrap();
+            }
+        }
+    }
+
+    /// Returns the number of files in the provided path, excluding ".lock" files.
+    fn count_files_without_lockfile(path: impl AsRef<Path>) -> eyre::Result<usize> {
+        let is_lockfile = |entry: &fs::DirEntry| {
+            entry.path().file_name().map(|name| name == "lock").unwrap_or(false)
+        };
+        let count = fs::read_dir(path)?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| !is_lockfile(entry))
+            .count();
+
+        Ok(count)
+    }
+
+    #[test]
+    fn test_dynamic_size() -> eyre::Result<()> {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(10)
+                    .build()?;
+            let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers)?;
+
+            let mut header = Header::default();
+            for num in 0..=15 {
+                header.number = num;
+                header_writer.append_header(&header, &BlockHash::default()).unwrap();
+            }
+            header_writer.commit().unwrap();
+
+            assert_eq!(sf_rw.headers_range(0..=15)?.len(), 16);
+            assert_eq!(
+                sf_rw.expected_block_index(StaticFileSegment::Headers),
+                Some(BTreeMap::from([
+                    (9, SegmentRangeInclusive::new(0, 9)),
+                    (19, SegmentRangeInclusive::new(10, 19))
+                ])),
+            )
+        }
+
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(5)
+                    .build()?;
+            let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers)?;
+
+            let mut header = Header::default();
+            for num in 16..=22 {
+                header.number = num;
+                header_writer.append_header(&header, &BlockHash::default()).unwrap();
+            }
+            header_writer.commit().unwrap();
+
+            assert_eq!(sf_rw.headers_range(0..=22)?.len(), 23);
+            assert_eq!(
+                sf_rw.expected_block_index(StaticFileSegment::Headers),
+                Some(BTreeMap::from([
+                    (9, SegmentRangeInclusive::new(0, 9)),
+                    (19, SegmentRangeInclusive::new(10, 19)),
+                    (24, SegmentRangeInclusive::new(20, 24))
+                ]))
+            )
+        }
+
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(15)
+                    .build()?;
+            let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers)?;
+
+            let mut header = Header::default();
+            for num in 23..=40 {
+                header.number = num;
+                header_writer.append_header(&header, &BlockHash::default()).unwrap();
+            }
+            header_writer.commit().unwrap();
+
+            assert_eq!(sf_rw.headers_range(0..=40)?.len(), 41);
+            assert_eq!(
+                sf_rw.expected_block_index(StaticFileSegment::Headers),
+                Some(BTreeMap::from([
+                    (9, SegmentRangeInclusive::new(0, 9)),
+                    (19, SegmentRangeInclusive::new(10, 19)),
+                    (24, SegmentRangeInclusive::new(20, 24)),
+                    (39, SegmentRangeInclusive::new(25, 39)),
+                    (54, SegmentRangeInclusive::new(40, 54))
+                ]))
+            )
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_account_changeset_static_files() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
+            .expect("Failed to create static file provider");
+
+        // Helper function to generate test changesets
+        fn generate_test_changesets(
+            block_num: u64,
+            addresses: Vec<Address>,
+        ) -> Vec<AccountBeforeTx> {
+            addresses
+                .into_iter()
+                .map(|address| AccountBeforeTx {
+                    address,
+                    info: Some(Account {
+                        nonce: block_num,
+                        balance: U256::from(block_num * 1000),
+                        bytecode_hash: None,
+                    }),
+                })
+                .collect()
+        }
+
+        // Test writing and reading account changesets
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            // Create test data for multiple blocks
+            let test_blocks = 10u64;
+            let addresses_per_block = 5;
+
+            for block_num in 0..test_blocks {
+                // Generate unique addresses for each block
+                let addresses: Vec<Address> = (0..addresses_per_block)
+                    .map(|i| {
+                        let mut addr = Address::ZERO;
+                        addr.0[0] = block_num as u8;
+                        addr.0[1] = i as u8;
+                        addr
+                    })
+                    .collect();
+
+                let changeset = generate_test_changesets(block_num, addresses.clone());
+
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Verify data can be read back correctly
+        {
+            let provider = sf_rw
+                .get_segment_provider_for_block(StaticFileSegment::AccountChangeSets, 5, None)
+                .unwrap();
+
+            // Check that the segment header has changeset offsets
+            let offsets = provider.read_changeset_offsets().unwrap();
+            assert!(offsets.is_some());
+            let offsets = offsets.unwrap();
+            assert_eq!(offsets.len(), 10); // Should have 10 blocks worth of offsets
+
+            // Verify each block has the expected number of changes
+            for (i, offset) in offsets.iter().enumerate() {
+                assert_eq!(offset.num_changes(), 5, "Block {} should have 5 changes", i);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_account_before_block() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
+            .expect("Failed to create static file provider");
+
+        // Setup test data
+        let test_address = Address::from([1u8; 20]);
+        let other_address = Address::from([2u8; 20]);
+        let missing_address = Address::from([3u8; 20]);
+
+        // Write changesets for multiple blocks
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            // Block 0: test_address and other_address change
+            writer
+                .append_account_changeset(
+                    vec![
+                        AccountBeforeTx {
+                            address: test_address,
+                            info: None, // Account created
+                        },
+                        AccountBeforeTx { address: other_address, info: None },
+                    ],
+                    0,
+                )
+                .unwrap();
+
+            // Block 1: only other_address changes
+            writer
+                .append_account_changeset(
+                    vec![AccountBeforeTx {
+                        address: other_address,
+                        info: Some(Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None }),
+                    }],
+                    1,
+                )
+                .unwrap();
+
+            // Block 2: test_address changes again
+            writer
+                .append_account_changeset(
+                    vec![AccountBeforeTx {
+                        address: test_address,
+                        info: Some(Account {
+                            nonce: 1,
+                            balance: U256::from(1000),
+                            bytecode_hash: None,
+                        }),
+                    }],
+                    2,
+                )
+                .unwrap();
+
+            writer.commit().unwrap();
+        }
+
+        // Test get_account_before_block
+        {
+            // Test retrieving account state before block 0
+            let result = sf_rw.get_account_before_block(0, test_address).unwrap();
+            assert!(result.is_some());
+            let account_before = result.unwrap();
+            assert_eq!(account_before.address, test_address);
+            assert!(account_before.info.is_none()); // Was created in block 0
+
+            // Test retrieving account state before block 2
+            let result = sf_rw.get_account_before_block(2, test_address).unwrap();
+            assert!(result.is_some());
+            let account_before = result.unwrap();
+            assert_eq!(account_before.address, test_address);
+            assert!(account_before.info.is_some());
+            let info = account_before.info.unwrap();
+            assert_eq!(info.nonce, 1);
+            assert_eq!(info.balance, U256::from(1000));
+
+            // Test retrieving account that doesn't exist in changeset for block
+            let result = sf_rw.get_account_before_block(1, test_address).unwrap();
+            assert!(result.is_none()); // test_address didn't change in block 1
+
+            // Test retrieving account that never existed
+            let result = sf_rw.get_account_before_block(2, missing_address).unwrap();
+            assert!(result.is_none());
+
+            // Test other_address changes
+            let result = sf_rw.get_account_before_block(1, other_address).unwrap();
+            assert!(result.is_some());
+            let account_before = result.unwrap();
+            assert_eq!(account_before.address, other_address);
+            assert!(account_before.info.is_some());
+        }
+    }
+
+    #[test]
+    fn test_account_changeset_truncation() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let blocks_per_file = 10;
+        // 3 main files (jar, dat, idx) + 1 csoff sidecar file for changeset segments
+        let files_per_range = 4;
+        let file_set_count = 3;
+        let initial_file_count = files_per_range * file_set_count;
+        let tip = blocks_per_file * file_set_count - 1;
+
+        // Setup: Create account changesets for multiple blocks
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(blocks_per_file)
+                    .build()
+                    .expect("failed to create static file provider");
+
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            for block_num in 0..=tip {
+                // Create varying number of changes per block
+                let num_changes = ((block_num % 5) + 1) as usize;
+                let mut changeset = Vec::with_capacity(num_changes);
+
+                for i in 0..num_changes {
+                    let mut address = Address::ZERO;
+                    address.0[0] = block_num as u8;
+                    address.0[1] = i as u8;
+
+                    changeset.push(AccountBeforeTx {
+                        address,
+                        info: Some(Account {
+                            nonce: block_num,
+                            balance: U256::from(block_num * 1000 + i as u64),
+                            bytecode_hash: None,
+                        }),
+                    });
+                }
+
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Helper function to validate truncation
+        fn validate_truncation(
+            sf_rw: &StaticFileProvider<EthPrimitives>,
+            static_dir: impl AsRef<Path>,
+            expected_tip: Option<u64>,
+            expected_file_count: u64,
+        ) -> eyre::Result<()> {
+            // Verify highest block
+            let highest_block =
+                sf_rw.get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
+            assert_eyre(highest_block, expected_tip, "block tip mismatch")?;
+
+            // Verify file count
+            assert_eyre(
+                count_files_without_lockfile(static_dir)?,
+                expected_file_count as usize,
+                "file count mismatch",
+            )?;
+
+            if let Some(tip) = expected_tip {
+                // Verify we can still read data up to the tip
+                let provider = sf_rw.get_segment_provider_for_block(
+                    StaticFileSegment::AccountChangeSets,
+                    tip,
+                    None,
+                )?;
+
+                // Check offsets are valid
+                let offsets = provider.read_changeset_offsets().unwrap();
+                assert!(offsets.is_some(), "Should have changeset offsets");
+            }
+
+            Ok(())
+        }
+
+        // Test truncation scenarios
+        let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
+            .with_blocks_per_file(blocks_per_file)
+            .build()
+            .expect("failed to create static file provider");
+
+        // Re-initialize the index to ensure it knows about the written files
+        sf_rw.initialize_index().expect("Failed to initialize index");
+
+        // Case 1: Truncate to block 20 (remove last 9 blocks)
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            writer.prune_account_changesets(20).unwrap();
+            writer.commit().unwrap();
+
+            validate_truncation(&sf_rw, &static_dir, Some(20), initial_file_count)
+                .expect("Truncation validation failed");
+        }
+
+        // Case 2: Truncate to block 9 (should remove 2 files)
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            writer.prune_account_changesets(9).unwrap();
+            writer.commit().unwrap();
+
+            validate_truncation(&sf_rw, &static_dir, Some(9), files_per_range)
+                .expect("Truncation validation failed");
+        }
+
+        // Case 3: Truncate all (should keep block 0)
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            writer.prune_account_changesets(0).unwrap();
+            writer.commit().unwrap();
+
+            // AccountChangeSets behaves like tx-based segments and keeps at least block 0
+            validate_truncation(&sf_rw, &static_dir, Some(0), files_per_range)
+                .expect("Truncation validation failed");
+        }
+    }
+
+    #[test]
+    fn test_changeset_binary_search() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
+            .expect("Failed to create static file provider");
+
+        // Create a block with many account changes to test binary search
+        let block_num = 0u64;
+        let num_accounts = 100;
+
+        let mut addresses: Vec<Address> = Vec::with_capacity(num_accounts);
+        for i in 0..num_accounts {
+            let mut addr = Address::ZERO;
+            addr.0[0] = (i / 256) as u8;
+            addr.0[1] = (i % 256) as u8;
+            addresses.push(addr);
+        }
+
+        // Write the changeset
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            let changeset: Vec<AccountBeforeTx> = addresses
+                .iter()
+                .map(|addr| AccountBeforeTx {
+                    address: *addr,
+                    info: Some(Account {
+                        nonce: 1,
+                        balance: U256::from(1000),
+                        bytecode_hash: None,
+                    }),
+                })
+                .collect();
+
+            writer.append_account_changeset(changeset, block_num).unwrap();
+            writer.commit().unwrap();
+        }
+
+        // Test binary search for various addresses
+        {
+            // Test finding first address
+            let result = sf_rw.get_account_before_block(block_num, addresses[0]).unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap().address, addresses[0]);
+
+            // Test finding last address
+            let result =
+                sf_rw.get_account_before_block(block_num, addresses[num_accounts - 1]).unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap().address, addresses[num_accounts - 1]);
+
+            // Test finding middle addresses
+            let mid = num_accounts / 2;
+            let result = sf_rw.get_account_before_block(block_num, addresses[mid]).unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap().address, addresses[mid]);
+
+            // Test not finding address that doesn't exist
+            let mut missing_addr = Address::ZERO;
+            missing_addr.0[0] = 255;
+            missing_addr.0[1] = 255;
+            let result = sf_rw.get_account_before_block(block_num, missing_addr).unwrap();
+            assert!(result.is_none());
+
+            // Test multiple lookups for performance
+            for i in (0..num_accounts).step_by(10) {
+                let result = sf_rw.get_account_before_block(block_num, addresses[i]).unwrap();
+                assert!(result.is_some());
+                assert_eq!(result.unwrap().address, addresses[i]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_storage_changeset_static_files() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
+            .expect("Failed to create static file provider");
+
+        // Test writing and reading storage changesets
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            // Create test data for multiple blocks
+            let test_blocks = 10u64;
+            let entries_per_block = 5;
+
+            for block_num in 0..test_blocks {
+                let changeset = (0..entries_per_block)
+                    .map(|i| {
+                        let mut addr = Address::ZERO;
+                        addr.0[0] = block_num as u8;
+                        addr.0[1] = i as u8;
+                        StorageBeforeTx {
+                            address: addr,
+                            key: B256::with_last_byte(i as u8),
+                            value: U256::from(block_num * 1000 + i as u64),
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                writer.append_storage_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Verify data can be read back correctly
+        {
+            let provider = sf_rw
+                .get_segment_provider_for_block(StaticFileSegment::StorageChangeSets, 5, None)
+                .unwrap();
+
+            // Check that the segment header has changeset offsets
+            let offsets = provider.read_changeset_offsets().unwrap();
+            assert!(offsets.is_some());
+            let offsets = offsets.unwrap();
+            assert_eq!(offsets.len(), 10); // Should have 10 blocks worth of offsets
+
+            // Verify each block has the expected number of changes
+            for (i, offset) in offsets.iter().enumerate() {
+                assert_eq!(offset.num_changes(), 5, "Block {} should have 5 changes", i);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_storage_before_block() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
+            .expect("Failed to create static file provider");
+
+        let test_address = Address::from([1u8; 20]);
+        let other_address = Address::from([2u8; 20]);
+        let missing_address = Address::from([3u8; 20]);
+        let test_key = B256::with_last_byte(1);
+        let other_key = B256::with_last_byte(2);
+
+        // Write changesets for multiple blocks
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            // Block 0: test_address and other_address change
+            writer
+                .append_storage_changeset(
+                    vec![
+                        StorageBeforeTx { address: test_address, key: test_key, value: U256::ZERO },
+                        StorageBeforeTx {
+                            address: other_address,
+                            key: other_key,
+                            value: U256::from(5),
+                        },
+                    ],
+                    0,
+                )
+                .unwrap();
+
+            // Block 1: only other_address changes
+            writer
+                .append_storage_changeset(
+                    vec![StorageBeforeTx {
+                        address: other_address,
+                        key: other_key,
+                        value: U256::from(7),
+                    }],
+                    1,
+                )
+                .unwrap();
+
+            // Block 2: test_address changes again
+            writer
+                .append_storage_changeset(
+                    vec![StorageBeforeTx {
+                        address: test_address,
+                        key: test_key,
+                        value: U256::from(9),
+                    }],
+                    2,
+                )
+                .unwrap();
+
+            writer.commit().unwrap();
+        }
+
+        // Test get_storage_before_block
+        {
+            let result = sf_rw.get_storage_before_block(0, test_address, test_key).unwrap();
+            assert!(result.is_some());
+            let entry = result.unwrap();
+            assert_eq!(entry.key, test_key);
+            assert_eq!(entry.value, U256::ZERO);
+
+            let result = sf_rw.get_storage_before_block(2, test_address, test_key).unwrap();
+            assert!(result.is_some());
+            let entry = result.unwrap();
+            assert_eq!(entry.key, test_key);
+            assert_eq!(entry.value, U256::from(9));
+
+            let result = sf_rw.get_storage_before_block(1, test_address, test_key).unwrap();
+            assert!(result.is_none());
+
+            let result = sf_rw.get_storage_before_block(2, missing_address, test_key).unwrap();
+            assert!(result.is_none());
+
+            let result = sf_rw.get_storage_before_block(1, other_address, other_key).unwrap();
+            assert!(result.is_some());
+            let entry = result.unwrap();
+            assert_eq!(entry.key, other_key);
+        }
+    }
+
+    #[test]
+    fn test_storage_changeset_truncation() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let blocks_per_file = 10;
+        // 3 main files (jar, dat, idx) + 1 csoff sidecar file for changeset segments
+        let files_per_range = 4;
+        let file_set_count = 3;
+        let initial_file_count = files_per_range * file_set_count;
+        let tip = blocks_per_file * file_set_count - 1;
+
+        // Setup: Create storage changesets for multiple blocks
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(blocks_per_file)
+                    .build()
+                    .expect("failed to create static file provider");
+
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            for block_num in 0..=tip {
+                let num_changes = ((block_num % 5) + 1) as usize;
+                let mut changeset = Vec::with_capacity(num_changes);
+
+                for i in 0..num_changes {
+                    let mut address = Address::ZERO;
+                    address.0[0] = block_num as u8;
+                    address.0[1] = i as u8;
+
+                    changeset.push(StorageBeforeTx {
+                        address,
+                        key: B256::with_last_byte(i as u8),
+                        value: U256::from(block_num * 1000 + i as u64),
+                    });
+                }
+
+                writer.append_storage_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        fn validate_truncation(
+            sf_rw: &StaticFileProvider<EthPrimitives>,
+            static_dir: impl AsRef<Path>,
+            expected_tip: Option<u64>,
+            expected_file_count: u64,
+        ) -> eyre::Result<()> {
+            let highest_block =
+                sf_rw.get_highest_static_file_block(StaticFileSegment::StorageChangeSets);
+            assert_eyre(highest_block, expected_tip, "block tip mismatch")?;
+
+            assert_eyre(
+                count_files_without_lockfile(static_dir)?,
+                expected_file_count as usize,
+                "file count mismatch",
+            )?;
+
+            if let Some(tip) = expected_tip {
+                let provider = sf_rw.get_segment_provider_for_block(
+                    StaticFileSegment::StorageChangeSets,
+                    tip,
+                    None,
+                )?;
+                let offsets = provider.read_changeset_offsets()?;
+                assert!(offsets.is_some(), "Should have changeset offsets");
+            }
+
+            Ok(())
+        }
+
+        let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
+            .with_blocks_per_file(blocks_per_file)
+            .build()
+            .expect("failed to create static file provider");
+
+        sf_rw.initialize_index().expect("Failed to initialize index");
+
+        // Case 1: Truncate to block 20
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+            writer.prune_storage_changesets(20).unwrap();
+            writer.commit().unwrap();
+
+            validate_truncation(&sf_rw, &static_dir, Some(20), initial_file_count)
+                .expect("Truncation validation failed");
+        }
+
+        // Case 2: Truncate to block 9
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+            writer.prune_storage_changesets(9).unwrap();
+            writer.commit().unwrap();
+
+            validate_truncation(&sf_rw, &static_dir, Some(9), files_per_range)
+                .expect("Truncation validation failed");
+        }
+
+        // Case 3: Truncate all (should keep block 0)
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+            writer.prune_storage_changesets(0).unwrap();
+            writer.commit().unwrap();
+
+            validate_truncation(&sf_rw, &static_dir, Some(0), files_per_range)
+                .expect("Truncation validation failed");
+        }
+    }
+
+    #[test]
+    fn test_storage_changeset_binary_search() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
+            .expect("Failed to create static file provider");
+
+        let block_num = 0u64;
+        let num_slots = 100;
+        let address = Address::from([4u8; 20]);
+
+        let mut keys: Vec<B256> = Vec::with_capacity(num_slots);
+        for i in 0..num_slots {
+            keys.push(B256::with_last_byte(i as u8));
+        }
+
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+            let changeset = keys
+                .iter()
+                .enumerate()
+                .map(|(i, key)| StorageBeforeTx { address, key: *key, value: U256::from(i as u64) })
+                .collect::<Vec<_>>();
+
+            writer.append_storage_changeset(changeset, block_num).unwrap();
+            writer.commit().unwrap();
+        }
+
+        {
+            let result = sf_rw.get_storage_before_block(block_num, address, keys[0]).unwrap();
+            assert!(result.is_some());
+            let entry = result.unwrap();
+            assert_eq!(entry.key, keys[0]);
+            assert_eq!(entry.value, U256::from(0));
+
+            let result =
+                sf_rw.get_storage_before_block(block_num, address, keys[num_slots - 1]).unwrap();
+            assert!(result.is_some());
+            let entry = result.unwrap();
+            assert_eq!(entry.key, keys[num_slots - 1]);
+
+            let mid = num_slots / 2;
+            let result = sf_rw.get_storage_before_block(block_num, address, keys[mid]).unwrap();
+            assert!(result.is_some());
+            let entry = result.unwrap();
+            assert_eq!(entry.key, keys[mid]);
+
+            let missing_key = B256::with_last_byte(255);
+            let result = sf_rw.get_storage_before_block(block_num, address, missing_key).unwrap();
+            assert!(result.is_none());
+
+            for i in (0..num_slots).step_by(10) {
+                let result = sf_rw.get_storage_before_block(block_num, address, keys[i]).unwrap();
+                assert!(result.is_some());
+                assert_eq!(result.unwrap().key, keys[i]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_last_block_flushed_on_commit() {
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
+            .expect("Failed to create static file provider");
+
+        let address = Address::from([5u8; 20]);
+        let key = B256::with_last_byte(1);
+
+        // Write changes for a single block without calling increment_block explicitly
+        // (append_storage_changeset calls it internally), then commit
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            // Append a single block's changeset (block 0)
+            writer
+                .append_storage_changeset(
+                    vec![StorageBeforeTx { address, key, value: U256::from(42) }],
+                    0,
+                )
+                .unwrap();
+
+            // Commit without any subsequent block - the current block's offset should be flushed
+            writer.commit().unwrap();
+        }
+
+        // Verify highest block is 0
+        let highest = sf_rw.get_highest_static_file_block(StaticFileSegment::StorageChangeSets);
+        assert_eq!(highest, Some(0), "Should have block 0 after commit");
+
+        // Verify the data is actually readable via the high-level API
+        let result = sf_rw.get_storage_before_block(0, address, key).unwrap();
+        assert!(result.is_some(), "Should be able to read the changeset entry");
+        let entry = result.unwrap();
+        assert_eq!(entry.value, U256::from(42));
+    }
+}

--- a/patches/reth-provider/src/providers/static_file/writer.rs
+++ b/patches/reth-provider/src/providers/static_file/writer.rs
@@ -1,0 +1,1669 @@
+use super::{
+    manager::StaticFileProviderInner, metrics::StaticFileProviderMetrics, StaticFileProvider,
+};
+use crate::providers::static_file::metrics::StaticFileProviderOperation;
+use alloy_consensus::BlockHeader;
+use alloy_primitives::{BlockHash, BlockNumber, TxNumber, U256};
+use parking_lot::{lock_api::RwLockWriteGuard, RawRwLock, RwLock};
+use reth_codecs::Compact;
+use reth_db::models::{AccountBeforeTx, StorageBeforeTx};
+use reth_db_api::models::CompactU256;
+use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
+use reth_node_types::NodePrimitives;
+use reth_primitives_traits::FastInstant as Instant;
+use reth_static_file_types::{
+    ChangesetOffset, ChangesetOffsetReader, ChangesetOffsetWriter, SegmentHeader,
+    SegmentRangeInclusive, StaticFileSegment,
+};
+use reth_storage_errors::provider::{ProviderError, ProviderResult, StaticFileWriterError};
+use std::{
+    borrow::Borrow,
+    cmp::Ordering,
+    fmt::Debug,
+    path::{Path, PathBuf},
+    sync::{Arc, Weak},
+};
+use tracing::{debug, instrument};
+
+/// Represents different pruning strategies for various static file segments.
+#[derive(Debug, Clone, Copy)]
+enum PruneStrategy {
+    /// Prune headers by number of blocks to delete.
+    Headers {
+        /// Number of blocks to delete.
+        num_blocks: u64,
+    },
+    /// Prune transactions by number of rows and last block.
+    Transactions {
+        /// Number of transaction rows to delete.
+        num_rows: u64,
+        /// The last block number after pruning.
+        last_block: BlockNumber,
+    },
+    /// Prune receipts by number of rows and last block.
+    Receipts {
+        /// Number of receipt rows to delete.
+        num_rows: u64,
+        /// The last block number after pruning.
+        last_block: BlockNumber,
+    },
+    /// Prune transaction senders by number of rows and last block.
+    TransactionSenders {
+        /// Number of transaction sender rows to delete.
+        num_rows: u64,
+        /// The last block number after pruning.
+        last_block: BlockNumber,
+    },
+    /// Prune account changesets to a target block number.
+    AccountChangeSets {
+        /// The target block number to prune to.
+        last_block: BlockNumber,
+    },
+    /// Prune storage changesets to a target block number.
+    StorageChangeSets {
+        /// The target block number to prune to.
+        last_block: BlockNumber,
+    },
+}
+
+/// Static file writers for every known [`StaticFileSegment`].
+///
+/// WARNING: Trying to use more than one writer for the same segment type **will result in a
+/// deadlock**.
+#[derive(Debug)]
+pub(crate) struct StaticFileWriters<N> {
+    headers: RwLock<Option<StaticFileProviderRW<N>>>,
+    transactions: RwLock<Option<StaticFileProviderRW<N>>>,
+    receipts: RwLock<Option<StaticFileProviderRW<N>>>,
+    transaction_senders: RwLock<Option<StaticFileProviderRW<N>>>,
+    account_change_sets: RwLock<Option<StaticFileProviderRW<N>>>,
+    storage_change_sets: RwLock<Option<StaticFileProviderRW<N>>>,
+}
+
+impl<N> Default for StaticFileWriters<N> {
+    fn default() -> Self {
+        Self {
+            headers: Default::default(),
+            transactions: Default::default(),
+            receipts: Default::default(),
+            transaction_senders: Default::default(),
+            account_change_sets: Default::default(),
+            storage_change_sets: Default::default(),
+        }
+    }
+}
+
+impl<N: NodePrimitives> StaticFileWriters<N> {
+    pub(crate) fn get_or_create(
+        &self,
+        segment: StaticFileSegment,
+        create_fn: impl FnOnce() -> ProviderResult<StaticFileProviderRW<N>>,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, N>> {
+        let mut write_guard = match segment {
+            StaticFileSegment::Headers => self.headers.write(),
+            StaticFileSegment::Transactions => self.transactions.write(),
+            StaticFileSegment::Receipts => self.receipts.write(),
+            StaticFileSegment::TransactionSenders => self.transaction_senders.write(),
+            StaticFileSegment::AccountChangeSets => self.account_change_sets.write(),
+            StaticFileSegment::StorageChangeSets => self.storage_change_sets.write(),
+        };
+
+        if write_guard.is_none() {
+            *write_guard = Some(create_fn()?);
+        }
+
+        Ok(StaticFileProviderRWRefMut(write_guard))
+    }
+
+    #[instrument(
+        name = "StaticFileWriters::commit",
+        level = "debug",
+        target = "providers::static_file",
+        skip_all
+    )]
+    pub(crate) fn commit(&self) -> ProviderResult<()> {
+        debug!(target: "providers::static_file", "Committing all static file segments");
+
+        for writer_lock in [
+            &self.headers,
+            &self.transactions,
+            &self.receipts,
+            &self.transaction_senders,
+            &self.account_change_sets,
+            &self.storage_change_sets,
+        ] {
+            let mut writer = writer_lock.write();
+            if let Some(writer) = writer.as_mut() {
+                writer.commit()?;
+            }
+        }
+
+        debug!(target: "providers::static_file", "Committed all static file segments");
+        Ok(())
+    }
+
+    pub(crate) fn has_unwind_queued(&self) -> bool {
+        for writer_lock in [
+            &self.headers,
+            &self.transactions,
+            &self.receipts,
+            &self.transaction_senders,
+            &self.account_change_sets,
+            &self.storage_change_sets,
+        ] {
+            let writer = writer_lock.read();
+            if let Some(writer) = writer.as_ref() &&
+                writer.will_prune_on_commit()
+            {
+                return true
+            }
+        }
+        false
+    }
+
+    /// Finalizes all writers by committing their configuration to disk and updating indices.
+    ///
+    /// Must be called after `sync_all` was called on individual writers.
+    /// Returns an error if any writer has prune queued.
+    #[instrument(
+        name = "StaticFileWriters::finalize",
+        level = "debug",
+        target = "providers::static_file",
+        skip_all
+    )]
+    pub(crate) fn finalize(&self) -> ProviderResult<()> {
+        debug!(target: "providers::static_file", "Finalizing all static file segments into disk");
+
+        for writer_lock in [
+            &self.headers,
+            &self.transactions,
+            &self.receipts,
+            &self.transaction_senders,
+            &self.account_change_sets,
+            &self.storage_change_sets,
+        ] {
+            let mut writer = writer_lock.write();
+            if let Some(writer) = writer.as_mut() {
+                writer.finalize()?;
+            }
+        }
+
+        debug!(target: "providers::static_file", "Finalized all static file segments into disk");
+        Ok(())
+    }
+}
+
+/// Mutable reference to a [`StaticFileProviderRW`] behind a [`RwLockWriteGuard`].
+#[derive(Debug)]
+pub struct StaticFileProviderRWRefMut<'a, N>(
+    pub(crate) RwLockWriteGuard<'a, RawRwLock, Option<StaticFileProviderRW<N>>>,
+);
+
+impl<N> std::ops::DerefMut for StaticFileProviderRWRefMut<'_, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // This is always created by [`StaticFileWriters::get_or_create`]
+        self.0.as_mut().expect("static file writer provider should be init")
+    }
+}
+
+impl<N> std::ops::Deref for StaticFileProviderRWRefMut<'_, N> {
+    type Target = StaticFileProviderRW<N>;
+
+    fn deref(&self) -> &Self::Target {
+        // This is always created by [`StaticFileWriters::get_or_create`]
+        self.0.as_ref().expect("static file writer provider should be init")
+    }
+}
+
+#[derive(Debug)]
+/// Extends `StaticFileProvider` with writing capabilities
+pub struct StaticFileProviderRW<N> {
+    /// Reference back to the provider. We need [Weak] here because [`StaticFileProviderRW`] is
+    /// stored in a [`reth_primitives_traits::dashmap::DashMap`] inside the parent
+    /// [`StaticFileProvider`].which is an [Arc]. If we were to use an [Arc] here, we would
+    /// create a reference cycle.
+    reader: Weak<StaticFileProviderInner<N>>,
+    /// A [`NippyJarWriter`] instance.
+    writer: NippyJarWriter<SegmentHeader>,
+    /// Path to opened file.
+    data_path: PathBuf,
+    /// Reusable buffer for encoding appended data.
+    buf: Vec<u8>,
+    /// Metrics.
+    metrics: Option<Arc<StaticFileProviderMetrics>>,
+    /// On commit, contains the pruning strategy to apply for the segment.
+    prune_on_commit: Option<PruneStrategy>,
+    /// Whether `sync_all()` has been called. Used by `finalize()` to avoid redundant syncs.
+    synced: bool,
+    /// Changeset offsets sidecar writer (only for changeset segments).
+    changeset_offsets: Option<ChangesetOffsetWriter>,
+    /// Current block's changeset offset being written.
+    current_changeset_offset: Option<ChangesetOffset>,
+}
+
+impl<N: NodePrimitives> StaticFileProviderRW<N> {
+    /// Creates a new [`StaticFileProviderRW`] for a [`StaticFileSegment`].
+    ///
+    /// Before use, transaction based segments should ensure the block end range is the expected
+    /// one, and heal if not. For more check `Self::ensure_end_range_consistency`.
+    pub fn new(
+        segment: StaticFileSegment,
+        block: BlockNumber,
+        reader: Weak<StaticFileProviderInner<N>>,
+        metrics: Option<Arc<StaticFileProviderMetrics>>,
+    ) -> ProviderResult<Self> {
+        let (writer, data_path) = Self::open(segment, block, reader.clone(), metrics.clone())?;
+
+        // Create writer WITHOUT sidecar first - we'll add it after healing
+        let mut writer = Self {
+            writer,
+            data_path,
+            buf: Vec::with_capacity(100),
+            reader,
+            metrics,
+            prune_on_commit: None,
+            synced: false,
+            changeset_offsets: None,
+            current_changeset_offset: None,
+        };
+
+        // Run NippyJar healing BEFORE setting up changeset sidecar
+        // This may reduce rows, which affects valid sidecar offsets
+        writer.ensure_end_range_consistency()?;
+
+        // Now set up changeset sidecar with post-heal header values
+        if segment.is_change_based() {
+            writer.heal_changeset_sidecar()?;
+        }
+
+        Ok(writer)
+    }
+
+    fn open(
+        segment: StaticFileSegment,
+        block: u64,
+        reader: Weak<StaticFileProviderInner<N>>,
+        metrics: Option<Arc<StaticFileProviderMetrics>>,
+    ) -> ProviderResult<(NippyJarWriter<SegmentHeader>, PathBuf)> {
+        let start = Instant::now();
+
+        let static_file_provider = Self::upgrade_provider_to_strong_reference(&reader);
+
+        let block_range = static_file_provider.find_fixed_range(segment, block);
+        let (jar, path) = match static_file_provider.get_segment_provider_for_block(
+            segment,
+            block_range.start(),
+            None,
+        ) {
+            Ok(provider) => (
+                NippyJar::load(provider.data_path()).map_err(ProviderError::other)?,
+                provider.data_path().into(),
+            ),
+            Err(ProviderError::MissingStaticFileBlock(_, _)) => {
+                let path = static_file_provider.directory().join(segment.filename(&block_range));
+                (create_jar(segment, &path, block_range), path)
+            }
+            Err(err) => return Err(err),
+        };
+
+        let result = match NippyJarWriter::new(jar) {
+            Ok(writer) => Ok((writer, path)),
+            Err(NippyJarError::FrozenJar) => {
+                // This static file has been frozen, so we should
+                Err(ProviderError::FinalizedStaticFile(segment, block))
+            }
+            Err(e) => Err(ProviderError::other(e)),
+        }?;
+
+        if let Some(metrics) = &metrics {
+            metrics.record_segment_operation(
+                segment,
+                StaticFileProviderOperation::OpenWriter,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(result)
+    }
+
+    /// If a file level healing happens, we need to update the end range on the
+    /// [`SegmentHeader`].
+    ///
+    /// However, for transaction based segments, the block end range has to be found and healed
+    /// externally.
+    ///
+    /// Check [`reth_nippy_jar::NippyJarChecker`] &
+    /// [`NippyJarWriter`] for more on healing.
+    fn ensure_end_range_consistency(&mut self) -> ProviderResult<()> {
+        // If we have lost rows (in this run or previous), we need to update the [SegmentHeader].
+        let expected_rows = if self.user_header().segment().is_headers() {
+            self.user_header().block_len().unwrap_or_default()
+        } else {
+            self.user_header().tx_len().unwrap_or_default()
+        };
+        let actual_rows = self.writer.rows() as u64;
+        let pruned_rows = expected_rows.saturating_sub(actual_rows);
+        if pruned_rows > 0 {
+            self.user_header_mut().prune(pruned_rows);
+        }
+
+        debug!(
+            target: "providers::static_file",
+            segment = ?self.writer.user_header().segment(),
+            path = ?self.data_path,
+            pruned_rows,
+            "Ensuring end range consistency"
+        );
+
+        self.writer.commit().map_err(ProviderError::other)?;
+
+        // Updates the [SnapshotProvider] manager
+        self.update_index()?;
+        Ok(())
+    }
+
+    /// Returns `true` if the writer will prune on commit.
+    pub const fn will_prune_on_commit(&self) -> bool {
+        self.prune_on_commit.is_some()
+    }
+
+    /// Heals the changeset offset sidecar after `NippyJar` healing.
+    ///
+    /// This must be called AFTER `ensure_end_range_consistency()` which may reduce rows.
+    /// Performs three-way consistency check between header, `NippyJar` rows, and sidecar file:
+    /// - Validates sidecar offsets don't point past actual `NippyJar` rows
+    /// - Heals header if sidecar was truncated during interrupted prune
+    /// - Truncates sidecar if offsets point past healed `NippyJar` data
+    fn heal_changeset_sidecar(&mut self) -> ProviderResult<()> {
+        let csoff_path = self.data_path.with_extension("csoff");
+
+        // Step 1: Read all three sources of truth
+        let header_claims_blocks = self.writer.user_header().changeset_offsets_len();
+        let actual_nippy_rows = self.writer.rows() as u64;
+
+        // Get actual sidecar file size (may differ from header after crash)
+        let actual_sidecar_blocks = if csoff_path.exists() {
+            let file_len = reth_fs_util::metadata(&csoff_path).map_err(ProviderError::other)?.len();
+            // Remove partial records from crash mid-write
+            let aligned_len = file_len - (file_len % 16);
+            aligned_len / 16
+        } else {
+            0
+        };
+
+        // Fresh segment or no sidecar data - nothing to heal
+        if header_claims_blocks == 0 && actual_sidecar_blocks == 0 {
+            self.changeset_offsets =
+                Some(ChangesetOffsetWriter::new(&csoff_path, 0).map_err(ProviderError::other)?);
+            return Ok(());
+        }
+
+        // Step 2: Validate sidecar offsets against actual NippyJar state
+        let valid_blocks = if actual_sidecar_blocks > 0 {
+            let reader = ChangesetOffsetReader::new(&csoff_path, actual_sidecar_blocks)
+                .map_err(ProviderError::other)?;
+
+            // Find last block where offset + num_changes <= actual_nippy_rows
+            // This correctly handles rows=0 with offset=0, num_changes=0 (empty blocks)
+            let mut valid = 0u64;
+            for i in 0..actual_sidecar_blocks {
+                if let Some(offset) = reader.get(i).map_err(ProviderError::other)? {
+                    if offset.offset() + offset.num_changes() <= actual_nippy_rows {
+                        valid = i + 1;
+                    } else {
+                        // This block points past EOF - stop here
+                        break;
+                    }
+                }
+            }
+            valid
+        } else {
+            0
+        };
+
+        // Step 3: Determine correct state from synced files (source of truth)
+        // Header is the commit marker - never enlarge, only shrink
+        let correct_blocks = valid_blocks.min(header_claims_blocks);
+
+        // Step 4: Heal if header doesn't match validated truth
+        let mut needs_header_commit = false;
+
+        if correct_blocks != header_claims_blocks || actual_sidecar_blocks != correct_blocks {
+            tracing::warn!(
+                target: "reth::static_file",
+                path = %csoff_path.display(),
+                header_claims = header_claims_blocks,
+                sidecar_has = actual_sidecar_blocks,
+                valid_blocks = correct_blocks,
+                actual_rows = actual_nippy_rows,
+                "Three-way healing: syncing header, sidecar, and NippyJar state"
+            );
+
+            // Truncate sidecar file if it has invalid blocks
+            if actual_sidecar_blocks > correct_blocks {
+                use std::fs::OpenOptions;
+                let file = OpenOptions::new()
+                    .write(true)
+                    .open(&csoff_path)
+                    .map_err(ProviderError::other)?;
+                file.set_len(correct_blocks * 16).map_err(ProviderError::other)?;
+                file.sync_all().map_err(ProviderError::other)?;
+
+                tracing::debug!(
+                    target: "reth::static_file",
+                    "Truncated sidecar from {} to {} blocks",
+                    actual_sidecar_blocks,
+                    correct_blocks
+                );
+            }
+
+            // Update header to match validated truth (can only shrink, never enlarge)
+            if correct_blocks < header_claims_blocks {
+                // Blocks were removed - use prune() to update both block_range and
+                // changeset_offsets_len atomically
+                let blocks_removed = header_claims_blocks - correct_blocks;
+                self.writer.user_header_mut().prune(blocks_removed);
+
+                tracing::debug!(
+                    target: "reth::static_file",
+                    "Updated header: removed {} blocks (changeset_offsets_len: {} -> {})",
+                    blocks_removed,
+                    header_claims_blocks,
+                    correct_blocks
+                );
+
+                needs_header_commit = true;
+            }
+        } else {
+            tracing::debug!(
+                target: "reth::static_file",
+                path = %csoff_path.display(),
+                blocks = correct_blocks,
+                "Changeset sidecar consistent, no healing needed"
+            );
+        }
+
+        // Open sidecar writer with corrected count (won't error now that sizes match)
+        let csoff_writer = ChangesetOffsetWriter::new(&csoff_path, correct_blocks)
+            .map_err(ProviderError::other)?;
+
+        self.changeset_offsets = Some(csoff_writer);
+
+        // Commit healed header if needed (after sidecar writer is set up)
+        if needs_header_commit {
+            self.writer.commit().map_err(ProviderError::other)?;
+
+            tracing::info!(
+                target: "reth::static_file",
+                path = %csoff_path.display(),
+                blocks = correct_blocks,
+                "Committed healed changeset offset header"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Flushes the current changeset offset (if any) to the `.csoff` sidecar file.
+    ///
+    /// This is idempotent - safe to call multiple times. After flushing, the current offset
+    /// is cleared to prevent duplicate writes.
+    ///
+    /// This must be called before committing or syncing to ensure the last block's offset
+    /// is persisted, since `increment_block()` only writes the *previous* block's offset.
+    fn flush_current_changeset_offset(&mut self) -> ProviderResult<()> {
+        if !self.writer.user_header().segment().is_change_based() {
+            return Ok(());
+        }
+
+        if let Some(offset) = self.current_changeset_offset.take() &&
+            let Some(writer) = &mut self.changeset_offsets
+        {
+            writer.append(&offset).map_err(ProviderError::other)?;
+        }
+        Ok(())
+    }
+
+    /// Syncs all data (rows, offsets, and changeset offsets sidecar) to disk.
+    ///
+    /// This does NOT commit the configuration. Call [`Self::finalize`] after to write the
+    /// configuration and mark the writer as clean.
+    ///
+    /// Returns an error if prune is queued (use [`Self::commit`] instead).
+    pub fn sync_all(&mut self) -> ProviderResult<()> {
+        if self.prune_on_commit.is_some() {
+            return Err(StaticFileWriterError::FinalizeWithPruneQueued.into());
+        }
+
+        // Write the final block's offset and sync the sidecar for changeset segments
+        self.flush_current_changeset_offset()?;
+        if let Some(writer) = &mut self.changeset_offsets {
+            writer.sync().map_err(ProviderError::other)?;
+            // Update the header with the actual number of offsets written
+            self.writer.user_header_mut().set_changeset_offsets_len(writer.len());
+        }
+
+        if self.writer.is_dirty() {
+            self.writer.sync_all().map_err(ProviderError::other)?;
+        }
+        self.synced = true;
+        Ok(())
+    }
+
+    /// Commits configuration to disk and updates the reader index.
+    ///
+    /// If `sync_all()` was not called, this will call it first to ensure data is persisted.
+    ///
+    /// Returns an error if prune is queued (use [`Self::commit`] instead).
+    #[instrument(
+        name = "StaticFileProviderRW::finalize",
+        level = "debug",
+        target = "providers::static_file",
+        skip_all
+    )]
+    pub fn finalize(&mut self) -> ProviderResult<()> {
+        if self.prune_on_commit.is_some() {
+            return Err(StaticFileWriterError::FinalizeWithPruneQueued.into());
+        }
+        if self.writer.is_dirty() {
+            if !self.synced {
+                // Must call self.sync_all() to flush changeset offsets and update
+                // the header's changeset_offsets_len, not just the inner writer
+                self.sync_all()?;
+            }
+
+            self.writer.finalize().map_err(ProviderError::other)?;
+            self.update_index()?;
+        }
+        self.synced = false;
+        Ok(())
+    }
+
+    /// Commits configuration changes to disk and updates the reader index with the new changes.
+    #[instrument(
+        name = "StaticFileProviderRW::commit",
+        level = "debug",
+        target = "providers::static_file",
+        skip_all
+    )]
+    pub fn commit(&mut self) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        // Truncates the data file if instructed to.
+        if let Some(strategy) = self.prune_on_commit.take() {
+            debug!(
+                target: "providers::static_file",
+                segment = ?self.writer.user_header().segment(),
+                "Pruning data on commit"
+            );
+            match strategy {
+                PruneStrategy::Headers { num_blocks } => self.prune_header_data(num_blocks)?,
+                PruneStrategy::Transactions { num_rows, last_block } => {
+                    self.prune_transaction_data(num_rows, last_block)?
+                }
+                PruneStrategy::Receipts { num_rows, last_block } => {
+                    self.prune_receipt_data(num_rows, last_block)?
+                }
+                PruneStrategy::TransactionSenders { num_rows, last_block } => {
+                    self.prune_transaction_sender_data(num_rows, last_block)?
+                }
+                PruneStrategy::AccountChangeSets { last_block } => {
+                    self.prune_account_changeset_data(last_block)?
+                }
+                PruneStrategy::StorageChangeSets { last_block } => {
+                    self.prune_storage_changeset_data(last_block)?
+                }
+            }
+        }
+
+        // For changeset segments, flush and sync the sidecar file before committing the main file.
+        // This ensures crash consistency: the sidecar is durable before the header references it.
+        self.flush_current_changeset_offset()?;
+        if let Some(writer) = &mut self.changeset_offsets {
+            writer.sync().map_err(ProviderError::other)?;
+            // Update the header with the actual number of offsets written
+            self.writer.user_header_mut().set_changeset_offsets_len(writer.len());
+        }
+
+        if self.writer.is_dirty() {
+            debug!(
+                target: "providers::static_file",
+                segment = ?self.writer.user_header().segment(),
+                "Committing writer to disk"
+            );
+
+            // Commits offsets and new user_header to disk
+            self.writer.commit().map_err(ProviderError::other)?;
+
+            if let Some(metrics) = &self.metrics {
+                metrics.record_segment_operation(
+                    self.writer.user_header().segment(),
+                    StaticFileProviderOperation::CommitWriter,
+                    Some(start.elapsed()),
+                );
+            }
+
+            debug!(
+                target: "providers::static_file",
+                segment = ?self.writer.user_header().segment(),
+                path = ?self.data_path,
+                duration = ?start.elapsed(),
+                "Committed writer to disk"
+            );
+
+            self.update_index()?;
+        }
+
+        Ok(())
+    }
+
+    /// Commits configuration changes to disk and updates the reader index with the new changes.
+    ///
+    /// CAUTION: does not call `sync_all` on the files.
+    #[cfg(feature = "test-utils")]
+    pub fn commit_without_sync_all(&mut self) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        debug!(
+            target: "providers::static_file",
+            segment = ?self.writer.user_header().segment(),
+            "Committing writer to disk (without sync)"
+        );
+
+        // Commits offsets and new user_header to disk
+        self.writer.commit_without_sync_all().map_err(ProviderError::other)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                self.writer.user_header().segment(),
+                StaticFileProviderOperation::CommitWriter,
+                Some(start.elapsed()),
+            );
+        }
+
+        debug!(
+            target: "providers::static_file",
+            segment = ?self.writer.user_header().segment(),
+            path = ?self.data_path,
+            duration = ?start.elapsed(),
+            "Committed writer to disk (without sync)"
+        );
+
+        self.update_index()?;
+
+        Ok(())
+    }
+
+    /// Updates the `self.reader` internal index.
+    fn update_index(&self) -> ProviderResult<()> {
+        let segment = self.writer.user_header().segment();
+
+        // We find the maximum block of the segment by checking this writer's last block.
+        //
+        // However if there's no block range (because there's no data), we try to calculate it by
+        // subtracting 1 from the expected block start, resulting on the last block of the
+        // previous file — but only if that file actually exists. If the previous file doesn't
+        // exist (e.g. first-ever file for a segment starting past range boundary), there's
+        // nothing to index.
+        let segment_max_block = self
+            .writer
+            .user_header()
+            .block_range()
+            .as_ref()
+            .map(|block_range| block_range.end())
+            .or_else(|| {
+                let expected_start = self.writer.user_header().expected_block_start();
+                if expected_start <= self.reader().genesis_block_number() {
+                    return None;
+                }
+
+                let prev_block = expected_start - 1;
+                let prev_range = self.reader().find_fixed_range(segment, prev_block);
+                let prev_path = self.reader().directory().join(segment.filename(&prev_range));
+                prev_path.exists().then_some(prev_block)
+            });
+
+        self.reader().update_index(segment, segment_max_block)
+    }
+
+    /// Ensures that the writer is positioned at the specified block number.
+    ///
+    /// If the writer is positioned at a greater block number than the specified one, the writer
+    /// will NOT be unwound and the error will be returned.
+    pub fn ensure_at_block(&mut self, advance_to: BlockNumber) -> ProviderResult<()> {
+        let current_block = if let Some(current_block_number) = self.current_block_number() {
+            current_block_number
+        } else {
+            self.increment_block(0)?;
+            0
+        };
+
+        match current_block.cmp(&advance_to) {
+            Ordering::Less => {
+                for block in current_block + 1..=advance_to {
+                    self.increment_block(block)?;
+                }
+            }
+            Ordering::Equal => {}
+            Ordering::Greater => {
+                return Err(ProviderError::UnexpectedStaticFileBlockNumber(
+                    self.writer.user_header().segment(),
+                    current_block,
+                    advance_to,
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Allows to increment the [`SegmentHeader`] end block. It will commit the current static file,
+    /// and create the next one if we are past the end range.
+    pub fn increment_block(&mut self, expected_block_number: BlockNumber) -> ProviderResult<()> {
+        let segment = self.writer.user_header().segment();
+
+        self.check_next_block_number(expected_block_number)?;
+
+        let start = Instant::now();
+        if let Some(last_block) = self.writer.user_header().block_end() {
+            // We have finished the previous static file and must freeze it
+            if last_block == self.writer.user_header().expected_block_end() {
+                // Commits offsets and new user_header to disk
+                self.commit()?;
+
+                // Opens the new static file
+                let (writer, data_path) =
+                    Self::open(segment, last_block + 1, self.reader.clone(), self.metrics.clone())?;
+                self.writer = writer;
+                self.data_path = data_path.clone();
+
+                // Update changeset offsets writer for the new file (starts empty)
+                if segment.is_change_based() {
+                    let csoff_path = data_path.with_extension("csoff");
+                    self.changeset_offsets = Some(
+                        ChangesetOffsetWriter::new(&csoff_path, 0).map_err(ProviderError::other)?,
+                    );
+                }
+
+                *self.writer.user_header_mut() = SegmentHeader::new(
+                    self.reader().find_fixed_range(segment, last_block + 1),
+                    None,
+                    None,
+                    segment,
+                );
+            }
+        }
+
+        self.writer.user_header_mut().increment_block();
+
+        // Handle changeset offset tracking for changeset segments
+        if segment.is_change_based() {
+            // Write previous block's offset if we have one
+            if let Some(offset) = self.current_changeset_offset.take() &&
+                let Some(writer) = &mut self.changeset_offsets
+            {
+                writer.append(&offset).map_err(ProviderError::other)?;
+            }
+            // Start tracking new block's offset
+            let new_offset = self.writer.rows() as u64;
+            self.current_changeset_offset = Some(ChangesetOffset::new(new_offset, 0));
+        }
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                segment,
+                StaticFileProviderOperation::IncrementBlock,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns the current block number of the static file writer.
+    pub fn current_block_number(&self) -> Option<u64> {
+        self.writer.user_header().block_end()
+    }
+
+    /// Returns a block number that is one next to the current tip of static files.
+    pub fn next_block_number(&self) -> u64 {
+        // The next static file block number can be found by checking the one after block_end.
+        // However, if it's a new file that hasn't been added any data, its block range will
+        // actually be None. In that case, the next block will be found on `expected_block_start`.
+        self.writer
+            .user_header()
+            .block_end()
+            .map(|b| b + 1)
+            .unwrap_or_else(|| self.writer.user_header().expected_block_start())
+    }
+
+    /// Verifies if the incoming block number matches the next expected block number
+    /// for a static file. This ensures data continuity when adding new blocks.
+    fn check_next_block_number(&self, expected_block_number: u64) -> ProviderResult<()> {
+        let next_static_file_block = self.next_block_number();
+
+        if expected_block_number != next_static_file_block {
+            return Err(ProviderError::UnexpectedStaticFileBlockNumber(
+                self.writer.user_header().segment(),
+                expected_block_number,
+                next_static_file_block,
+            ))
+        }
+        Ok(())
+    }
+
+    /// Truncates account changesets to the given block. It deletes and loads an older static file
+    /// if the block goes beyond the start of the current block range.
+    ///
+    /// # Note
+    /// Commits to the configuration file at the end
+    fn truncate_changesets(&mut self, last_block: u64) -> ProviderResult<()> {
+        let segment = self.writer.user_header().segment();
+        debug_assert!(segment.is_change_based());
+
+        // Get the current block range
+        let current_block_end = self
+            .writer
+            .user_header()
+            .block_end()
+            .ok_or(ProviderError::MissingStaticFileBlock(segment, 0))?;
+
+        // If we're already at or before the target block, nothing to do
+        if current_block_end <= last_block {
+            return Ok(())
+        }
+
+        // Navigate to the correct file if the target block is in a previous file
+        let mut expected_block_start = self.writer.user_header().expected_block_start();
+        while last_block < expected_block_start && expected_block_start > 0 {
+            self.delete_current_and_open_previous()?;
+            expected_block_start = self.writer.user_header().expected_block_start();
+        }
+
+        // Find the number of rows to keep (up to and including last_block)
+        let blocks_to_keep = if last_block >= expected_block_start {
+            last_block - expected_block_start + 1
+        } else {
+            0
+        };
+
+        // Read changeset offsets from sidecar file to find where to truncate
+        let csoff_path = self.data_path.with_extension("csoff");
+        let changeset_offsets_len = self.writer.user_header().changeset_offsets_len();
+
+        // Flush any pending changeset offset before reading the sidecar
+        self.flush_current_changeset_offset()?;
+
+        let rows_to_keep = if blocks_to_keep == 0 {
+            0
+        } else if blocks_to_keep >= changeset_offsets_len {
+            // Keep all rows in this file
+            self.writer.rows() as u64
+        } else {
+            // Read offset for the block after last_block from sidecar.
+            // Use committed length from header, ignoring any uncommitted records
+            // that may exist in the file after a crash.
+            let reader = ChangesetOffsetReader::new(&csoff_path, changeset_offsets_len)
+                .map_err(ProviderError::other)?;
+            if let Some(next_offset) = reader.get(blocks_to_keep).map_err(ProviderError::other)? {
+                next_offset.offset()
+            } else {
+                // If we can't read the offset, keep all rows
+                self.writer.rows() as u64
+            }
+        };
+
+        let total_rows = self.writer.rows() as u64;
+        let rows_to_delete = total_rows.saturating_sub(rows_to_keep);
+
+        if rows_to_delete > 0 {
+            // Calculate the number of blocks to prune
+            let current_block_end = self
+                .writer
+                .user_header()
+                .block_end()
+                .ok_or(ProviderError::MissingStaticFileBlock(segment, 0))?;
+            let blocks_to_remove = current_block_end - last_block;
+
+            // Update segment header - for changesets, prune expects number of blocks, not rows
+            self.writer.user_header_mut().prune(blocks_to_remove);
+
+            // Prune the actual rows
+            self.writer.prune_rows(rows_to_delete as usize).map_err(ProviderError::other)?;
+        }
+
+        // Update the block range
+        self.writer.user_header_mut().set_block_range(expected_block_start, last_block);
+
+        // Sync changeset offsets to match the new block range
+        self.writer.user_header_mut().sync_changeset_offsets();
+
+        // Truncate the sidecar file to match the new block count
+        if let Some(writer) = &mut self.changeset_offsets {
+            writer.truncate(blocks_to_keep).map_err(ProviderError::other)?;
+        }
+
+        // Clear current changeset offset tracking since we've pruned
+        self.current_changeset_offset = None;
+
+        // Commits new changes to disk
+        self.commit()?;
+
+        Ok(())
+    }
+
+    /// Truncates a number of rows from disk. It deletes and loads an older static file if block
+    /// goes beyond the start of the current block range.
+    ///
+    /// **`last_block`** should be passed only with transaction based segments.
+    ///
+    /// # Note
+    /// Commits to the configuration file at the end.
+    fn truncate(&mut self, num_rows: u64, last_block: Option<u64>) -> ProviderResult<()> {
+        let mut remaining_rows = num_rows;
+        let segment = self.writer.user_header().segment();
+        while remaining_rows > 0 {
+            let len = if segment.is_block_based() {
+                self.writer.user_header().block_len().unwrap_or_default()
+            } else {
+                self.writer.user_header().tx_len().unwrap_or_default()
+            };
+
+            if remaining_rows >= len {
+                // If there's more rows to delete than this static file contains, then just
+                // delete the whole file and go to the next static file
+                let block_start = self.writer.user_header().expected_block_start();
+
+                // We only delete the file if it's NOT the first static file AND:
+                // * it's a Header segment  OR
+                // * it's a tx-based segment AND `last_block` is lower than the first block of this
+                //   file's block range. Otherwise, having no rows simply means that this block
+                //   range has no transactions, but the file should remain.
+                if block_start != 0 &&
+                    (segment.is_headers() || last_block.is_some_and(|b| b < block_start))
+                {
+                    self.delete_current_and_open_previous()?;
+                } else {
+                    // Update `SegmentHeader`
+                    self.writer.user_header_mut().prune(len);
+                    self.writer.prune_rows(len as usize).map_err(ProviderError::other)?;
+                    break
+                }
+
+                remaining_rows -= len;
+            } else {
+                // Update `SegmentHeader`
+                self.writer.user_header_mut().prune(remaining_rows);
+
+                // Truncate data
+                self.writer.prune_rows(remaining_rows as usize).map_err(ProviderError::other)?;
+                remaining_rows = 0;
+            }
+        }
+
+        // Only Transactions and Receipts
+        if let Some(last_block) = last_block {
+            let mut expected_block_start = self.writer.user_header().expected_block_start();
+
+            if num_rows == 0 {
+                // Edge case for when we are unwinding a chain of empty blocks that goes across
+                // files, and therefore, the only reference point to know which file
+                // we are supposed to be at is `last_block`.
+                while last_block < expected_block_start {
+                    self.delete_current_and_open_previous()?;
+                    expected_block_start = self.writer.user_header().expected_block_start();
+                }
+            }
+            self.writer.user_header_mut().set_block_range(expected_block_start, last_block);
+        }
+
+        // Commits new changes to disk.
+        self.commit()?;
+
+        Ok(())
+    }
+
+    /// Delete the current static file, and replace this provider writer with the previous static
+    /// file.
+    fn delete_current_and_open_previous(&mut self) -> Result<(), ProviderError> {
+        let segment = self.user_header().segment();
+        let current_path = self.data_path.clone();
+        let (previous_writer, data_path) = Self::open(
+            segment,
+            self.writer.user_header().expected_block_start() - 1,
+            self.reader.clone(),
+            self.metrics.clone(),
+        )?;
+        self.writer = previous_writer;
+        self.writer.set_dirty();
+        self.data_path = data_path.clone();
+
+        // Delete the sidecar file for changeset segments before deleting the main jar
+        if segment.is_change_based() {
+            let csoff_path = current_path.with_extension("csoff");
+            if csoff_path.exists() {
+                std::fs::remove_file(&csoff_path).map_err(ProviderError::other)?;
+            }
+            // Re-initialize the changeset offsets writer for the previous file
+            let new_csoff_path = data_path.with_extension("csoff");
+            let committed_len = self.writer.user_header().changeset_offsets_len();
+            self.changeset_offsets = Some(
+                ChangesetOffsetWriter::new(&new_csoff_path, committed_len)
+                    .map_err(ProviderError::other)?,
+            );
+        }
+
+        // Clear current changeset offset tracking since we're switching files
+        self.current_changeset_offset = None;
+
+        NippyJar::<SegmentHeader>::load(&current_path)
+            .map_err(ProviderError::other)?
+            .delete()
+            .map_err(ProviderError::other)?;
+        Ok(())
+    }
+
+    /// Appends column to static file.
+    fn append_column<T: Compact>(&mut self, column: T) -> ProviderResult<()> {
+        self.buf.clear();
+        column.to_compact(&mut self.buf);
+
+        self.writer.append_column(Some(Ok(&self.buf))).map_err(ProviderError::other)?;
+        Ok(())
+    }
+
+    /// Appends to tx number-based static file.
+    fn append_with_tx_number<V: Compact>(
+        &mut self,
+        tx_num: TxNumber,
+        value: V,
+    ) -> ProviderResult<()> {
+        if let Some(range) = self.writer.user_header().tx_range() {
+            let next_tx = range.end() + 1;
+            if next_tx != tx_num {
+                return Err(ProviderError::UnexpectedStaticFileTxNumber(
+                    self.writer.user_header().segment(),
+                    tx_num,
+                    next_tx,
+                ))
+            }
+            self.writer.user_header_mut().increment_tx();
+        } else {
+            self.writer.user_header_mut().set_tx_range(tx_num, tx_num);
+        }
+
+        self.append_column(value)?;
+
+        Ok(())
+    }
+
+    /// Appends change to changeset static file.
+    fn append_change<V: Compact>(&mut self, change: &V) -> ProviderResult<()> {
+        if let Some(ref mut offset) = self.current_changeset_offset {
+            offset.increment_num_changes();
+        }
+        self.append_column(change)?;
+        Ok(())
+    }
+
+    /// Appends header to static file.
+    ///
+    /// It **CALLS** `increment_block()` since the number of headers is equal to the number of
+    /// blocks.
+    pub fn append_header(&mut self, header: &N::BlockHeader, hash: &BlockHash) -> ProviderResult<()>
+    where
+        N::BlockHeader: Compact,
+    {
+        self.append_header_with_td(header, U256::ZERO, hash)
+    }
+
+    /// Appends header to static file with a specified total difficulty.
+    ///
+    /// It **CALLS** `increment_block()` since the number of headers is equal to the number of
+    /// blocks.
+    pub fn append_header_with_td(
+        &mut self,
+        header: &N::BlockHeader,
+        total_difficulty: U256,
+        hash: &BlockHash,
+    ) -> ProviderResult<()>
+    where
+        N::BlockHeader: Compact,
+    {
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Headers);
+
+        self.increment_block(header.number())?;
+
+        self.append_column(header)?;
+        self.append_column(CompactU256::from(total_difficulty))?;
+        self.append_column(hash)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Headers,
+                StaticFileProviderOperation::Append,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends header to static file without calling `increment_block`.
+    /// This is useful for genesis blocks with non-zero block numbers.
+    pub fn append_header_direct(
+        &mut self,
+        header: &N::BlockHeader,
+        total_difficulty: U256,
+        hash: &BlockHash,
+    ) -> ProviderResult<()>
+    where
+        N::BlockHeader: Compact,
+    {
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Headers);
+
+        self.append_column(header)?;
+        self.append_column(CompactU256::from(total_difficulty))?;
+        self.append_column(hash)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Headers,
+                StaticFileProviderOperation::Append,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends transaction to static file.
+    ///
+    /// It **DOES NOT CALL** `increment_block()`, it should be handled elsewhere. There might be
+    /// empty blocks and this function wouldn't be called.
+    pub fn append_transaction(&mut self, tx_num: TxNumber, tx: &N::SignedTx) -> ProviderResult<()>
+    where
+        N::SignedTx: Compact,
+    {
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Transactions);
+        self.append_with_tx_number(tx_num, tx)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Transactions,
+                StaticFileProviderOperation::Append,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends receipt to static file.
+    ///
+    /// It **DOES NOT** call `increment_block()`, it should be handled elsewhere. There might be
+    /// empty blocks and this function wouldn't be called.
+    pub fn append_receipt(&mut self, tx_num: TxNumber, receipt: &N::Receipt) -> ProviderResult<()>
+    where
+        N::Receipt: Compact,
+    {
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Receipts);
+        self.append_with_tx_number(tx_num, receipt)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Receipts,
+                StaticFileProviderOperation::Append,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends multiple receipts to the static file.
+    pub fn append_receipts<I, R>(&mut self, receipts: I) -> ProviderResult<()>
+    where
+        I: Iterator<Item = Result<(TxNumber, R), ProviderError>>,
+        R: Borrow<N::Receipt>,
+        N::Receipt: Compact,
+    {
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Receipts);
+
+        let mut receipts_iter = receipts.into_iter().peekable();
+        // If receipts are empty, we can simply return None
+        if receipts_iter.peek().is_none() {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        // At this point receipts contains at least one receipt, so this would be overwritten.
+        let mut count: u64 = 0;
+
+        for receipt_result in receipts_iter {
+            let (tx_num, receipt) = receipt_result?;
+            self.append_with_tx_number(tx_num, receipt.borrow())?;
+            count += 1;
+        }
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operations(
+                StaticFileSegment::Receipts,
+                StaticFileProviderOperation::Append,
+                count,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends transaction sender to static file.
+    ///
+    /// It **DOES NOT** call `increment_block()`, it should be handled elsewhere. There might be
+    /// empty blocks and this function wouldn't be called.
+    pub fn append_transaction_sender(
+        &mut self,
+        tx_num: TxNumber,
+        sender: &alloy_primitives::Address,
+    ) -> ProviderResult<()> {
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::TransactionSenders);
+        self.append_with_tx_number(tx_num, sender)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::TransactionSenders,
+                StaticFileProviderOperation::Append,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends multiple transaction senders to the static file.
+    pub fn append_transaction_senders<I>(&mut self, senders: I) -> ProviderResult<()>
+    where
+        I: Iterator<Item = (TxNumber, alloy_primitives::Address)>,
+    {
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::TransactionSenders);
+
+        let mut senders_iter = senders.into_iter().peekable();
+        // If senders are empty, we can simply return
+        if senders_iter.peek().is_none() {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        // At this point senders contains at least one sender, so this would be overwritten.
+        let mut count: u64 = 0;
+        for (tx_num, sender) in senders_iter {
+            self.append_with_tx_number(tx_num, sender)?;
+            count += 1;
+        }
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operations(
+                StaticFileSegment::TransactionSenders,
+                StaticFileProviderOperation::Append,
+                count,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends a block changeset to the static file.
+    ///
+    /// It **CALLS** `increment_block()`.
+    ///
+    /// Returns the current number of changesets in the file, if any.
+    pub fn append_account_changeset(
+        &mut self,
+        mut changeset: Vec<AccountBeforeTx>,
+        block_number: u64,
+    ) -> ProviderResult<()> {
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::AccountChangeSets);
+        let start = Instant::now();
+
+        self.increment_block(block_number)?;
+        self.ensure_no_queued_prune()?;
+
+        // first sort the changeset by address
+        changeset.sort_by_key(|change| change.address);
+
+        let mut count: u64 = 0;
+
+        for change in changeset {
+            self.append_change(&change)?;
+            count += 1;
+        }
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operations(
+                StaticFileSegment::AccountChangeSets,
+                StaticFileProviderOperation::Append,
+                count,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends a block storage changeset to the static file.
+    ///
+    /// It **CALLS** `increment_block()`.
+    pub fn append_storage_changeset(
+        &mut self,
+        mut changeset: Vec<StorageBeforeTx>,
+        block_number: u64,
+    ) -> ProviderResult<()> {
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::StorageChangeSets);
+        let start = Instant::now();
+
+        self.increment_block(block_number)?;
+        self.ensure_no_queued_prune()?;
+
+        // sort by address + storage key
+        changeset.sort_by_key(|change| (change.address, change.key));
+
+        let mut count: u64 = 0;
+        for change in changeset {
+            self.append_change(&change)?;
+            count += 1;
+        }
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operations(
+                StaticFileSegment::StorageChangeSets,
+                StaticFileProviderOperation::Append,
+                count,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Adds an instruction to prune `to_delete` transactions during commit.
+    ///
+    /// Note: `last_block` refers to the block the unwinds ends at.
+    pub fn prune_transactions(
+        &mut self,
+        to_delete: u64,
+        last_block: BlockNumber,
+    ) -> ProviderResult<()> {
+        debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::Transactions);
+        self.queue_prune(PruneStrategy::Transactions { num_rows: to_delete, last_block })
+    }
+
+    /// Adds an instruction to prune `to_delete` receipts during commit.
+    ///
+    /// Note: `last_block` refers to the block the unwinds ends at.
+    pub fn prune_receipts(
+        &mut self,
+        to_delete: u64,
+        last_block: BlockNumber,
+    ) -> ProviderResult<()> {
+        debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::Receipts);
+        self.queue_prune(PruneStrategy::Receipts { num_rows: to_delete, last_block })
+    }
+
+    /// Adds an instruction to prune `to_delete` transaction senders during commit.
+    ///
+    /// Note: `last_block` refers to the block the unwinds ends at.
+    pub fn prune_transaction_senders(
+        &mut self,
+        to_delete: u64,
+        last_block: BlockNumber,
+    ) -> ProviderResult<()> {
+        debug_assert_eq!(
+            self.writer.user_header().segment(),
+            StaticFileSegment::TransactionSenders
+        );
+        self.queue_prune(PruneStrategy::TransactionSenders { num_rows: to_delete, last_block })
+    }
+
+    /// Adds an instruction to prune `to_delete` headers during commit.
+    pub fn prune_headers(&mut self, to_delete: u64) -> ProviderResult<()> {
+        debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::Headers);
+        self.queue_prune(PruneStrategy::Headers { num_blocks: to_delete })
+    }
+
+    /// Adds an instruction to prune changesets until the given block.
+    pub fn prune_account_changesets(&mut self, last_block: u64) -> ProviderResult<()> {
+        debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::AccountChangeSets);
+        self.queue_prune(PruneStrategy::AccountChangeSets { last_block })
+    }
+
+    /// Adds an instruction to prune storage changesets until the given block.
+    pub fn prune_storage_changesets(&mut self, last_block: u64) -> ProviderResult<()> {
+        debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::StorageChangeSets);
+        self.queue_prune(PruneStrategy::StorageChangeSets { last_block })
+    }
+
+    /// Adds an instruction to prune elements during commit using the specified strategy.
+    fn queue_prune(&mut self, strategy: PruneStrategy) -> ProviderResult<()> {
+        self.ensure_no_queued_prune()?;
+        self.prune_on_commit = Some(strategy);
+        Ok(())
+    }
+
+    /// Returns Error if there is a pruning instruction that needs to be applied.
+    fn ensure_no_queued_prune(&self) -> ProviderResult<()> {
+        if self.prune_on_commit.is_some() {
+            return Err(ProviderError::other(StaticFileWriterError::new(
+                "Pruning should be committed before appending or pruning more data",
+            )));
+        }
+        Ok(())
+    }
+
+    /// Removes the last `to_delete` transactions from the data file.
+    fn prune_transaction_data(
+        &mut self,
+        to_delete: u64,
+        last_block: BlockNumber,
+    ) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Transactions);
+
+        self.truncate(to_delete, Some(last_block))?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Transactions,
+                StaticFileProviderOperation::Prune,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Prunes the last `to_delete` account changesets from the data file.
+    fn prune_account_changeset_data(&mut self, last_block: BlockNumber) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::AccountChangeSets);
+
+        self.truncate_changesets(last_block)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::AccountChangeSets,
+                StaticFileProviderOperation::Prune,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Prunes the last storage changesets from the data file.
+    fn prune_storage_changeset_data(&mut self, last_block: BlockNumber) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::StorageChangeSets);
+
+        self.truncate_changesets(last_block)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::StorageChangeSets,
+                StaticFileProviderOperation::Prune,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Prunes the last `to_delete` receipts from the data file.
+    fn prune_receipt_data(
+        &mut self,
+        to_delete: u64,
+        last_block: BlockNumber,
+    ) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Receipts);
+
+        self.truncate(to_delete, Some(last_block))?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Receipts,
+                StaticFileProviderOperation::Prune,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Prunes the last `to_delete` transaction senders from the data file.
+    fn prune_transaction_sender_data(
+        &mut self,
+        to_delete: u64,
+        last_block: BlockNumber,
+    ) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::TransactionSenders);
+
+        self.truncate(to_delete, Some(last_block))?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::TransactionSenders,
+                StaticFileProviderOperation::Prune,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Prunes the last `to_delete` headers from the data file.
+    fn prune_header_data(&mut self, to_delete: u64) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Headers);
+
+        self.truncate(to_delete, None)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Headers,
+                StaticFileProviderOperation::Prune,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns a [`StaticFileProvider`] associated with this writer.
+    pub fn reader(&self) -> StaticFileProvider<N> {
+        Self::upgrade_provider_to_strong_reference(&self.reader)
+    }
+
+    /// Upgrades a weak reference of [`StaticFileProviderInner`] to a strong reference
+    /// [`StaticFileProvider`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the parent [`StaticFileProvider`] is fully dropped while the child writer is still
+    /// active. In reality, it's impossible to detach the [`StaticFileProviderRW`] from the
+    /// [`StaticFileProvider`].
+    fn upgrade_provider_to_strong_reference(
+        provider: &Weak<StaticFileProviderInner<N>>,
+    ) -> StaticFileProvider<N> {
+        provider.upgrade().map(StaticFileProvider).expect("StaticFileProvider is dropped")
+    }
+
+    /// Helper function to access [`SegmentHeader`].
+    pub const fn user_header(&self) -> &SegmentHeader {
+        self.writer.user_header()
+    }
+
+    /// Helper function to access a mutable reference to [`SegmentHeader`].
+    pub const fn user_header_mut(&mut self) -> &mut SegmentHeader {
+        self.writer.user_header_mut()
+    }
+
+    /// Helper function to override block range for testing.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub const fn set_block_range(&mut self, block_range: std::ops::RangeInclusive<BlockNumber>) {
+        self.writer.user_header_mut().set_block_range(*block_range.start(), *block_range.end())
+    }
+
+    /// Helper function to override block range for testing.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub const fn inner(&mut self) -> &mut NippyJarWriter<SegmentHeader> {
+        &mut self.writer
+    }
+}
+
+fn create_jar(
+    segment: StaticFileSegment,
+    path: &Path,
+    expected_block_range: SegmentRangeInclusive,
+) -> NippyJar<SegmentHeader> {
+    let mut jar = NippyJar::new(
+        segment.columns(),
+        path,
+        SegmentHeader::new(expected_block_range, None, None, segment),
+    );
+
+    // Transaction and Receipt already have the compression scheme used natively in its encoding.
+    // (zstd-dictionary)
+    if segment.is_headers() {
+        jar = jar.with_lz4();
+    }
+
+    jar
+}

--- a/patches/reth-provider/src/providers/static_file/writer_tests.rs
+++ b/patches/reth-provider/src/providers/static_file/writer_tests.rs
@@ -1,0 +1,886 @@
+//! Crash recovery tests for changeset offset healing.
+//!
+//! These tests verify the three-way consistency healing logic between:
+//! 1. Header (`SegmentHeader.changeset_offsets_len`)
+//! 2. `NippyJar` rows (actual row count)
+//! 3. Sidecar file (.csoff)
+//!
+//! All tests use real `NippyJar` files via `StaticFileProvider` to test the full healing path.
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use reth_db::{models::AccountBeforeTx, test_utils::create_test_static_files_dir};
+    use reth_primitives_traits::Account;
+    use reth_static_file_types::{ChangesetOffset, ChangesetOffsetReader, StaticFileSegment};
+    use std::{fs::OpenOptions, io::Write as _, path::PathBuf};
+
+    use crate::providers::{
+        static_file::manager::{StaticFileProviderBuilder, StaticFileWriter},
+        StaticFileProvider,
+    };
+    use reth_chain_state::EthPrimitives;
+
+    // ==================== HELPER FUNCTIONS ====================
+
+    /// Creates a `StaticFileProvider` for testing with the given `blocks_per_file` setting.
+    fn setup_test_provider(
+        static_dir: &tempfile::TempDir,
+        blocks_per_file: u64,
+    ) -> StaticFileProvider<EthPrimitives> {
+        StaticFileProviderBuilder::read_write(static_dir)
+            .with_blocks_per_file(blocks_per_file)
+            .build()
+            .expect("Failed to build static file provider")
+    }
+
+    /// Generates test changeset data for a block.
+    fn generate_test_changeset(block_num: u64, num_changes: usize) -> Vec<AccountBeforeTx> {
+        (0..num_changes)
+            .map(|i| {
+                let mut address = Address::ZERO;
+                address.0[0] = block_num as u8;
+                address.0[1] = i as u8;
+                AccountBeforeTx {
+                    address,
+                    info: Some(Account {
+                        nonce: block_num,
+                        balance: U256::from(block_num * 1000 + i as u64),
+                        bytecode_hash: None,
+                    }),
+                }
+            })
+            .collect()
+    }
+
+    /// Writes test blocks to the `AccountChangeSets` segment.
+    /// Returns the path to the sidecar file.
+    fn write_test_blocks(
+        provider: &StaticFileProvider<EthPrimitives>,
+        num_blocks: u64,
+        changes_per_block: usize,
+    ) -> PathBuf {
+        let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        for block_num in 0..num_blocks {
+            let changeset = generate_test_changeset(block_num, changes_per_block);
+            writer.append_account_changeset(changeset, block_num).unwrap();
+        }
+
+        writer.commit().unwrap();
+
+        // Return path to sidecar
+        get_sidecar_path(provider, 0)
+    }
+
+    /// Gets the .csoff sidecar path for a given block.
+    fn get_sidecar_path(provider: &StaticFileProvider<EthPrimitives>, block: u64) -> PathBuf {
+        let range = provider.find_fixed_range(StaticFileSegment::AccountChangeSets, block);
+        let filename = StaticFileSegment::AccountChangeSets.filename(&range);
+        provider.directory().join(filename).with_extension("csoff")
+    }
+
+    /// Reads the block count from a sidecar file (file size / 16).
+    fn get_sidecar_block_count(path: &PathBuf) -> u64 {
+        if !path.exists() {
+            return 0;
+        }
+        let metadata = std::fs::metadata(path).unwrap();
+        metadata.len() / 16
+    }
+
+    /// Appends a partial record to sidecar (simulates crash mid-write).
+    fn corrupt_sidecar_partial_write(path: &PathBuf, partial_bytes: usize) {
+        let mut file = OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(&vec![0u8; partial_bytes]).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    /// Appends fake blocks to sidecar that point past actual `NippyJar` rows.
+    fn corrupt_sidecar_add_fake_blocks(path: &PathBuf, num_fake_blocks: u64, start_offset: u64) {
+        let mut file = OpenOptions::new().append(true).open(path).unwrap();
+        for i in 0..num_fake_blocks {
+            let offset = ChangesetOffset::new(start_offset + i * 5, 5);
+            let mut buf = [0u8; 16];
+            buf[..8].copy_from_slice(&offset.offset().to_le_bytes());
+            buf[8..].copy_from_slice(&offset.num_changes().to_le_bytes());
+            file.write_all(&buf).unwrap();
+        }
+        file.sync_all().unwrap();
+    }
+
+    /// Truncates the sidecar file to a specific number of blocks.
+    fn truncate_sidecar(path: &PathBuf, num_blocks: u64) {
+        let file = OpenOptions::new().write(true).open(path).unwrap();
+        file.set_len(num_blocks * 16).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    /// Reads the `changeset_offsets_len` from the segment header.
+    fn get_header_block_count(provider: &StaticFileProvider<EthPrimitives>, block: u64) -> u64 {
+        let jar_provider = provider
+            .get_segment_provider_for_block(StaticFileSegment::AccountChangeSets, block, None)
+            .unwrap();
+        jar_provider.user_header().changeset_offsets_len()
+    }
+
+    /// Gets the actual row count from `NippyJar`.
+    fn get_nippy_row_count(provider: &StaticFileProvider<EthPrimitives>, block: u64) -> u64 {
+        let jar_provider = provider
+            .get_segment_provider_for_block(StaticFileSegment::AccountChangeSets, block, None)
+            .unwrap();
+        jar_provider.rows() as u64
+    }
+
+    // ==================== APPEND CRASH SCENARIOS ====================
+
+    #[test]
+    fn test_append_crash_partial_sidecar_record() {
+        // SCENARIO: Crash mid-write of a 16-byte sidecar record.
+        // State after crash: Sidecar has N complete records + partial bytes.
+        // Expected: Healing truncates partial bytes, keeps N complete records.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 5 blocks with 3 changes each
+        let sidecar_path = write_test_blocks(&provider, 5, 3);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5);
+
+        // Corrupt: append partial record (8 of 16 bytes)
+        corrupt_sidecar_partial_write(&sidecar_path, 8);
+        assert_eq!(
+            std::fs::metadata(&sidecar_path).unwrap().len(),
+            5 * 16 + 8,
+            "Should have 5 records + 8 partial bytes"
+        );
+
+        // Reopen provider - triggers healing
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Verify healing truncated partial record
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5, "Should have 5 complete records");
+        assert_eq!(
+            std::fs::metadata(&sidecar_path).unwrap().len(),
+            5 * 16,
+            "File should be exactly 80 bytes"
+        );
+    }
+
+    #[test]
+    fn test_append_crash_sidecar_synced_header_not_committed() {
+        // SCENARIO: Sidecar was synced with new blocks, but header commit crashed.
+        // State after crash: Sidecar has more blocks than header claims.
+        // Expected: Healing clamps to header value (never enlarges header).
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 5 blocks
+        let sidecar_path = write_test_blocks(&provider, 5, 3);
+        let total_rows = 5 * 3; // 15 rows
+
+        // Corrupt: add 3 fake blocks to sidecar (simulates sidecar sync before header commit)
+        // These blocks point to valid rows (within the 15 rows we have)
+        // But header doesn't know about them
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 3, total_rows as u64);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 8, "Sidecar should have 8 blocks");
+
+        // Reopen - healing should clamp to header's 5 blocks
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        // Header is authoritative - sidecar should be truncated to 5
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5, "Should clamp to header value");
+        assert_eq!(get_header_block_count(&provider, 0), 5);
+    }
+
+    #[test]
+    fn test_append_crash_sidecar_ahead_of_nippy_offsets() {
+        // APPEND CP2: After data sync, before offsets sync.
+        // SCENARIO: Sidecar was synced first (has new blocks), data file has new rows,
+        // but NippyJar offsets file is stale. Config is stale.
+        //
+        // We can't easily simulate NippyJar internal offset mismatch, but we CAN test
+        // that sidecar entries are validated against actual_nippy_rows (from NippyJar.rows()).
+        // If sidecar claims blocks that would exceed NippyJar's row count, healing truncates.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 5 blocks with 3 changes each (15 rows total)
+        let sidecar_path = write_test_blocks(&provider, 5, 3);
+        assert_eq!(get_nippy_row_count(&provider, 0), 15);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5);
+
+        // Corrupt sidecar: add 3 fake blocks that claim to point to rows beyond NippyJar's 15
+        // Block 6: offset=15, count=3 (rows 15-17, but only 15 rows exist!)
+        // Block 7: offset=18, count=3 (rows 18-20, invalid)
+        // Block 8: offset=21, count=3 (rows 21-23, invalid)
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 3, 15);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 8);
+
+        // Reopen - healing should detect sidecar offsets point past actual NippyJar rows
+        // and truncate back. Since header is 5, healing clamps to min(8, 5) = 5.
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        // Sidecar should be clamped to header's 5 blocks
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5);
+        assert_eq!(get_header_block_count(&provider, 0), 5);
+        // NippyJar rows unchanged
+        assert_eq!(get_nippy_row_count(&provider, 0), 15);
+    }
+
+    #[test]
+    fn test_append_clean_no_crash() {
+        // BASELINE: Normal append with no crash.
+        // All three sources should be in sync.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 10 blocks with 5 changes each
+        let sidecar_path = write_test_blocks(&provider, 10, 5);
+
+        // Verify all in sync
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+        assert_eq!(get_header_block_count(&provider, 0), 10);
+        assert_eq!(get_nippy_row_count(&provider, 0), 50); // 10 blocks * 5 changes
+
+        // Reopen multiple times - should remain stable
+        drop(provider);
+        for _ in 0..3 {
+            let provider = setup_test_provider(&static_dir, 100);
+            let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+        }
+    }
+
+    // ==================== PRUNE CRASH SCENARIOS ====================
+
+    #[test]
+    fn test_prune_crash_sidecar_truncated_header_stale() {
+        // SCENARIO: Prune truncated sidecar but crashed before header commit.
+        // State after crash: Sidecar has fewer blocks than header claims.
+        // Expected: Healing updates header to match sidecar.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 10 blocks
+        let sidecar_path = write_test_blocks(&provider, 10, 5);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+
+        // Simulate prune crash: truncate sidecar to 7 blocks but don't update header
+        // (In real crash, header would still claim 10 blocks)
+        truncate_sidecar(&sidecar_path, 7);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 7);
+
+        // Reopen - healing should detect sidecar < header and fix header
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        {
+            let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            // Writer commits healed header on open
+        }
+        // Drop writer and reopen provider to see committed changes
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // After healing, header should match sidecar
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 7);
+        assert_eq!(get_header_block_count(&provider, 0), 7);
+    }
+
+    #[test]
+    fn test_prune_crash_sidecar_offsets_past_nippy_rows() {
+        // SCENARIO: NippyJar was pruned but sidecar wasn't truncated.
+        // State after crash: Sidecar has offsets pointing past actual NippyJar rows.
+        // Expected: Healing validates offsets and truncates invalid blocks.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 10 blocks with 5 changes each (50 rows total)
+        let sidecar_path = write_test_blocks(&provider, 10, 5);
+
+        // Verify initial state
+        assert_eq!(get_nippy_row_count(&provider, 0), 50);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+
+        // Now add fake blocks to sidecar that point past row 50
+        // These simulate a crash where sidecar wasn't cleaned up after NippyJar prune
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 5, 50); // Blocks pointing to rows 50-74
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 15);
+
+        // Reopen - healing should detect invalid offsets and truncate
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        // Should be back to 10 valid blocks (offsets pointing within 50 rows)
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+        assert_eq!(get_header_block_count(&provider, 0), 10);
+    }
+
+    #[test]
+    fn test_prune_crash_nippy_offsets_truncated_data_stale() {
+        // PRUNE CP1-3: Tests healing when sidecar has offsets past NippyJar.rows().
+        // NippyJar heals internally, then changeset healing validates against rows().
+        // Verifies healing uses actual_nippy_rows as source of truth.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 10 blocks with varying changes
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            for block_num in 0..10 {
+                let changes = (block_num % 5 + 1) as usize; // 1-5 changes per block
+                writer
+                    .append_account_changeset(
+                        generate_test_changeset(block_num, changes),
+                        block_num,
+                    )
+                    .unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        let sidecar_path = get_sidecar_path(&provider, 0);
+        let actual_rows = get_nippy_row_count(&provider, 0);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+
+        // Simulate a scenario where sidecar has blocks pointing past actual rows.
+        // Add 2 fake blocks that would exceed the row count.
+        // Block 11: offset=actual_rows, count=5 (pointing past EOF)
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 2, actual_rows);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 12);
+
+        // Reopen - healing validates all offsets against NippyJar.rows()
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        // After healing: sidecar clamped to header (10), rows unchanged
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10, "Sidecar clamped to header");
+        assert_eq!(get_header_block_count(&provider, 0), 10);
+        assert_eq!(get_nippy_row_count(&provider, 0), actual_rows, "NippyJar rows unchanged");
+    }
+
+    #[test]
+    fn test_prune_crash_sidecar_truncate_not_synced() {
+        // PRUNE CP6: Sidecar truncated but not synced (power loss could resurrect old length).
+        // SCENARIO: We pruned from 10 to 7 blocks. Header was updated to 7.
+        // Sidecar was truncated to 7 but fsync didn't complete before power loss.
+        // After restart, filesystem resurrects sidecar back to 10 (old length).
+        //
+        // State after crash: Header says 7, sidecar shows 10.
+        // Expected: Healing clamps sidecar to header's 7 (header is authoritative).
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 10 blocks with 5 changes each
+        let sidecar_path = write_test_blocks(&provider, 10, 5);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+        assert_eq!(get_header_block_count(&provider, 0), 10);
+
+        // Prune to 7 blocks (keep blocks 0-6)
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            writer.prune_account_changesets(6).unwrap();
+            writer.commit().unwrap();
+        }
+
+        // Verify prune worked
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        assert_eq!(get_header_block_count(&provider, 0), 7);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 7);
+
+        // Now write 3 more blocks (back to 10 total)
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            for block_num in 7..10 {
+                let changeset = generate_test_changeset(block_num, 5);
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+        assert_eq!(get_header_block_count(&provider, 0), 10);
+
+        // Prune back to 7 again
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            writer.prune_account_changesets(6).unwrap();
+            writer.commit().unwrap();
+        }
+        drop(provider);
+
+        // SIMULATE POWER LOSS: Restore sidecar to 10 blocks (as if truncate wasn't synced)
+        // Extend sidecar back to 10 blocks to simulate "resurrected" state
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 3, 35);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10, "Simulated resurrected sidecar");
+
+        // Reopen - healing should detect sidecar (10) > header (7) and clamp
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        // Header is authoritative - sidecar must be clamped to 7
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 7, "Sidecar clamped to header");
+        assert_eq!(get_header_block_count(&provider, 0), 7, "Header unchanged");
+    }
+
+    #[test]
+    fn test_prune_with_unflushed_current_offset() {
+        // REGRESSION (Issue #7): truncate_changesets() didn't call flush_current_changeset_offset()
+        // before reading the sidecar. This caused incorrect truncation when there was an unflushed
+        // current_changeset_offset from recent appends.
+        //
+        // Test scenario: Prune immediately after appending without committing first.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        let sidecar_path = get_sidecar_path(&provider, 0);
+
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            // Step 1: Write 5 blocks (0-4), commit
+            for block_num in 0..5u64 {
+                let changeset = generate_test_changeset(block_num, 3);
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+            writer.commit().unwrap();
+
+            // Step 2: Append 5 more blocks (5-9) WITHOUT committing
+            for block_num in 5..10u64 {
+                let changeset = generate_test_changeset(block_num, 3);
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+            // Note: NOT committing here - block 9's offset is only in current_changeset_offset
+
+            // Step 3: Prune to block 7 (should keep blocks 0-7, including uncommitted 5-7)
+            // This tests that the unflushed current_changeset_offset (for block 9) is properly
+            // flushed before reading the sidecar during truncation.
+            writer.prune_account_changesets(7).unwrap();
+
+            // Step 4: Commit
+            writer.commit().unwrap();
+        }
+
+        // Step 5: Verify sidecar has 8 blocks, header has 8 blocks, rows are correct
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 8, "Sidecar should have 8 blocks (0-7)");
+        assert_eq!(get_header_block_count(&provider, 0), 8, "Header should have 8 blocks");
+        assert_eq!(
+            get_nippy_row_count(&provider, 0),
+            24,
+            "Should have 8 blocks * 3 changes = 24 rows"
+        );
+
+        // Verify stability after reopen
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 8, "Sidecar stable after reopen");
+        assert_eq!(get_header_block_count(&provider, 0), 8, "Header stable after reopen");
+        assert_eq!(get_nippy_row_count(&provider, 0), 24, "Rows stable after reopen");
+    }
+
+    #[test]
+    fn test_prune_clean_no_crash() {
+        // BASELINE: Normal prune with no crash.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 10 blocks
+        write_test_blocks(&provider, 10, 5);
+
+        // Prune to keep blocks 0-6 (7 blocks total, removing blocks 7-9)
+        // prune_account_changesets takes last_block to keep, not count to remove
+        let sidecar_path = get_sidecar_path(&provider, 0);
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            writer.prune_account_changesets(6).unwrap(); // Keep blocks 0-6
+            writer.commit().unwrap();
+        }
+
+        // Reopen provider to see committed changes
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Verify all in sync at 7 blocks (0-6)
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 7);
+        assert_eq!(get_header_block_count(&provider, 0), 7);
+
+        // Rows should also be reduced (7 blocks * 5 changes = 35 rows)
+        assert_eq!(get_nippy_row_count(&provider, 0), 35);
+    }
+
+    // ==================== VALIDATION EDGE CASES ====================
+
+    #[test]
+    fn test_empty_segment_fresh_start() {
+        // SCENARIO: Brand new segment with no data.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Just open a writer without writing anything
+        {
+            let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+        }
+
+        // Sidecar might not exist or be empty
+        let sidecar_path = get_sidecar_path(&provider, 0);
+        let block_count = get_sidecar_block_count(&sidecar_path);
+        assert_eq!(block_count, 0, "Fresh segment should have 0 blocks");
+    }
+
+    #[test]
+    fn test_all_empty_blocks_preserved_on_reopen() {
+        // REGRESSION: When all blocks have empty changesets (0 rows in NippyJar),
+        // healing incorrectly pruned all blocks because the validation was skipped
+        // when actual_nippy_rows == 0. But (offset=0, num_changes=0) is valid when rows=0.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 5 blocks with 0 changes each => 0 total rows in NippyJar
+        let sidecar_path = write_test_blocks(&provider, 5, 0);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5);
+        assert_eq!(get_header_block_count(&provider, 0), 5);
+        assert_eq!(get_nippy_row_count(&provider, 0), 0);
+
+        // Reopen - healing must preserve all 5 blocks
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        // Must still have 5 blocks after healing
+        assert_eq!(
+            get_sidecar_block_count(&sidecar_path),
+            5,
+            "Healing should not prune empty blocks"
+        );
+        assert_eq!(get_header_block_count(&provider, 0), 5);
+        assert_eq!(get_nippy_row_count(&provider, 0), 0);
+    }
+
+    #[test]
+    fn test_empty_blocks_zero_changes() {
+        // SCENARIO: Some blocks have 0 changes (empty changesets).
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            // Block 0: 3 changes
+            writer.append_account_changeset(generate_test_changeset(0, 3), 0).unwrap();
+
+            // Block 1: 0 changes (empty)
+            writer.append_account_changeset(vec![], 1).unwrap();
+
+            // Block 2: 2 changes
+            writer.append_account_changeset(generate_test_changeset(2, 2), 2).unwrap();
+
+            // Block 3: 0 changes (empty)
+            writer.append_account_changeset(vec![], 3).unwrap();
+
+            // Block 4: 5 changes
+            writer.append_account_changeset(generate_test_changeset(4, 5), 4).unwrap();
+
+            writer.commit().unwrap();
+        }
+
+        let sidecar_path = get_sidecar_path(&provider, 0);
+
+        // Verify 5 blocks recorded
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5);
+        assert_eq!(get_header_block_count(&provider, 0), 5);
+
+        // Verify offsets are correct
+        let reader = ChangesetOffsetReader::new(&sidecar_path, 5).unwrap();
+
+        let o0 = reader.get(0).unwrap().unwrap();
+        assert_eq!(o0.offset(), 0);
+        assert_eq!(o0.num_changes(), 3);
+
+        let o1 = reader.get(1).unwrap().unwrap();
+        assert_eq!(o1.offset(), 3);
+        assert_eq!(o1.num_changes(), 0); // Empty block
+
+        let o2 = reader.get(2).unwrap().unwrap();
+        assert_eq!(o2.offset(), 3); // Same offset as block 1 (0 changes didn't advance)
+        assert_eq!(o2.num_changes(), 2);
+
+        let o3 = reader.get(3).unwrap().unwrap();
+        assert_eq!(o3.offset(), 5);
+        assert_eq!(o3.num_changes(), 0); // Empty block
+
+        let o4 = reader.get(4).unwrap().unwrap();
+        assert_eq!(o4.offset(), 5);
+        assert_eq!(o4.num_changes(), 5);
+
+        // Total rows: 3 + 0 + 2 + 0 + 5 = 10
+        assert_eq!(get_nippy_row_count(&provider, 0), 10);
+
+        // Reopen and verify healing doesn't break empty blocks
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5);
+    }
+
+    #[test]
+    fn test_healing_never_enlarges_header() {
+        // INVARIANT: Header is the commit marker. Healing should NEVER enlarge it.
+        // Even if sidecar has more valid blocks, we trust header.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 5 blocks
+        let sidecar_path = write_test_blocks(&provider, 5, 3);
+
+        // Add more blocks to sidecar that would be "valid" (point within existing rows)
+        // These simulate uncommitted blocks from a crashed append
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 3, 0);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 8);
+
+        // Reopen - healing should clamp to header's 5, not enlarge to 8
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5, "Must clamp to header");
+        assert_eq!(get_header_block_count(&provider, 0), 5, "Header unchanged");
+    }
+
+    #[test]
+    fn test_multiple_reopen_cycles_stable() {
+        // STABILITY: Opening and closing multiple times shouldn't change anything.
+
+        let (static_dir, _) = create_test_static_files_dir();
+
+        // Initial write
+        {
+            let provider = setup_test_provider(&static_dir, 100);
+            write_test_blocks(&provider, 10, 5);
+        }
+
+        // Reopen 5 times
+        for i in 0..5 {
+            let provider = setup_test_provider(&static_dir, 100);
+            let sidecar_path = get_sidecar_path(&provider, 0);
+
+            let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            assert_eq!(get_sidecar_block_count(&sidecar_path), 10, "Cycle {}: block count", i);
+            assert_eq!(get_header_block_count(&provider, 0), 10, "Cycle {}: header", i);
+            assert_eq!(get_nippy_row_count(&provider, 0), 50, "Cycle {}: rows", i);
+        }
+    }
+
+    #[test]
+    fn test_combined_partial_and_extra_blocks() {
+        // COMBINED: Partial record AND extra complete blocks.
+        // Healing should handle both: truncate partial, then validate remaining.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 5 blocks
+        let sidecar_path = write_test_blocks(&provider, 5, 3);
+
+        // Corrupt: add 2 fake blocks pointing past EOF, then partial record
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 2, 100); // Invalid offsets
+        corrupt_sidecar_partial_write(&sidecar_path, 10); // Partial record
+
+        let file_size = std::fs::metadata(&sidecar_path).unwrap().len();
+        assert_eq!(file_size, 5 * 16 + 2 * 16 + 10, "5 valid + 2 fake + 10 partial");
+
+        // Reopen - healing should:
+        // 1. Truncate partial (10 bytes)
+        // 2. Clamp to header's 5 blocks (remove 2 fake blocks)
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 5);
+        assert_eq!(get_header_block_count(&provider, 0), 5);
+    }
+
+    // ==================== REGRESSION TESTS ====================
+
+    #[test]
+    fn test_prune_double_decrement_regression() {
+        // REGRESSION: Previously, healing called set_changeset_offsets_len() then prune(),
+        // causing double decrement. Now we only call prune() which handles both.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write 10 blocks
+        let sidecar_path = write_test_blocks(&provider, 10, 5);
+
+        // Simulate prune crash: sidecar at 7, header should be updated from 10 to 7
+        truncate_sidecar(&sidecar_path, 7);
+
+        // Reopen - healing fixes header
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        {
+            let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            // Writer commits healed header on open
+        }
+        // Reopen provider to see committed changes
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Should be exactly 7, not 7 - (10-7) = 4 (double decrement bug)
+        assert_eq!(get_header_block_count(&provider, 0), 7);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 7);
+    }
+
+    #[test]
+    fn test_prune_with_uncommitted_sidecar_records() {
+        // REGRESSION: truncate_changesets() previously read file size from disk instead of
+        // using the committed length from header. After a crash, sidecar may have uncommitted
+        // records. The fix uses ChangesetOffsetReader::new() with explicit length.
+        //
+        // SCENARIO: Simulate crash where sidecar has more records than header claims,
+        // then prune. The prune should use header's block count, not sidecar's.
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Step 1: Write 10 blocks with 5 changes each, commit
+        let sidecar_path = write_test_blocks(&provider, 10, 5);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10);
+        assert_eq!(get_header_block_count(&provider, 0), 10);
+        assert_eq!(get_nippy_row_count(&provider, 0), 50);
+
+        // Step 2: Corrupt sidecar by adding 3 fake blocks that point to valid but
+        // uncommitted offsets. This simulates a crash where sidecar was synced but
+        // header wasn't committed.
+        corrupt_sidecar_add_fake_blocks(&sidecar_path, 3, 50);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 13, "Sidecar has 3 uncommitted blocks");
+
+        // Step 3: Reopen provider - healing runs and clamps sidecar to header's 10
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+        {
+            let _writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+        }
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 10, "Healing clamped sidecar to 10");
+        assert_eq!(get_header_block_count(&provider, 0), 10);
+
+        // Step 4: Prune to block 6 (keep blocks 0-6, remove 7-9)
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            writer.prune_account_changesets(6).unwrap();
+            writer.commit().unwrap();
+        }
+
+        // Step 5: Verify sidecar has 7 blocks, header has 7 blocks, rows are correct
+        drop(provider);
+        let provider = setup_test_provider(&static_dir, 100);
+
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 7, "Sidecar should have 7 blocks");
+        assert_eq!(get_header_block_count(&provider, 0), 7, "Header should have 7 blocks");
+        assert_eq!(
+            get_nippy_row_count(&provider, 0),
+            35,
+            "Should have 7 blocks * 5 changes = 35 rows"
+        );
+    }
+
+    /// Opening a writer for a block past the first range boundary should succeed
+    /// even when no previous static file exists for the segment.
+    #[test]
+    fn test_get_writer_no_previous_file() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Request a writer starting at block 250, which falls into range 200..=299.
+        // No file exists for range 100..=199 (the "previous" range).
+        // This must not panic or error.
+        let mut writer = provider
+            .get_writer(250, StaticFileSegment::AccountChangeSets)
+            .expect("get_writer should succeed without previous file");
+
+        // The index should have no entry for AccountChangeSets yet (empty jar).
+        assert!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).is_none(),
+            "Empty jar should not create an index entry"
+        );
+
+        // Writing data requires padding from the range start (200) to block 250,
+        // same as the migration code does.
+        let writer_start = writer.next_block_number();
+        for block in writer_start..250 {
+            writer.append_account_changeset(vec![], block).unwrap();
+        }
+        let changeset = generate_test_changeset(250, 2);
+        writer.append_account_changeset(changeset, 250).unwrap();
+        writer.commit().unwrap();
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).unwrap(),
+            250,
+            "After writing block 250, highest block should be 250"
+        );
+    }
+
+    /// When a previous file DOES exist, opening a new empty writer for the next
+    /// range should still update the index to point at the previous file.
+    #[test]
+    fn test_get_writer_with_previous_file() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write blocks 0..=99 to fill the first file completely.
+        {
+            let mut writer = provider.get_writer(0, StaticFileSegment::AccountChangeSets).unwrap();
+            for block in 0..100 {
+                writer.append_account_changeset(generate_test_changeset(block, 1), block).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).unwrap(),
+            99
+        );
+
+        // Now get a writer for block 100 (next range 100..=199).
+        // The previous file (0..=99) exists, so this should succeed.
+        let writer = provider
+            .get_writer(100, StaticFileSegment::AccountChangeSets)
+            .expect("get_writer should succeed with previous file");
+
+        // The index should still reflect the previous file's max block.
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).unwrap(),
+            99,
+            "Index should still point at previous file's max block"
+        );
+
+        drop(writer);
+    }
+}

--- a/patches/reth-provider/src/test_utils/blocks.rs
+++ b/patches/reth-provider/src/test_utils/blocks.rs
@@ -1,0 +1,513 @@
+//! Dummy blocks and data for tests
+use crate::{DBProvider, DatabaseProviderRW, ExecutionOutcome};
+use alloy_consensus::{TxLegacy, EMPTY_OMMER_ROOT_HASH};
+use alloy_primitives::{
+    b256, hex_literal::hex, map::HashMap, Address, BlockNumber, Bytes, Log, TxKind, B256, U256,
+};
+
+use alloy_consensus::Header;
+use alloy_eips::eip4895::{Withdrawal, Withdrawals};
+use alloy_primitives::Signature;
+use reth_db_api::{database::Database, models::StoredBlockBodyIndices, tables};
+use reth_ethereum_primitives::{BlockBody, Receipt, Transaction, TransactionSigned, TxType};
+use reth_node_types::NodeTypes;
+use reth_primitives_traits::{Account, RecoveredBlock, SealedBlock, SealedHeader};
+use reth_trie::root::{state_root_unhashed, storage_root_unhashed};
+use revm_database::BundleState;
+use revm_state::AccountInfo;
+use std::{str::FromStr, sync::LazyLock};
+
+/// Assert genesis block
+pub fn assert_genesis_block<DB: Database, N: NodeTypes>(
+    provider: &DatabaseProviderRW<DB, N>,
+    g: SealedBlock<reth_ethereum_primitives::Block>,
+) {
+    let n = g.number;
+    let h = B256::ZERO;
+    let tx = provider;
+
+    // check if tables contain only the genesis block data
+    assert_eq!(tx.table::<tables::Headers>().unwrap(), vec![(g.number, g.header().clone())]);
+
+    assert_eq!(tx.table::<tables::HeaderNumbers>().unwrap(), vec![(h, n)]);
+    assert_eq!(tx.table::<tables::CanonicalHeaders>().unwrap(), vec![(n, h)]);
+    assert_eq!(
+        tx.table::<tables::BlockBodyIndices>().unwrap(),
+        vec![(0, StoredBlockBodyIndices::default())]
+    );
+    assert_eq!(tx.table::<tables::BlockOmmers>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::BlockWithdrawals>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::Transactions>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::TransactionBlocks>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::TransactionHashNumbers>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::Receipts>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::PlainAccountState>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::PlainStorageState>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::AccountsHistory>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::StoragesHistory>().unwrap(), vec![]);
+    // Reorged bytecodes are not reverted per https://github.com/paradigmxyz/reth/issues/1588
+    // assert_eq!(tx.table::<tables::Bytecodes>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::AccountChangeSets>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::StorageChangeSets>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::HashedAccounts>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::HashedStorages>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::AccountsTrie>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::StoragesTrie>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::TransactionSenders>().unwrap(), vec![]);
+    // StageCheckpoints is not updated in tests
+}
+
+pub(crate) static TEST_BLOCK: LazyLock<SealedBlock<reth_ethereum_primitives::Block>> =
+    LazyLock::new(|| {
+        SealedBlock::from_sealed_parts(
+            SealedHeader::new(
+                Header {
+                    parent_hash: hex!(
+                        "c86e8cc0310ae7c531c758678ddbfd16fc51c8cef8cec650b032de9869e8b94f"
+                    )
+                    .into(),
+                    ommers_hash: EMPTY_OMMER_ROOT_HASH,
+                    beneficiary: hex!("2adc25665018aa1fe0e6bc666dac8fc2697ff9ba").into(),
+                    state_root: hex!(
+                        "50554882fbbda2c2fd93fdc466db9946ea262a67f7a76cc169e714f105ab583d"
+                    )
+                    .into(),
+                    transactions_root: hex!(
+                        "0967f09ef1dfed20c0eacfaa94d5cd4002eda3242ac47eae68972d07b106d192"
+                    )
+                    .into(),
+                    receipts_root: hex!(
+                        "e3c8b47fbfc94667ef4cceb17e5cc21e3b1eebd442cebb27f07562b33836290d"
+                    )
+                    .into(),
+                    difficulty: U256::from(131_072),
+                    number: 0,
+                    gas_limit: 1_000_000,
+                    gas_used: 14_352,
+                    timestamp: 1_000,
+                    ..Default::default()
+                },
+                hex!("cf7b274520720b50e6a4c3e5c4d553101f44945396827705518ce17cb7219a42").into(),
+            ),
+            BlockBody {
+                transactions: vec![TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                gas_price: 10,
+                gas_limit: 400_000,
+                to: TxKind::Call(hex!("095e7baea6a6c7c4c2dfeb977efac326af552d87").into()),
+                ..Default::default()
+            }),
+            Signature::new(
+                U256::from_str(
+                    "51983300959770368863831494747186777928121405155922056726144551509338672451120",
+                )
+                .unwrap(),
+                U256::from_str(
+                    "29056683545955299640297374067888344259176096769870751649153779895496107008675",
+                )
+                .unwrap(),
+                false,
+            )
+        )],
+                ..Default::default()
+            },
+        )
+    });
+
+/// Test chain with genesis, blocks, execution results
+/// that have valid changesets.
+#[derive(Debug)]
+pub struct BlockchainTestData {
+    /// Genesis
+    pub genesis: SealedBlock<reth_ethereum_primitives::Block>,
+    /// Blocks with its execution result
+    pub blocks: Vec<(RecoveredBlock<reth_ethereum_primitives::Block>, ExecutionOutcome)>,
+}
+
+impl BlockchainTestData {
+    /// Create test data with two blocks that are connected, specifying their block numbers.
+    pub fn default_from_number(first: BlockNumber) -> Self {
+        let one = block1(first);
+        let mut extended_execution_outcome = one.1.clone();
+        let two = block2(first + 1, one.0.hash(), &extended_execution_outcome);
+        extended_execution_outcome.extend(two.1.clone());
+        let three = block3(first + 2, two.0.hash(), &extended_execution_outcome);
+        extended_execution_outcome.extend(three.1.clone());
+        let four = block4(first + 3, three.0.hash(), &extended_execution_outcome);
+        extended_execution_outcome.extend(four.1.clone());
+        let five = block5(first + 4, four.0.hash(), &extended_execution_outcome);
+        Self { genesis: genesis(), blocks: vec![one, two, three, four, five] }
+    }
+}
+
+impl Default for BlockchainTestData {
+    fn default() -> Self {
+        let one = block1(1);
+        let mut extended_execution_outcome = one.1.clone();
+        let two = block2(2, one.0.hash(), &extended_execution_outcome);
+        extended_execution_outcome.extend(two.1.clone());
+        let three = block3(3, two.0.hash(), &extended_execution_outcome);
+        extended_execution_outcome.extend(three.1.clone());
+        let four = block4(4, three.0.hash(), &extended_execution_outcome);
+        extended_execution_outcome.extend(four.1.clone());
+        let five = block5(5, four.0.hash(), &extended_execution_outcome);
+        Self { genesis: genesis(), blocks: vec![one, two, three, four, five] }
+    }
+}
+
+/// Genesis block
+pub fn genesis() -> SealedBlock<reth_ethereum_primitives::Block> {
+    SealedBlock::from_sealed_parts(
+        SealedHeader::new(
+            Header { number: 0, difficulty: U256::from(1), ..Default::default() },
+            B256::ZERO,
+        ),
+        Default::default(),
+    )
+}
+
+fn bundle_state_root(execution_outcome: &ExecutionOutcome) -> B256 {
+    state_root_unhashed(execution_outcome.bundle_accounts_iter().filter_map(
+        |(address, account)| {
+            account.info.as_ref().map(|info| {
+                (
+                    address,
+                    Account::from(info).into_trie_account(storage_root_unhashed(
+                        account
+                            .storage
+                            .iter()
+                            .filter(|(_, value)| !value.present_value.is_zero())
+                            .map(|(slot, value)| ((*slot).into(), value.present_value)),
+                    )),
+                )
+            })
+        },
+    ))
+}
+
+/// Block one that points to genesis
+fn block1(
+    number: BlockNumber,
+) -> (RecoveredBlock<reth_ethereum_primitives::Block>, ExecutionOutcome) {
+    // block changes
+    let account1: Address = [0x60; 20].into();
+    let account2: Address = [0x61; 20].into();
+    let slot = U256::from(5);
+    let info = AccountInfo { nonce: 1, balance: U256::from(10), ..Default::default() };
+
+    let execution_outcome = ExecutionOutcome::new(
+        BundleState::builder(number..=number)
+            .state_present_account_info(account1, info.clone())
+            .revert_account_info(number, account1, Some(None))
+            .state_present_account_info(account2, info)
+            .revert_account_info(number, account2, Some(None))
+            .state_storage(account1, HashMap::from_iter([(slot, (U256::ZERO, U256::from(10)))]))
+            .build(),
+        vec![vec![Receipt {
+            tx_type: TxType::Eip2930,
+            success: true,
+            cumulative_gas_used: 300,
+            logs: vec![Log::new_unchecked(
+                Address::new([0x60; 20]),
+                vec![B256::with_last_byte(1), B256::with_last_byte(2)],
+                Bytes::default(),
+            )],
+        }]],
+        number,
+        Vec::new(),
+    );
+
+    let state_root = bundle_state_root(&execution_outcome);
+    assert_eq!(
+        state_root,
+        b256!("0x5d035ccb3e75a9057452ff060b773b213ec1fc353426174068edfc3971a0b6bd")
+    );
+
+    let (mut header, mut body) = TEST_BLOCK.clone().split_header_body();
+    body.withdrawals = Some(Withdrawals::new(vec![Withdrawal::default()]));
+    header.number = number;
+    header.state_root = state_root;
+    header.parent_hash = B256::ZERO;
+    let block = SealedBlock::seal_parts(header, body);
+
+    (RecoveredBlock::new_sealed(block, vec![Address::new([0x30; 20])]), execution_outcome)
+}
+
+/// Block two that points to block 1
+fn block2(
+    number: BlockNumber,
+    parent_hash: B256,
+    prev_execution_outcome: &ExecutionOutcome,
+) -> (RecoveredBlock<reth_ethereum_primitives::Block>, ExecutionOutcome) {
+    // block changes
+    let account: Address = [0x60; 20].into();
+    let slot = U256::from(5);
+
+    let execution_outcome = ExecutionOutcome::new(
+        BundleState::builder(number..=number)
+            .state_present_account_info(
+                account,
+                AccountInfo { nonce: 3, balance: U256::from(20), ..Default::default() },
+            )
+            .state_storage(account, HashMap::from_iter([(slot, (U256::ZERO, U256::from(15)))]))
+            .revert_account_info(
+                number,
+                account,
+                Some(Some(AccountInfo { nonce: 1, balance: U256::from(10), ..Default::default() })),
+            )
+            .revert_storage(number, account, Vec::from([(slot, U256::from(10))]))
+            .build(),
+        vec![vec![Receipt {
+            tx_type: TxType::Eip1559,
+            success: false,
+            cumulative_gas_used: 400,
+            logs: vec![Log::new_unchecked(
+                Address::new([0x61; 20]),
+                vec![B256::with_last_byte(3), B256::with_last_byte(4)],
+                Bytes::default(),
+            )],
+        }]],
+        number,
+        Vec::new(),
+    );
+
+    let mut extended = prev_execution_outcome.clone();
+    extended.extend(execution_outcome.clone());
+    let state_root = bundle_state_root(&extended);
+    assert_eq!(
+        state_root,
+        b256!("0x90101a13dd059fa5cca99ed93d1dc23657f63626c5b8f993a2ccbdf7446b64f8")
+    );
+
+    let (mut header, mut body) = TEST_BLOCK.clone().split_header_body();
+
+    body.withdrawals = Some(Withdrawals::new(vec![Withdrawal::default()]));
+    header.number = number;
+    header.state_root = state_root;
+    // parent_hash points to block1 hash
+    header.parent_hash = parent_hash;
+    let block = SealedBlock::seal_parts(header, body);
+
+    (RecoveredBlock::new_sealed(block, vec![Address::new([0x31; 20])]), execution_outcome)
+}
+
+/// Block three that points to block 2
+fn block3(
+    number: BlockNumber,
+    parent_hash: B256,
+    prev_execution_outcome: &ExecutionOutcome,
+) -> (RecoveredBlock<reth_ethereum_primitives::Block>, ExecutionOutcome) {
+    let address_range = 1..=20;
+    let slot_range = 1..=100;
+
+    let mut bundle_state_builder = BundleState::builder(number..=number);
+    for idx in address_range {
+        let address = Address::with_last_byte(idx);
+        bundle_state_builder = bundle_state_builder
+            .state_present_account_info(
+                address,
+                AccountInfo { nonce: 1, balance: U256::from(idx), ..Default::default() },
+            )
+            .state_storage(
+                address,
+                slot_range
+                    .clone()
+                    .map(|slot| (U256::from(slot), (U256::ZERO, U256::from(slot))))
+                    .collect(),
+            )
+            .revert_account_info(number, address, Some(None))
+            .revert_storage(number, address, Vec::new());
+    }
+    let execution_outcome = ExecutionOutcome::new(
+        bundle_state_builder.build(),
+        vec![vec![Receipt {
+            tx_type: TxType::Eip1559,
+            success: true,
+            cumulative_gas_used: 400,
+            logs: vec![Log::new_unchecked(
+                Address::new([0x61; 20]),
+                vec![B256::with_last_byte(3), B256::with_last_byte(4)],
+                Bytes::default(),
+            )],
+        }]],
+        number,
+        Vec::new(),
+    );
+
+    let mut extended = prev_execution_outcome.clone();
+    extended.extend(execution_outcome.clone());
+    let state_root = bundle_state_root(&extended);
+
+    let (mut header, mut body) = TEST_BLOCK.clone().split_header_body();
+    body.withdrawals = Some(Withdrawals::new(vec![Withdrawal::default()]));
+    header.number = number;
+    header.state_root = state_root;
+    // parent_hash points to block1 hash
+    header.parent_hash = parent_hash;
+    let block = SealedBlock::seal_parts(header, body);
+
+    (RecoveredBlock::new_sealed(block, vec![Address::new([0x31; 20])]), execution_outcome)
+}
+
+/// Block four that points to block 3
+fn block4(
+    number: BlockNumber,
+    parent_hash: B256,
+    prev_execution_outcome: &ExecutionOutcome,
+) -> (RecoveredBlock<reth_ethereum_primitives::Block>, ExecutionOutcome) {
+    let address_range = 1..=20;
+    let slot_range = 1..=100;
+
+    let mut bundle_state_builder = BundleState::builder(number..=number);
+    for idx in address_range {
+        let address = Address::with_last_byte(idx);
+        // increase balance for every even account and destroy every odd
+        bundle_state_builder = if idx.is_multiple_of(2) {
+            bundle_state_builder
+                .state_present_account_info(
+                    address,
+                    AccountInfo { nonce: 1, balance: U256::from(idx * 2), ..Default::default() },
+                )
+                .state_storage(
+                    address,
+                    slot_range
+                        .clone()
+                        .map(|slot| (U256::from(slot), (U256::from(slot), U256::from(slot * 2))))
+                        .collect(),
+                )
+        } else {
+            bundle_state_builder.state_address(address).state_storage(
+                address,
+                slot_range
+                    .clone()
+                    .map(|slot| (U256::from(slot), (U256::from(slot), U256::ZERO)))
+                    .collect(),
+            )
+        };
+        // record previous account info
+        bundle_state_builder = bundle_state_builder
+            .revert_account_info(
+                number,
+                address,
+                Some(Some(AccountInfo {
+                    nonce: 1,
+                    balance: U256::from(idx),
+                    ..Default::default()
+                })),
+            )
+            .revert_storage(
+                number,
+                address,
+                slot_range.clone().map(|slot| (U256::from(slot), U256::from(slot))).collect(),
+            );
+    }
+    let execution_outcome = ExecutionOutcome::new(
+        bundle_state_builder.build(),
+        vec![vec![Receipt {
+            tx_type: TxType::Eip1559,
+            success: true,
+            cumulative_gas_used: 400,
+            logs: vec![Log::new_unchecked(
+                Address::new([0x61; 20]),
+                vec![B256::with_last_byte(3), B256::with_last_byte(4)],
+                Bytes::default(),
+            )],
+        }]],
+        number,
+        Vec::new(),
+    );
+
+    let mut extended = prev_execution_outcome.clone();
+    extended.extend(execution_outcome.clone());
+    let state_root = bundle_state_root(&extended);
+
+    let (mut header, mut body) = TEST_BLOCK.clone().split_header_body();
+    body.withdrawals = Some(Withdrawals::new(vec![Withdrawal::default()]));
+    header.number = number;
+    header.state_root = state_root;
+    // parent_hash points to block1 hash
+    header.parent_hash = parent_hash;
+    let block = SealedBlock::seal_parts(header, body);
+
+    (RecoveredBlock::new_sealed(block, vec![Address::new([0x31; 20])]), execution_outcome)
+}
+
+/// Block five that points to block 4
+fn block5(
+    number: BlockNumber,
+    parent_hash: B256,
+    prev_execution_outcome: &ExecutionOutcome,
+) -> (RecoveredBlock<reth_ethereum_primitives::Block>, ExecutionOutcome) {
+    let address_range = 1..=20;
+    let slot_range = 1..=100;
+
+    let mut bundle_state_builder = BundleState::builder(number..=number);
+    for idx in address_range {
+        let address = Address::with_last_byte(idx);
+        // update every even account and recreate every odd only with half of slots
+        bundle_state_builder = bundle_state_builder
+            .state_present_account_info(
+                address,
+                AccountInfo { nonce: 1, balance: U256::from(idx * 2), ..Default::default() },
+            )
+            .state_storage(
+                address,
+                slot_range
+                    .clone()
+                    .take(50)
+                    .map(|slot| (U256::from(slot), (U256::from(slot), U256::from(slot * 4))))
+                    .collect(),
+            );
+        bundle_state_builder = if idx.is_multiple_of(2) {
+            bundle_state_builder
+                .revert_account_info(
+                    number,
+                    address,
+                    Some(Some(AccountInfo {
+                        nonce: 1,
+                        balance: U256::from(idx * 2),
+                        ..Default::default()
+                    })),
+                )
+                .revert_storage(
+                    number,
+                    address,
+                    slot_range
+                        .clone()
+                        .map(|slot| (U256::from(slot), U256::from(slot * 2)))
+                        .collect(),
+                )
+        } else {
+            bundle_state_builder.revert_address(number, address)
+        };
+    }
+    let execution_outcome = ExecutionOutcome::new(
+        bundle_state_builder.build(),
+        vec![vec![Receipt {
+            tx_type: TxType::Eip1559,
+            success: true,
+            cumulative_gas_used: 400,
+            logs: vec![Log::new_unchecked(
+                Address::new([0x61; 20]),
+                vec![B256::with_last_byte(3), B256::with_last_byte(4)],
+                Bytes::default(),
+            )],
+        }]],
+        number,
+        Vec::new(),
+    );
+
+    let mut extended = prev_execution_outcome.clone();
+    extended.extend(execution_outcome.clone());
+    let state_root = bundle_state_root(&extended);
+
+    let (mut header, mut body) = TEST_BLOCK.clone().split_header_body();
+    body.withdrawals = Some(Withdrawals::new(vec![Withdrawal::default()]));
+    header.number = number;
+    header.state_root = state_root;
+    // parent_hash points to block1 hash
+    header.parent_hash = parent_hash;
+    let block = SealedBlock::seal_parts(header, body);
+
+    (RecoveredBlock::new_sealed(block, vec![Address::new([0x31; 20])]), execution_outcome)
+}

--- a/patches/reth-provider/src/test_utils/mock.rs
+++ b/patches/reth-provider/src/test_utils/mock.rs
@@ -1,0 +1,1151 @@
+use crate::{
+    traits::{BlockSource, ReceiptProvider},
+    AccountReader, BalProvider, BalStoreHandle, BlockHashReader, BlockIdReader, BlockNumReader,
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader, HeaderProvider,
+    PruneCheckpointReader, ReceiptProviderIdExt, StateProvider, StateProviderBox,
+    StateProviderFactory, StateReader, StateRootProvider, TransactionVariant, TransactionsProvider,
+};
+use alloy_consensus::{
+    constants::EMPTY_ROOT_HASH,
+    transaction::{TransactionMeta, TxHashRef},
+    BlockHeader,
+};
+use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
+use alloy_primitives::{
+    keccak256,
+    map::{AddressMap, B256Map, HashMap},
+    Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, B256, U256,
+};
+use parking_lot::Mutex;
+use reth_chain_state::{CanonStateNotifications, CanonStateSubscriptions};
+use reth_chainspec::{ChainInfo, EthChainSpec};
+use reth_db::transaction::DbTx;
+use reth_db_api::{
+    mock::{DatabaseMock, TxMock},
+    models::{AccountBeforeTx, StorageSettings, StoredBlockBodyIndices},
+};
+use reth_ethereum_primitives::EthPrimitives;
+use reth_execution_types::ExecutionOutcome;
+use reth_primitives_traits::{
+    Account, Block, BlockBody, Bytecode, GotExpected, NodePrimitives, RecoveredBlock, SealedHeader,
+    SignerRecoverable, StorageEntry,
+};
+use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
+use reth_stages_types::{StageCheckpoint, StageId};
+use reth_storage_api::{
+    BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory,
+    HashedPostStateProvider, NodePrimitivesProvider, StageCheckpointReader, StateProofProvider,
+    StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
+};
+use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
+use reth_trie::{
+    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
+    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+};
+use std::{
+    collections::BTreeMap,
+    fmt::Debug,
+    ops::{RangeBounds, RangeInclusive},
+    sync::Arc,
+};
+use tokio::sync::broadcast;
+
+/// A mock implementation for Provider interfaces.
+#[derive(Debug)]
+pub struct MockEthProvider<T: NodePrimitives = EthPrimitives, ChainSpec = reth_chainspec::ChainSpec>
+{
+    ///local block store
+    pub blocks: Arc<Mutex<B256Map<T::Block>>>,
+    /// Local header store
+    pub headers: Arc<Mutex<B256Map<<T::Block as Block>::Header>>>,
+    /// Local receipt store indexed by block number
+    pub receipts: Arc<Mutex<HashMap<BlockNumber, Vec<T::Receipt>>>>,
+    /// Local account store
+    pub accounts: Arc<Mutex<AddressMap<ExtendedAccount>>>,
+    /// Local chain spec
+    pub chain_spec: Arc<ChainSpec>,
+    /// Local state roots
+    pub state_roots: Arc<Mutex<Vec<B256>>>,
+    /// Local block body indices store
+    pub block_body_indices: Arc<Mutex<HashMap<BlockNumber, StoredBlockBodyIndices>>>,
+    /// Local BAL store handle
+    pub bal_store: BalStoreHandle,
+    tx: TxMock,
+    prune_modes: Arc<PruneModes>,
+}
+
+impl<T: NodePrimitives, ChainSpec> Clone for MockEthProvider<T, ChainSpec>
+where
+    T::Block: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            blocks: self.blocks.clone(),
+            headers: self.headers.clone(),
+            receipts: self.receipts.clone(),
+            accounts: self.accounts.clone(),
+            chain_spec: self.chain_spec.clone(),
+            state_roots: self.state_roots.clone(),
+            block_body_indices: self.block_body_indices.clone(),
+            bal_store: self.bal_store.clone(),
+            tx: self.tx.clone(),
+            prune_modes: self.prune_modes.clone(),
+        }
+    }
+}
+
+impl<T: NodePrimitives> MockEthProvider<T, reth_chainspec::ChainSpec> {
+    /// Create a new, empty instance
+    pub fn new() -> Self {
+        Self {
+            blocks: Default::default(),
+            headers: Default::default(),
+            receipts: Default::default(),
+            accounts: Default::default(),
+            chain_spec: Arc::new(reth_chainspec::ChainSpecBuilder::mainnet().build()),
+            state_roots: Default::default(),
+            block_body_indices: Default::default(),
+            bal_store: Default::default(),
+            tx: Default::default(),
+            prune_modes: Default::default(),
+        }
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec> MockEthProvider<T, ChainSpec> {
+    /// Add block to local block store
+    pub fn add_block(&self, hash: B256, block: T::Block) {
+        self.add_header(hash, block.header().clone());
+        self.blocks.lock().insert(hash, block);
+    }
+
+    /// Add multiple blocks to local block store
+    pub fn extend_blocks(&self, iter: impl IntoIterator<Item = (B256, T::Block)>) {
+        for (hash, block) in iter {
+            self.add_block(hash, block)
+        }
+    }
+
+    /// Add header to local header store
+    pub fn add_header(&self, hash: B256, header: <T::Block as Block>::Header) {
+        self.headers.lock().insert(hash, header);
+    }
+
+    /// Add multiple headers to local header store
+    pub fn extend_headers(
+        &self,
+        iter: impl IntoIterator<Item = (B256, <T::Block as Block>::Header)>,
+    ) {
+        for (hash, header) in iter {
+            self.add_header(hash, header)
+        }
+    }
+
+    /// Add account to local account store
+    pub fn add_account(&self, address: Address, account: ExtendedAccount) {
+        self.accounts.lock().insert(address, account);
+    }
+
+    /// Add account to local account store
+    pub fn extend_accounts(&self, iter: impl IntoIterator<Item = (Address, ExtendedAccount)>) {
+        for (address, account) in iter {
+            self.add_account(address, account)
+        }
+    }
+
+    /// Add receipts to local receipt store
+    pub fn add_receipts(&self, block_number: BlockNumber, receipts: Vec<T::Receipt>) {
+        self.receipts.lock().insert(block_number, receipts);
+    }
+
+    /// Add multiple receipts to local receipt store
+    pub fn extend_receipts(&self, iter: impl IntoIterator<Item = (BlockNumber, Vec<T::Receipt>)>) {
+        for (block_number, receipts) in iter {
+            self.add_receipts(block_number, receipts);
+        }
+    }
+
+    /// Add block body indices to local store
+    pub fn add_block_body_indices(
+        &self,
+        block_number: BlockNumber,
+        indices: StoredBlockBodyIndices,
+    ) {
+        self.block_body_indices.lock().insert(block_number, indices);
+    }
+
+    /// Add state root to local state root store
+    pub fn add_state_root(&self, state_root: B256) {
+        self.state_roots.lock().push(state_root);
+    }
+
+    /// Set chain spec.
+    pub fn with_chain_spec<C>(self, chain_spec: C) -> MockEthProvider<T, C> {
+        MockEthProvider {
+            blocks: self.blocks,
+            headers: self.headers,
+            receipts: self.receipts,
+            accounts: self.accounts,
+            chain_spec: Arc::new(chain_spec),
+            state_roots: self.state_roots,
+            block_body_indices: self.block_body_indices,
+            bal_store: self.bal_store,
+            tx: self.tx,
+            prune_modes: self.prune_modes,
+        }
+    }
+
+    /// Adds the genesis block from the chain spec to the provider.
+    ///
+    /// This is useful for tests that require a valid latest block (e.g., transaction validation).
+    pub fn with_genesis_block(self) -> Self
+    where
+        ChainSpec: EthChainSpec<Header = <T::Block as Block>::Header>,
+        <T::Block as Block>::Body: Default,
+    {
+        let genesis_hash = self.chain_spec.genesis_hash();
+        let genesis_header = self.chain_spec.genesis_header().clone();
+        let genesis_block = T::Block::new(genesis_header, Default::default());
+        self.add_block(genesis_hash, genesis_block);
+        self
+    }
+}
+
+impl Default for MockEthProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec> BalProvider for MockEthProvider<T, ChainSpec> {
+    fn bal_store(&self) -> &BalStoreHandle {
+        &self.bal_store
+    }
+}
+
+/// An extended account for local store
+#[derive(Debug, Clone)]
+pub struct ExtendedAccount {
+    account: Account,
+    bytecode: Option<Bytecode>,
+    storage: HashMap<StorageKey, StorageValue>,
+}
+
+impl ExtendedAccount {
+    /// Create new instance of extended account
+    pub fn new(nonce: u64, balance: U256) -> Self {
+        Self {
+            account: Account { nonce, balance, bytecode_hash: None },
+            bytecode: None,
+            storage: Default::default(),
+        }
+    }
+
+    /// Set bytecode and bytecode hash on the extended account
+    pub fn with_bytecode(mut self, bytecode: Bytes) -> Self {
+        let hash = keccak256(&bytecode);
+        self.account.bytecode_hash = Some(hash);
+        self.bytecode = Some(Bytecode::new_raw(bytecode));
+        self
+    }
+
+    /// Add storage to the extended account. If the storage key is already present,
+    /// the value is updated.
+    pub fn extend_storage(
+        mut self,
+        storage: impl IntoIterator<Item = (StorageKey, StorageValue)>,
+    ) -> Self {
+        self.storage.extend(storage);
+        self
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProviderFactory
+    for MockEthProvider<T, ChainSpec>
+{
+    type DB = DatabaseMock;
+    type Provider = Self;
+    type ProviderRW = Self;
+
+    fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    type Tx = TxMock;
+
+    fn tx_ref(&self) -> &Self::Tx {
+        &self.tx
+    }
+
+    fn tx_mut(&mut self) -> &mut Self::Tx {
+        &mut self.tx
+    }
+
+    fn into_tx(self) -> Self::Tx {
+        self.tx
+    }
+
+    fn commit(self) -> ProviderResult<()> {
+        Ok(self.tx.commit()?)
+    }
+
+    fn prune_modes_ref(&self) -> &PruneModes {
+        &self.prune_modes
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> HeaderProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    type Header = <T::Block as Block>::Header;
+
+    fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        let lock = self.headers.lock();
+        Ok(lock.get(&block_hash).cloned())
+    }
+
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::Header>> {
+        let lock = self.headers.lock();
+        Ok(lock.values().find(|h| h.number() == num).cloned())
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
+        let lock = self.headers.lock();
+
+        let mut headers: Vec<_> =
+            lock.values().filter(|header| range.contains(&header.number())).cloned().collect();
+        headers.sort_by_key(|header| header.number());
+
+        Ok(headers)
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        Ok(self.header_by_number(number)?.map(SealedHeader::seal_slow))
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        mut predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        Ok(self
+            .headers_range(range)?
+            .into_iter()
+            .map(SealedHeader::seal_slow)
+            .take_while(|h| predicate(h))
+            .collect())
+    }
+}
+
+impl<T, ChainSpec> ChainSpecProvider for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: EthChainSpec + 'static + Debug + Send + Sync,
+{
+    type ChainSpec = ChainSpec;
+
+    fn chain_spec(&self) -> Arc<Self::ChainSpec> {
+        self.chain_spec.clone()
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> TransactionsProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    type Transaction = T::SignedTx;
+
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        let lock = self.blocks.lock();
+        let tx_number = lock
+            .values()
+            .flat_map(|block| block.body().transactions())
+            .position(|tx| *tx.tx_hash() == tx_hash)
+            .map(|pos| pos as TxNumber);
+
+        Ok(tx_number)
+    }
+
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        let lock = self.blocks.lock();
+        let transaction =
+            lock.values().flat_map(|block| block.body().transactions()).nth(id as usize).cloned();
+
+        Ok(transaction)
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        id: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        let lock = self.blocks.lock();
+        let transaction =
+            lock.values().flat_map(|block| block.body().transactions()).nth(id as usize).cloned();
+
+        Ok(transaction)
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        Ok(self.blocks.lock().iter().find_map(|(_, block)| {
+            block.body().transactions_iter().find(|tx| *tx.tx_hash() == hash).cloned()
+        }))
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        let lock = self.blocks.lock();
+        for (block_hash, block) in lock.iter() {
+            for (index, tx) in block.body().transactions_iter().enumerate() {
+                if *tx.tx_hash() == hash {
+                    let meta = TransactionMeta {
+                        tx_hash: hash,
+                        index: index as u64,
+                        block_hash: *block_hash,
+                        block_number: block.header().number(),
+                        base_fee: block.header().base_fee_per_gas(),
+                        excess_blob_gas: block.header().excess_blob_gas(),
+                        timestamp: block.header().timestamp(),
+                    };
+                    return Ok(Some((tx.clone(), meta)))
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn transactions_by_block(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        Ok(self.block(id)?.map(|b| b.body().clone_transactions()))
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        range: impl RangeBounds<alloy_primitives::BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        // init btreemap so we can return in order
+        let mut map = BTreeMap::new();
+        for (_, block) in self.blocks.lock().iter() {
+            if range.contains(&block.header().number()) {
+                map.insert(block.header().number(), block.body().clone_transactions());
+            }
+        }
+
+        Ok(map.into_values().collect())
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        let lock = self.blocks.lock();
+        let transactions = lock
+            .values()
+            .flat_map(|block| block.body().transactions())
+            .enumerate()
+            .filter(|&(tx_number, _)| range.contains(&(tx_number as TxNumber)))
+            .map(|(_, tx)| tx.clone())
+            .collect();
+
+        Ok(transactions)
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        let lock = self.blocks.lock();
+        let transactions = lock
+            .values()
+            .flat_map(|block| block.body().transactions())
+            .enumerate()
+            .filter_map(|(tx_number, tx)| {
+                if range.contains(&(tx_number as TxNumber)) {
+                    tx.recover_signer().ok()
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Ok(transactions)
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        self.transaction_by_id(id).map(|tx_option| tx_option.map(|tx| tx.recover_signer().unwrap()))
+    }
+}
+
+impl<T, ChainSpec> ReceiptProvider for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: Send + Sync + 'static,
+{
+    type Receipt = T::Receipt;
+
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+        Ok(None)
+    }
+
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+        Ok(None)
+    }
+
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+        let receipts_lock = self.receipts.lock();
+
+        match block {
+            BlockHashOrNumber::Hash(hash) => {
+                // Find block number by hash first
+                let headers_lock = self.headers.lock();
+                if let Some(header) = headers_lock.get(&hash) {
+                    Ok(receipts_lock.get(&header.number()).cloned())
+                } else {
+                    Ok(None)
+                }
+            }
+            BlockHashOrNumber::Number(number) => Ok(receipts_lock.get(&number).cloned()),
+        }
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Receipt>> {
+        Ok(vec![])
+    }
+
+    fn receipts_by_block_range(
+        &self,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+        let receipts_lock = self.receipts.lock();
+        let headers_lock = self.headers.lock();
+
+        let mut result = Vec::new();
+        for block_number in block_range {
+            // Only include blocks that exist in headers (i.e., have been added to the provider)
+            if headers_lock.values().any(|header| header.number() == block_number) {
+                if let Some(block_receipts) = receipts_lock.get(&block_number) {
+                    result.push(block_receipts.clone());
+                } else {
+                    // If block exists but no receipts found, add empty vec
+                    result.push(vec![]);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl<T, ChainSpec> ReceiptProviderIdExt for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    Self: ReceiptProvider + BlockIdReader,
+{
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync + 'static> BlockHashReader
+    for MockEthProvider<T, ChainSpec>
+{
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        let lock = self.headers.lock();
+        let hash =
+            lock.iter().find_map(|(hash, header)| (header.number() == number).then_some(*hash));
+        Ok(hash)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        let lock = self.headers.lock();
+        let mut hashes: Vec<_> =
+            lock.iter().filter(|(_, header)| (start..end).contains(&header.number())).collect();
+
+        hashes.sort_by_key(|(_, header)| header.number());
+
+        Ok(hashes.into_iter().map(|(hash, _)| *hash).collect())
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync + 'static> BlockNumReader
+    for MockEthProvider<T, ChainSpec>
+{
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        let best_block_number = self.best_block_number()?;
+        let lock = self.headers.lock();
+
+        Ok(lock
+            .iter()
+            .find(|(_, header)| header.number() == best_block_number)
+            .map(|(hash, header)| ChainInfo { best_hash: *hash, best_number: header.number() })
+            .unwrap_or_default())
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        let lock = self.headers.lock();
+        lock.iter()
+            .max_by_key(|h| h.1.number())
+            .map(|(_, header)| header.number())
+            .ok_or(ProviderError::BestBlockNotFound)
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.best_block_number()
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<alloy_primitives::BlockNumber>> {
+        let lock = self.headers.lock();
+        Ok(lock.get(&hash).map(|header| header.number()))
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> BlockIdReader
+    for MockEthProvider<T, ChainSpec>
+{
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<alloy_eips::BlockNumHash>> {
+        Ok(None)
+    }
+
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<alloy_eips::BlockNumHash>> {
+        Ok(None)
+    }
+
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<alloy_eips::BlockNumHash>> {
+        Ok(None)
+    }
+}
+
+//look
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> BlockReader
+    for MockEthProvider<T, ChainSpec>
+{
+    type Block = T::Block;
+
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        _source: BlockSource,
+    ) -> ProviderResult<Option<Self::Block>> {
+        self.block(hash.into())
+    }
+
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+        let lock = self.blocks.lock();
+        match id {
+            BlockHashOrNumber::Hash(hash) => Ok(lock.get(&hash).cloned()),
+            BlockHashOrNumber::Number(num) => {
+                Ok(lock.values().find(|b| b.header().number() == num).cloned())
+            }
+        }
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn pending_block_and_receipts(
+        &self,
+    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<T::Receipt>)>> {
+        Ok(None)
+    }
+
+    fn recovered_block(
+        &self,
+        _id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn sealed_block_with_senders(
+        &self,
+        _id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
+        let lock = self.blocks.lock();
+
+        let mut blocks: Vec<_> = lock
+            .values()
+            .filter(|block| range.contains(&block.header().number()))
+            .cloned()
+            .collect();
+        blocks.sort_by_key(|block| block.header().number());
+
+        Ok(blocks)
+    }
+
+    fn block_with_senders_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        Ok(vec![])
+    }
+
+    fn recovered_block_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        Ok(vec![])
+    }
+
+    fn block_by_transaction_id(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        Ok(None)
+    }
+}
+
+impl<T, ChainSpec> BlockReaderIdExt for MockEthProvider<T, ChainSpec>
+where
+    ChainSpec: EthChainSpec + Send + Sync + 'static,
+    T: NodePrimitives,
+{
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<T::Block>> {
+        match id {
+            BlockId::Number(num) => self.block_by_number_or_tag(num),
+            BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
+        }
+    }
+
+    fn sealed_header_by_id(
+        &self,
+        id: BlockId,
+    ) -> ProviderResult<Option<SealedHeader<<T::Block as Block>::Header>>> {
+        self.header_by_id(id)?.map_or_else(|| Ok(None), |h| Ok(Some(SealedHeader::seal_slow(h))))
+    }
+
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<<T::Block as Block>::Header>> {
+        match self.block_by_id(id)? {
+            None => Ok(None),
+            Some(block) => Ok(Some(block.into_header())),
+        }
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> AccountReader for MockEthProvider<T, ChainSpec> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(self.accounts.lock().get(address).cloned().map(|a| a.account))
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> StageCheckpointReader
+    for MockEthProvider<T, ChainSpec>
+{
+    fn get_stage_checkpoint(&self, _id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
+        Ok(None)
+    }
+
+    fn get_stage_checkpoint_progress(&self, _id: StageId) -> ProviderResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    fn get_all_checkpoints(&self) -> ProviderResult<Vec<(String, StageCheckpoint)>> {
+        Ok(vec![])
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> PruneCheckpointReader
+    for MockEthProvider<T, ChainSpec>
+{
+    fn get_prune_checkpoint(
+        &self,
+        _segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
+        Ok(None)
+    }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        Ok(vec![])
+    }
+}
+
+impl<T, ChainSpec> StateRootProvider for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: Send + Sync,
+{
+    fn state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
+        Ok(self.state_roots.lock().pop().unwrap_or_default())
+    }
+
+    fn state_root_from_nodes(&self, _input: TrieInput) -> ProviderResult<B256> {
+        Ok(self.state_roots.lock().pop().unwrap_or_default())
+    }
+
+    fn state_root_with_updates(
+        &self,
+        _state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let state_root = self.state_roots.lock().pop().unwrap_or_default();
+        Ok((state_root, Default::default()))
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        _input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let state_root = self.state_roots.lock().pop().unwrap_or_default();
+        Ok((state_root, Default::default()))
+    }
+}
+
+impl<T, ChainSpec> StorageRootProvider for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: Send + Sync,
+{
+    fn storage_root(
+        &self,
+        _address: Address,
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        Ok(EMPTY_ROOT_HASH)
+    }
+
+    fn storage_proof(
+        &self,
+        _address: Address,
+        slot: B256,
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<reth_trie::StorageProof> {
+        Ok(StorageProof::new(slot))
+    }
+
+    fn storage_multiproof(
+        &self,
+        _address: Address,
+        _slots: &[B256],
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        Ok(StorageMultiProof::empty())
+    }
+}
+
+impl<T, ChainSpec> StateProofProvider for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: Send + Sync,
+{
+    fn proof(
+        &self,
+        _input: TrieInput,
+        address: Address,
+        _slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        Ok(AccountProof::new(address))
+    }
+
+    fn multiproof(
+        &self,
+        _input: TrieInput,
+        _targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        Ok(MultiProof::default())
+    }
+
+    fn witness(
+        &self,
+        _input: TrieInput,
+        _target: HashedPostState,
+        _mode: reth_trie::ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
+        Ok(Vec::default())
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> HashedPostStateProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    fn hashed_post_state(&self, _state: &revm_database::BundleState) -> HashedPostState {
+        HashedPostState::default()
+    }
+}
+
+impl<T, ChainSpec> StateProvider for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: EthChainSpec + Send + Sync + 'static,
+{
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let lock = self.accounts.lock();
+        Ok(lock.get(&account).and_then(|account| account.storage.get(&storage_key)).copied())
+    }
+}
+
+impl<T, ChainSpec> BytecodeReader for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: Send + Sync,
+{
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        let lock = self.accounts.lock();
+        Ok(lock.values().find_map(|account| {
+            match (account.account.bytecode_hash.as_ref(), account.bytecode.as_ref()) {
+                (Some(bytecode_hash), Some(bytecode)) if bytecode_hash == code_hash => {
+                    Some(bytecode.clone())
+                }
+                _ => None,
+            }
+        }))
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> StorageSettingsCache
+    for MockEthProvider<T, ChainSpec>
+{
+    fn cached_storage_settings(&self) -> StorageSettings {
+        StorageSettings::default()
+    }
+
+    fn set_storage_settings_cache(&self, _settings: StorageSettings) {}
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> StateProviderFactory
+    for MockEthProvider<T, ChainSpec>
+{
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn state_by_block_number_or_tag(
+        &self,
+        number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
+        match number_or_tag {
+            BlockNumberOrTag::Latest => self.latest(),
+            BlockNumberOrTag::Finalized => {
+                // we can only get the finalized state by hash, not by num
+                let hash =
+                    self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
+
+                // only look at historical state
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Safe => {
+                // we can only get the safe state by hash, not by num
+                let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
+
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Earliest => {
+                self.history_by_block_number(self.earliest_block_number()?)
+            }
+            BlockNumberOrTag::Pending => self.pending(),
+            BlockNumberOrTag::Number(num) => self.history_by_block_number(num),
+        }
+    }
+
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
+        Ok(Some(Box::new(self.clone())))
+    }
+
+    fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>> {
+        Ok(Some(Box::new(self.clone())))
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> BlockBodyIndicesProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        Ok(self.block_body_indices.lock().get(&num).copied())
+    }
+    fn block_body_indices_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        Ok(vec![])
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> ChangeSetReader for MockEthProvider<T, ChainSpec> {
+    fn account_block_changeset(
+        &self,
+        _block_number: BlockNumber,
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
+        Ok(Vec::default())
+    }
+
+    fn get_account_before_block(
+        &self,
+        _block_number: BlockNumber,
+        _address: Address,
+    ) -> ProviderResult<Option<AccountBeforeTx>> {
+        Ok(None)
+    }
+
+    fn account_changesets_range(
+        &self,
+        _range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
+        Ok(Vec::default())
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> StorageChangeSetReader
+    for MockEthProvider<T, ChainSpec>
+{
+    fn storage_changeset(
+        &self,
+        _block_number: BlockNumber,
+    ) -> ProviderResult<Vec<(reth_db_api::models::BlockNumberAddress, StorageEntry)>> {
+        Ok(Vec::default())
+    }
+
+    fn get_storage_before_block(
+        &self,
+        _block_number: BlockNumber,
+        _address: Address,
+        _storage_key: B256,
+    ) -> ProviderResult<Option<StorageEntry>> {
+        Ok(None)
+    }
+
+    fn storage_changesets_range(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<(reth_db_api::models::BlockNumberAddress, StorageEntry)>> {
+        Ok(Vec::default())
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> StateReader for MockEthProvider<T, ChainSpec> {
+    type Receipt = T::Receipt;
+
+    fn get_state(
+        &self,
+        _block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+        Ok(None)
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> CanonStateSubscriptions
+    for MockEthProvider<T, ChainSpec>
+{
+    fn subscribe_to_canonical_state(&self) -> CanonStateNotifications<T> {
+        broadcast::channel(1).1
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> NodePrimitivesProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    type Primitives = T;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_primitives::BlockHash;
+    use reth_ethereum_primitives::Receipt;
+
+    #[test]
+    fn test_mock_provider_receipts() {
+        let provider = MockEthProvider::<EthPrimitives>::new();
+
+        let block_hash = BlockHash::random();
+        let block_number = 1u64;
+        let header = Header { number: block_number, ..Default::default() };
+
+        let receipt1 = Receipt { cumulative_gas_used: 21000, success: true, ..Default::default() };
+        let receipt2 = Receipt { cumulative_gas_used: 42000, success: true, ..Default::default() };
+        let receipts = vec![receipt1, receipt2];
+
+        provider.add_header(block_hash, header);
+        provider.add_receipts(block_number, receipts.clone());
+
+        let result = provider.receipts_by_block(block_hash.into()).unwrap();
+        assert_eq!(result, Some(receipts.clone()));
+
+        let result = provider.receipts_by_block(block_number.into()).unwrap();
+        assert_eq!(result, Some(receipts.clone()));
+
+        let range_result = provider.receipts_by_block_range(1..=1).unwrap();
+        assert_eq!(range_result, vec![receipts]);
+
+        let non_existent = provider.receipts_by_block(BlockHash::random().into()).unwrap();
+        assert_eq!(non_existent, None);
+
+        let empty_range = provider.receipts_by_block_range(10..=20).unwrap();
+        assert_eq!(empty_range, Vec::<Vec<Receipt>>::new());
+    }
+
+    #[test]
+    fn test_mock_provider_receipts_multiple_blocks() {
+        let provider = MockEthProvider::<EthPrimitives>::new();
+
+        let block1_hash = BlockHash::random();
+        let block2_hash = BlockHash::random();
+        let block1_number = 1u64;
+        let block2_number = 2u64;
+
+        let header1 = Header { number: block1_number, ..Default::default() };
+        let header2 = Header { number: block2_number, ..Default::default() };
+
+        let receipts1 =
+            vec![Receipt { cumulative_gas_used: 21000, success: true, ..Default::default() }];
+        let receipts2 =
+            vec![Receipt { cumulative_gas_used: 42000, success: true, ..Default::default() }];
+
+        provider.add_header(block1_hash, header1);
+        provider.add_header(block2_hash, header2);
+        provider.add_receipts(block1_number, receipts1.clone());
+        provider.add_receipts(block2_number, receipts2.clone());
+
+        let range_result = provider.receipts_by_block_range(1..=2).unwrap();
+        assert_eq!(range_result.len(), 2);
+        assert_eq!(range_result[0], receipts1);
+        assert_eq!(range_result[1], receipts2);
+
+        let partial_range = provider.receipts_by_block_range(1..=1).unwrap();
+        assert_eq!(partial_range.len(), 1);
+        assert_eq!(partial_range[0], receipts1);
+    }
+}

--- a/patches/reth-provider/src/test_utils/mod.rs
+++ b/patches/reth-provider/src/test_utils/mod.rs
@@ -1,0 +1,149 @@
+use crate::{
+    providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBBuilder, StaticFileProvider},
+    HashingWriter, ProviderFactory, TrieWriter,
+};
+use alloy_primitives::B256;
+use reth_chainspec::{ChainSpec, MAINNET};
+use reth_db::{mdbx::DatabaseArguments, test_utils::TempDatabase, DatabaseEnv};
+use reth_errors::ProviderResult;
+use reth_ethereum_engine_primitives::EthEngineTypes;
+use reth_node_types::NodeTypesWithDBAdapter;
+use reth_primitives_traits::{Account, StorageEntry};
+use reth_storage_api::StorageSettingsCache;
+use reth_trie::StateRoot;
+use reth_trie_db::DatabaseStateRoot;
+use std::sync::Arc;
+
+type DbStateRoot<'a, TX, A> = StateRoot<
+    reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+    reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+>;
+
+pub mod blocks;
+mod mock;
+mod noop;
+
+pub use mock::{ExtendedAccount, MockEthProvider};
+pub use noop::NoopProvider;
+pub use reth_chain_state::test_utils::TestCanonStateSubscriptions;
+
+/// Mock [`reth_node_types::NodeTypes`] for testing.
+pub type MockNodeTypes = reth_node_types::AnyNodeTypesWithEngine<
+    reth_ethereum_primitives::EthPrimitives,
+    reth_ethereum_engine_primitives::EthEngineTypes,
+    reth_chainspec::ChainSpec,
+    crate::EthStorage,
+    EthEngineTypes,
+>;
+
+/// Mock [`reth_node_types::NodeTypesWithDB`] for testing.
+pub type MockNodeTypesWithDB<DB = Arc<TempDatabase<DatabaseEnv>>> =
+    NodeTypesWithDBAdapter<MockNodeTypes, DB>;
+
+/// Creates test provider factory with mainnet chain spec.
+pub fn create_test_provider_factory() -> ProviderFactory<MockNodeTypesWithDB> {
+    create_test_provider_factory_with_chain_spec(MAINNET.clone())
+}
+
+/// Creates test provider factory with provided chain spec.
+pub fn create_test_provider_factory_with_chain_spec(
+    chain_spec: Arc<ChainSpec>,
+) -> ProviderFactory<MockNodeTypesWithDB> {
+    create_test_provider_factory_with_node_types::<MockNodeTypes>(chain_spec)
+}
+
+/// Creates test provider factory with provided chain spec.
+pub fn create_test_provider_factory_with_node_types<N: NodeTypesForProvider>(
+    chain_spec: Arc<N::ChainSpec>,
+) -> ProviderFactory<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>> {
+    // Create a single temp directory that contains all data dirs (db, static_files, rocksdb).
+    // TempDatabase will clean up the entire directory on drop.
+    let datadir_path = reth_db::test_utils::tempdir_path();
+
+    let static_files_path = datadir_path.join("static_files");
+    let rocksdb_path = datadir_path.join("rocksdb");
+
+    // Create static_files directory
+    std::fs::create_dir_all(&static_files_path).expect("failed to create static_files dir");
+
+    // Create database with the datadir path so TempDatabase cleans up everything on drop
+    let db = reth_db::test_utils::create_test_rw_db_with_datadir(&datadir_path);
+
+    ProviderFactory::new(
+        db,
+        chain_spec,
+        StaticFileProvider::read_write(static_files_path).expect("static file provider"),
+        RocksDBBuilder::new(&rocksdb_path)
+            .with_default_tables()
+            .build()
+            .expect("failed to create test RocksDB provider"),
+        reth_tasks::Runtime::test(),
+    )
+    .expect("failed to create test provider factory")
+}
+
+/// Creates test provider factory with provided chain spec and custom database arguments.
+///
+/// Same as [`create_test_provider_factory_with_chain_spec`] but allows overriding the default
+/// test database arguments (e.g. to increase the MDBX geometry for heavy benchmarks).
+pub fn create_test_provider_factory_with_chain_spec_and_db_args(
+    chain_spec: Arc<ChainSpec>,
+    db_args: DatabaseArguments,
+) -> ProviderFactory<MockNodeTypesWithDB> {
+    let datadir_path = reth_db::test_utils::tempdir_path();
+
+    let db_path = datadir_path.join("db");
+    let static_files_path = datadir_path.join("static_files");
+    let rocksdb_path = datadir_path.join("rocksdb");
+
+    std::fs::create_dir_all(&static_files_path).expect("failed to create static_files dir");
+
+    let db = reth_db::init_db(&db_path, db_args).expect("failed to init db");
+    let db = Arc::new(TempDatabase::new(db, datadir_path));
+
+    ProviderFactory::new(
+        db,
+        chain_spec,
+        StaticFileProvider::read_write(static_files_path).expect("static file provider"),
+        RocksDBBuilder::new(&rocksdb_path)
+            .with_default_tables()
+            .build()
+            .expect("failed to create test RocksDB provider"),
+        reth_tasks::Runtime::test(),
+    )
+    .expect("failed to create test provider factory")
+}
+
+/// Inserts the genesis alloc from the provided chain spec into the trie.
+pub fn insert_genesis<N: ProviderNodeTypes<ChainSpec = ChainSpec>>(
+    provider_factory: &ProviderFactory<N>,
+    chain_spec: Arc<N::ChainSpec>,
+) -> ProviderResult<B256> {
+    let provider = provider_factory.provider_rw()?;
+
+    // Hash accounts and insert them into hashing table.
+    let genesis = chain_spec.genesis();
+    let alloc_accounts =
+        genesis.alloc.iter().map(|(addr, account)| (*addr, Some(Account::from(account))));
+    provider.insert_account_for_hashing(alloc_accounts).unwrap();
+
+    let alloc_storage = genesis.alloc.clone().into_iter().filter_map(|(addr, account)| {
+        // Only return `Some` if there is storage.
+        account.storage.map(|storage| {
+            (
+                addr,
+                storage.into_iter().map(|(key, value)| StorageEntry { key, value: value.into() }),
+            )
+        })
+    });
+    provider.insert_storage_for_hashing(alloc_storage)?;
+
+    let (root, updates) = reth_trie_db::with_adapter!(provider, |A| {
+        DbStateRoot::<_, A>::from_tx(provider.tx_ref()).root_with_updates()?
+    });
+    provider.write_trie_updates(updates).unwrap();
+
+    provider.commit()?;
+
+    Ok(root)
+}

--- a/patches/reth-provider/src/test_utils/noop.rs
+++ b/patches/reth-provider/src/test_utils/noop.rs
@@ -1,0 +1,38 @@
+//! Additional testing support for `NoopProvider`.
+
+use crate::{
+    providers::{RocksDBProvider, StaticFileProvider, StaticFileProviderRWRefMut},
+    RocksDBProviderFactory, StaticFileProviderFactory,
+};
+use reth_errors::{ProviderError, ProviderResult};
+use reth_primitives_traits::NodePrimitives;
+use std::path::PathBuf;
+
+/// Re-exported for convenience
+pub use reth_storage_api::noop::NoopProvider;
+
+impl<C: Send + Sync, N: NodePrimitives> StaticFileProviderFactory for NoopProvider<C, N> {
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
+        StaticFileProvider::read_only(PathBuf::default()).unwrap()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        _block: alloy_primitives::BlockNumber,
+        _segment: reth_static_file_types::StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        Err(ProviderError::ReadOnlyStaticFileAccess)
+    }
+}
+
+impl<C: Send + Sync, N: NodePrimitives> RocksDBProviderFactory for NoopProvider<C, N> {
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        RocksDBProvider::builder(PathBuf::default()).build().unwrap()
+    }
+
+    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {}
+
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+        Ok(())
+    }
+}

--- a/patches/reth-provider/src/traits/full.rs
+++ b/patches/reth-provider/src/traits/full.rs
@@ -1,0 +1,87 @@
+//! Helper provider traits to encapsulate all provider traits for simplicity.
+
+use crate::{
+    AccountReader, BalProvider, BlockReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader,
+    DatabaseProviderFactory, HashedPostStateProvider, PruneCheckpointReader,
+    RocksDBProviderFactory, StageCheckpointReader, StateProviderFactory, StateReader,
+    StaticFileProviderFactory,
+};
+use reth_chain_state::{
+    CanonStateSubscriptions, ForkChoiceSubscriptions, PersistedBlockSubscriptions,
+};
+use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
+use reth_storage_api::{NodePrimitivesProvider, StorageChangeSetReader, StorageSettingsCache};
+use std::fmt::Debug;
+
+/// Helper trait to unify all provider traits for simplicity.
+pub trait FullProvider<N: NodeTypesWithDB>:
+    DatabaseProviderFactory<
+        DB = N::DB,
+        Provider: BlockReader
+                      + StageCheckpointReader
+                      + PruneCheckpointReader
+                      + ChangeSetReader
+                      + StorageChangeSetReader
+                      + StorageSettingsCache,
+    > + NodePrimitivesProvider<Primitives = N::Primitives>
+    + StaticFileProviderFactory<Primitives = N::Primitives>
+    + RocksDBProviderFactory
+    + BlockReaderIdExt<
+        Transaction = TxTy<N>,
+        Block = BlockTy<N>,
+        Receipt = ReceiptTy<N>,
+        Header = HeaderTy<N>,
+    > + AccountReader
+    + BalProvider
+    + StateProviderFactory
+    + StateReader
+    + HashedPostStateProvider
+    + ChainSpecProvider<ChainSpec = N::ChainSpec>
+    + ChangeSetReader
+    + StorageChangeSetReader
+    + CanonStateSubscriptions
+    + ForkChoiceSubscriptions<Header = HeaderTy<N>>
+    + PersistedBlockSubscriptions
+    + StageCheckpointReader
+    + Clone
+    + Debug
+    + Unpin
+    + 'static
+{
+}
+
+impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
+    T: DatabaseProviderFactory<
+            DB = N::DB,
+            Provider: BlockReader
+                          + StageCheckpointReader
+                          + PruneCheckpointReader
+                          + ChangeSetReader
+                          + StorageChangeSetReader
+                          + StorageSettingsCache,
+        > + NodePrimitivesProvider<Primitives = N::Primitives>
+        + StaticFileProviderFactory<Primitives = N::Primitives>
+        + RocksDBProviderFactory
+        + BlockReaderIdExt<
+            Transaction = TxTy<N>,
+            Block = BlockTy<N>,
+            Receipt = ReceiptTy<N>,
+            Header = HeaderTy<N>,
+        > + AccountReader
+        + BalProvider
+        + StateProviderFactory
+        + StateReader
+        + HashedPostStateProvider
+        + ChainSpecProvider<ChainSpec = N::ChainSpec>
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + CanonStateSubscriptions
+        + ForkChoiceSubscriptions<Header = HeaderTy<N>>
+        + PersistedBlockSubscriptions
+        + StageCheckpointReader
+        + Clone
+        + Debug
+        + Unpin
+        + 'static
+{
+}

--- a/patches/reth-provider/src/traits/mod.rs
+++ b/patches/reth-provider/src/traits/mod.rs
@@ -1,0 +1,15 @@
+//! Collection of common provider traits.
+
+// Re-export all the traits
+pub use reth_storage_api::*;
+
+pub use reth_chainspec::ChainSpecProvider;
+
+mod static_file_provider;
+pub use static_file_provider::StaticFileProviderFactory;
+
+mod rocksdb_provider;
+pub use rocksdb_provider::RocksDBProviderFactory;
+
+mod full;
+pub use full::FullProvider;

--- a/patches/reth-provider/src/traits/rocksdb_provider.rs
+++ b/patches/reth-provider/src/traits/rocksdb_provider.rs
@@ -1,0 +1,186 @@
+use crate::{
+    either_writer::{RawRocksDBBatch, RocksBatchArg, RocksDBRefArg},
+    providers::RocksDBProvider,
+};
+use reth_storage_api::StorageSettingsCache;
+use reth_storage_errors::provider::ProviderResult;
+
+/// `RocksDB` provider factory.
+///
+/// This trait provides access to the `RocksDB` provider
+pub trait RocksDBProviderFactory {
+    /// Returns the `RocksDB` provider.
+    fn rocksdb_provider(&self) -> RocksDBProvider;
+
+    /// Adds a pending `RocksDB` batch to be committed when this provider is committed.
+    ///
+    /// This allows deferring `RocksDB` commits to happen at the same time as MDBX and static file
+    /// commits, ensuring atomicity across all storage backends.
+    fn set_pending_rocksdb_batch(&self, batch: rocksdb::WriteBatchWithTransaction<true>);
+
+    /// Takes all pending `RocksDB` batches and commits them.
+    ///
+    /// This drains the pending batches from the lock and commits each one using the `RocksDB`
+    /// provider. Can be called before flush to persist `RocksDB` writes independently of the
+    /// full commit path.
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()>;
+
+    /// Executes a closure with a `RocksDB` point-in-time snapshot for consistent reads.
+    ///
+    /// This helper encapsulates `RocksDB` access for read operations.
+    /// On legacy MDBX-only nodes (where `storage_v2` is false), this skips creating
+    /// the `RocksDB` snapshot entirely, avoiding unnecessary overhead.
+    ///
+    /// Unlike a transaction-based approach, this works in both read-only and read-write
+    /// modes since the snapshot provides a consistent view of the data at the time it
+    /// was created.
+    fn with_rocksdb_snapshot<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        Self: StorageSettingsCache,
+        F: FnOnce(RocksDBRefArg<'_>) -> ProviderResult<R>,
+    {
+        if self.cached_storage_settings().storage_v2 {
+            let rocksdb = self.rocksdb_provider();
+            let snapshot = rocksdb.snapshot();
+            return f(Some(snapshot));
+        }
+        f(None)
+    }
+
+    /// Executes a closure with a `RocksDB` batch, automatically registering it for commit.
+    ///
+    /// This helper encapsulates all the cfg-gated `RocksDB` batch handling.
+    fn with_rocksdb_batch<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        F: FnOnce(RocksBatchArg<'_>) -> ProviderResult<(R, Option<RawRocksDBBatch>)>,
+    {
+        let rocksdb = self.rocksdb_provider();
+        let batch = rocksdb.batch();
+        let (result, raw_batch) = f(batch)?;
+        if let Some(b) = raw_batch {
+            self.set_pending_rocksdb_batch(b);
+        }
+        Ok(result)
+    }
+
+    /// Executes a closure with a `RocksDB` batch that auto-commits on threshold.
+    ///
+    /// Unlike [`Self::with_rocksdb_batch`], this uses a batch that automatically commits
+    /// when it exceeds the size threshold, preventing OOM during large bulk writes.
+    /// The consistency check on startup heals any crash between auto-commits.
+    fn with_rocksdb_batch_auto_commit<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        F: FnOnce(RocksBatchArg<'_>) -> ProviderResult<(R, Option<RawRocksDBBatch>)>,
+    {
+        let rocksdb = self.rocksdb_provider();
+        let batch = rocksdb.batch_with_auto_commit();
+        let (result, raw_batch) = f(batch)?;
+        if let Some(b) = raw_batch {
+            self.set_pending_rocksdb_batch(b);
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_db_api::models::StorageSettings;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Mock `RocksDB` provider that tracks snapshot creation calls.
+    struct MockRocksDBProvider {
+        tx_call_count: AtomicUsize,
+    }
+
+    impl MockRocksDBProvider {
+        const fn new() -> Self {
+            Self { tx_call_count: AtomicUsize::new(0) }
+        }
+
+        fn tx_call_count(&self) -> usize {
+            self.tx_call_count.load(Ordering::SeqCst)
+        }
+
+        fn increment_tx_count(&self) {
+            self.tx_call_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Test provider that implements [`RocksDBProviderFactory`] + [`StorageSettingsCache`].
+    struct TestProvider {
+        settings: StorageSettings,
+        mock_rocksdb: MockRocksDBProvider,
+        temp_dir: tempfile::TempDir,
+    }
+
+    impl TestProvider {
+        fn new(settings: StorageSettings) -> Self {
+            Self {
+                settings,
+                mock_rocksdb: MockRocksDBProvider::new(),
+                temp_dir: tempfile::TempDir::new().unwrap(),
+            }
+        }
+
+        fn tx_call_count(&self) -> usize {
+            self.mock_rocksdb.tx_call_count()
+        }
+    }
+
+    impl StorageSettingsCache for TestProvider {
+        fn cached_storage_settings(&self) -> StorageSettings {
+            self.settings
+        }
+
+        fn set_storage_settings_cache(&self, _settings: StorageSettings) {}
+    }
+
+    impl RocksDBProviderFactory for TestProvider {
+        fn rocksdb_provider(&self) -> RocksDBProvider {
+            self.mock_rocksdb.increment_tx_count();
+            RocksDBProvider::new(self.temp_dir.path()).unwrap()
+        }
+
+        fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {}
+
+        fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_legacy_settings_skip_rocksdb_snapshot() {
+        let provider = TestProvider::new(StorageSettings::v1());
+
+        let result = provider.with_rocksdb_snapshot(|rocksdb| {
+            assert!(rocksdb.is_none(), "legacy settings should pass None");
+            Ok(42)
+        });
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(
+            provider.tx_call_count(),
+            0,
+            "should not create RocksDB provider for legacy settings"
+        );
+    }
+
+    #[test]
+    fn test_rocksdb_settings_create_snapshot() {
+        let settings = StorageSettings::v2();
+        let provider = TestProvider::new(settings);
+
+        let result = provider.with_rocksdb_snapshot(|rocksdb| {
+            assert!(rocksdb.is_some(), "rocksdb settings should pass Some snapshot");
+            Ok(42)
+        });
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(
+            provider.tx_call_count(),
+            1,
+            "should create RocksDB provider when storage_v2 is true"
+        );
+    }
+}

--- a/patches/reth-provider/src/traits/static_file_provider.rs
+++ b/patches/reth-provider/src/traits/static_file_provider.rs
@@ -1,0 +1,21 @@
+use alloy_primitives::BlockNumber;
+use reth_errors::ProviderResult;
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::NodePrimitivesProvider;
+
+use crate::providers::{StaticFileProvider, StaticFileProviderRWRefMut};
+
+/// Static file provider factory.
+pub trait StaticFileProviderFactory: NodePrimitivesProvider {
+    /// Create new instance of static file provider.
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives>;
+
+    /// Returns a mutable reference to a
+    /// [`StaticFileProviderRW`](`crate::providers::StaticFileProviderRW`) of a
+    /// [`StaticFileSegment`].
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>>;
+}

--- a/patches/reth-provider/src/writer/mod.rs
+++ b/patches/reth-provider/src/writer/mod.rs
@@ -1,0 +1,1194 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        test_utils::create_test_provider_factory, AccountReader, StorageTrieWriter, TrieWriter,
+    };
+    use alloy_primitives::{keccak256, map::HashMap, Address, B256, U256};
+    use reth_db_api::{
+        cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
+        models::{AccountBeforeTx, BlockNumberAddress},
+        tables,
+        transaction::{DbTx, DbTxMut},
+    };
+    use reth_ethereum_primitives::Receipt;
+    use reth_execution_types::ExecutionOutcome;
+    use reth_primitives_traits::{Account, StorageEntry};
+    use reth_storage_api::{
+        DatabaseProviderFactory, HashedPostStateProvider, StateWriteConfig, StateWriter,
+        StorageSettingsCache,
+    };
+    use reth_trie::{
+        test_utils::{state_root, storage_root_prehashed},
+        HashedPostState, HashedStorage, StateRoot, StorageRoot, StorageRootProgress,
+    };
+    use reth_trie_db::{DatabaseStateRoot, DatabaseStorageRoot, LegacyKeyAdapter, PackedKeyAdapter};
+    use revm_database::{
+        states::{
+            bundle_state::BundleRetention, changes::PlainStorageRevert, PlainStorageChangeset,
+        },
+        BundleState, OriginalValuesKnown, State,
+    };
+    use revm_database_interface::{DatabaseCommit, EmptyDB};
+    use revm_state::{
+        Account as RevmAccount, AccountInfo as RevmAccountInfo, AccountStatus, EvmStorageSlot,
+    };
+    use std::{collections::BTreeMap, str::FromStr};
+
+    #[test]
+    fn wiped_entries_are_removed() {
+        let provider_factory = create_test_provider_factory();
+
+        let addresses = (0..10).map(|_| Address::random()).collect::<Vec<_>>();
+        let destroyed_address = *addresses.first().unwrap();
+        let destroyed_address_hashed = keccak256(destroyed_address);
+        let slot = B256::with_last_byte(1);
+        let hashed_slot = keccak256(slot);
+        {
+            let provider_rw = provider_factory.provider_rw().unwrap();
+            let mut accounts_cursor =
+                provider_rw.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
+            let mut storage_cursor =
+                provider_rw.tx_ref().cursor_write::<tables::HashedStorages>().unwrap();
+
+            for address in addresses {
+                let hashed_address = keccak256(address);
+                accounts_cursor
+                    .insert(hashed_address, &Account { nonce: 1, ..Default::default() })
+                    .unwrap();
+                storage_cursor
+                    .insert(
+                        hashed_address,
+                        &StorageEntry { key: hashed_slot, value: U256::from(1) },
+                    )
+                    .unwrap();
+            }
+            provider_rw.commit().unwrap();
+        }
+
+        let mut hashed_state = HashedPostState::default();
+        hashed_state.accounts.insert(destroyed_address_hashed, None);
+        hashed_state.storages.insert(destroyed_address_hashed, HashedStorage::new(true));
+
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        assert!(matches!(provider_rw.write_hashed_state(&hashed_state.into_sorted()), Ok(())));
+        provider_rw.commit().unwrap();
+
+        let provider = provider_factory.provider().unwrap();
+        assert_eq!(
+            provider.tx_ref().get::<tables::HashedAccounts>(destroyed_address_hashed),
+            Ok(None)
+        );
+        assert_eq!(
+            provider
+                .tx_ref()
+                .cursor_read::<tables::HashedStorages>()
+                .unwrap()
+                .seek_by_key_subkey(destroyed_address_hashed, hashed_slot),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn write_to_db_account_info() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+
+        let address_a = Address::ZERO;
+        let address_b = Address::repeat_byte(0xff);
+
+        let account_a = RevmAccountInfo { balance: U256::from(1), nonce: 1, ..Default::default() };
+        let account_b = RevmAccountInfo { balance: U256::from(2), nonce: 2, ..Default::default() };
+        let account_b_changed =
+            RevmAccountInfo { balance: U256::from(3), nonce: 3, ..Default::default() };
+
+        let mut state = State::builder().with_bundle_update().build();
+        state.insert_not_existing(address_a);
+        state.insert_account(address_b, account_b.clone());
+
+        // 0x00.. is created
+        state.commit(HashMap::from_iter([(
+            address_a,
+            RevmAccount {
+                info: account_a.clone(),
+                status: AccountStatus::Touched | AccountStatus::Created,
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+
+        // 0xff.. is changed (balance + 1, nonce + 1)
+        state.commit(HashMap::from_iter([(
+            address_b,
+            RevmAccount {
+                info: account_b_changed.clone(),
+                status: AccountStatus::Touched,
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+
+        state.merge_transitions(BundleRetention::Reverts);
+        let mut revm_bundle_state = state.take_bundle();
+
+        // Write plain state and reverts separately.
+        let reverts = revm_bundle_state.take_all_reverts().to_plain_state_reverts();
+        let plain_state = revm_bundle_state.to_plain_state(OriginalValuesKnown::Yes);
+        assert!(plain_state.storage.is_empty());
+        assert!(plain_state.contracts.is_empty());
+        provider.write_state_changes(plain_state).expect("Could not write plain state to DB");
+
+        assert_eq!(reverts.storage, [[]]);
+        provider.write_state_reverts(reverts, 1, StateWriteConfig::default()).expect("Could not write reverts to DB");
+
+        let reth_account_a = account_a.into();
+        let reth_account_b = account_b.into();
+        let reth_account_b_changed = (&account_b_changed).into();
+
+        // Check plain state
+        assert_eq!(
+            provider.basic_account(&address_a).expect("Could not read account state"),
+            Some(reth_account_a),
+            "Account A state is wrong"
+        );
+        assert_eq!(
+            provider.basic_account(&address_b).expect("Could not read account state"),
+            Some(reth_account_b_changed),
+            "Account B state is wrong"
+        );
+
+        // Check change set
+        let mut changeset_cursor = provider
+            .tx_ref()
+            .cursor_dup_read::<tables::AccountChangeSets>()
+            .expect("Could not open changeset cursor");
+        assert_eq!(
+            changeset_cursor.seek_exact(1).expect("Could not read account change set"),
+            Some((1, AccountBeforeTx { address: address_a, info: None })),
+            "Account A changeset is wrong"
+        );
+        assert_eq!(
+            changeset_cursor.next_dup().expect("Changeset table is malformed"),
+            Some((1, AccountBeforeTx { address: address_b, info: Some(reth_account_b) })),
+            "Account B changeset is wrong"
+        );
+
+        let mut state = State::builder().with_bundle_update().build();
+        state.insert_account(address_b, account_b_changed.clone());
+
+        // 0xff.. is destroyed
+        state.commit(HashMap::from_iter([(
+            address_b,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::SelfDestructed,
+                info: account_b_changed,
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+
+        state.merge_transitions(BundleRetention::Reverts);
+        let mut revm_bundle_state = state.take_bundle();
+
+        // Write plain state and reverts separately.
+        let reverts = revm_bundle_state.take_all_reverts().to_plain_state_reverts();
+        let plain_state = revm_bundle_state.to_plain_state(OriginalValuesKnown::Yes);
+        // Account B selfdestructed so flag for it should be present.
+        assert_eq!(
+            plain_state.storage,
+            [PlainStorageChangeset { address: address_b, wipe_storage: true, storage: vec![] }]
+        );
+        assert!(plain_state.contracts.is_empty());
+        provider.write_state_changes(plain_state).expect("Could not write plain state to DB");
+
+        assert_eq!(
+            reverts.storage,
+            [[PlainStorageRevert { address: address_b, wiped: true, storage_revert: vec![] }]]
+        );
+        provider.write_state_reverts(reverts, 2, StateWriteConfig::default()).expect("Could not write reverts to DB");
+
+        // Check new plain state for account B
+        assert_eq!(
+            provider.basic_account(&address_b).expect("Could not read account state"),
+            None,
+            "Account B should be deleted"
+        );
+
+        // Check change set
+        assert_eq!(
+            changeset_cursor.seek_exact(2).expect("Could not read account change set"),
+            Some((2, AccountBeforeTx { address: address_b, info: Some(reth_account_b_changed) })),
+            "Account B changeset is wrong after deletion"
+        );
+    }
+
+    #[test]
+    fn write_to_db_storage() {
+        let factory = create_test_provider_factory();
+        let provider = factory.database_provider_rw().unwrap();
+
+        let address_a = Address::ZERO;
+        let address_b = Address::repeat_byte(0xff);
+
+        let account_b = RevmAccountInfo { balance: U256::from(2), nonce: 2, ..Default::default() };
+
+        let mut state = State::builder().with_bundle_update().build();
+        state.insert_not_existing(address_a);
+        state.insert_account_with_storage(
+            address_b,
+            account_b.clone(),
+            HashMap::from_iter([(U256::from(1), U256::from(1))]),
+        );
+
+        state.commit(HashMap::from_iter([
+            (
+                address_a,
+                RevmAccount {
+                    status: AccountStatus::Touched | AccountStatus::Created,
+                    info: RevmAccountInfo::default(),
+                    // 0x00 => 0 => 1
+                    // 0x01 => 0 => 2
+                    storage: HashMap::from_iter([
+                        (
+                            U256::from(0),
+                            EvmStorageSlot { present_value: U256::from(1), ..Default::default() },
+                        ),
+                        (
+                            U256::from(1),
+                            EvmStorageSlot { present_value: U256::from(2), ..Default::default() },
+                        ),
+                    ]),
+                    transaction_id: 0,
+                },
+            ),
+            (
+                address_b,
+                RevmAccount {
+                    status: AccountStatus::Touched,
+                    info: account_b,
+                    // 0x01 => 1 => 2
+                    storage: HashMap::from_iter([(
+                        U256::from(1),
+                        EvmStorageSlot {
+                            present_value: U256::from(2),
+                            original_value: U256::from(1),
+                            ..Default::default()
+                        },
+                    )]),
+                    transaction_id: 0,
+                },
+            ),
+        ]));
+
+        state.merge_transitions(BundleRetention::Reverts);
+
+        let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
+        provider
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
+            .expect("Could not write bundle state to DB");
+
+        // Check plain storage state
+        let mut storage_cursor = provider
+            .tx_ref()
+            .cursor_dup_read::<tables::PlainStorageState>()
+            .expect("Could not open plain storage state cursor");
+
+        assert_eq!(
+            storage_cursor.seek_exact(address_a).unwrap(),
+            Some((address_a, StorageEntry { key: B256::ZERO, value: U256::from(1) })),
+            "Slot 0 for account A should be 1"
+        );
+        assert_eq!(
+            storage_cursor.next_dup().unwrap(),
+            Some((
+                address_a,
+                StorageEntry { key: B256::from(U256::from(1).to_be_bytes()), value: U256::from(2) }
+            )),
+            "Slot 1 for account A should be 2"
+        );
+        assert_eq!(
+            storage_cursor.next_dup().unwrap(),
+            None,
+            "Account A should only have 2 storage slots"
+        );
+
+        assert_eq!(
+            storage_cursor.seek_exact(address_b).unwrap(),
+            Some((
+                address_b,
+                StorageEntry { key: B256::from(U256::from(1).to_be_bytes()), value: U256::from(2) }
+            )),
+            "Slot 1 for account B should be 2"
+        );
+        assert_eq!(
+            storage_cursor.next_dup().unwrap(),
+            None,
+            "Account B should only have 1 storage slot"
+        );
+
+        // Check change set
+        let mut changeset_cursor = provider
+            .tx_ref()
+            .cursor_dup_read::<tables::StorageChangeSets>()
+            .expect("Could not open storage changeset cursor");
+        assert_eq!(
+            changeset_cursor.seek_exact(BlockNumberAddress((1, address_a))).unwrap(),
+            Some((
+                BlockNumberAddress((1, address_a)),
+                StorageEntry { key: B256::ZERO, value: U256::from(0) }
+            )),
+            "Slot 0 for account A should have changed from 0"
+        );
+        assert_eq!(
+            changeset_cursor.next_dup().unwrap(),
+            Some((
+                BlockNumberAddress((1, address_a)),
+                StorageEntry { key: B256::from(U256::from(1).to_be_bytes()), value: U256::from(0) }
+            )),
+            "Slot 1 for account A should have changed from 0"
+        );
+        assert_eq!(
+            changeset_cursor.next_dup().unwrap(),
+            None,
+            "Account A should only be in the changeset 2 times"
+        );
+
+        assert_eq!(
+            changeset_cursor.seek_exact(BlockNumberAddress((1, address_b))).unwrap(),
+            Some((
+                BlockNumberAddress((1, address_b)),
+                StorageEntry { key: B256::from(U256::from(1).to_be_bytes()), value: U256::from(1) }
+            )),
+            "Slot 1 for account B should have changed from 1"
+        );
+        assert_eq!(
+            changeset_cursor.next_dup().unwrap(),
+            None,
+            "Account B should only be in the changeset 1 time"
+        );
+
+        // Delete account A
+        let mut state = State::builder().with_bundle_update().build();
+        state.insert_account(address_a, RevmAccountInfo::default());
+
+        state.commit(HashMap::from_iter([(
+            address_a,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::SelfDestructed,
+                info: RevmAccountInfo::default(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+
+        state.merge_transitions(BundleRetention::Reverts);
+        let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 2, Vec::new());
+        provider
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
+            .expect("Could not write bundle state to DB");
+
+        assert_eq!(
+            storage_cursor.seek_exact(address_a).unwrap(),
+            None,
+            "Account A should have no storage slots after deletion"
+        );
+
+        assert_eq!(
+            changeset_cursor.seek_exact(BlockNumberAddress((2, address_a))).unwrap(),
+            Some((
+                BlockNumberAddress((2, address_a)),
+                StorageEntry { key: B256::ZERO, value: U256::from(1) }
+            )),
+            "Slot 0 for account A should have changed from 1 on deletion"
+        );
+        assert_eq!(
+            changeset_cursor.next_dup().unwrap(),
+            Some((
+                BlockNumberAddress((2, address_a)),
+                StorageEntry { key: B256::from(U256::from(1).to_be_bytes()), value: U256::from(2) }
+            )),
+            "Slot 1 for account A should have changed from 2 on deletion"
+        );
+        assert_eq!(
+            changeset_cursor.next_dup().unwrap(),
+            None,
+            "Account A should only be in the changeset 2 times on deletion"
+        );
+    }
+
+    #[test]
+    fn write_to_db_multiple_selfdestructs() {
+        let factory = create_test_provider_factory();
+        let provider = factory.database_provider_rw().unwrap();
+
+        let address1 = Address::random();
+        let account_info = RevmAccountInfo { nonce: 1, ..Default::default() };
+
+        // Block #0: initial state.
+        let mut init_state = State::builder().with_bundle_update().build();
+        init_state.insert_not_existing(address1);
+        init_state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                info: account_info.clone(),
+                status: AccountStatus::Touched | AccountStatus::Created,
+                // 0x00 => 0 => 1
+                // 0x01 => 0 => 2
+                storage: HashMap::from_iter([
+                    (
+                        U256::ZERO,
+                        EvmStorageSlot { present_value: U256::from(1), ..Default::default() },
+                    ),
+                    (
+                        U256::from(1),
+                        EvmStorageSlot { present_value: U256::from(2), ..Default::default() },
+                    ),
+                ]),
+                transaction_id: 0,
+            },
+        )]));
+        init_state.merge_transitions(BundleRetention::Reverts);
+
+        let outcome =
+            ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
+        provider
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
+            .expect("Could not write bundle state to DB");
+
+        let mut state = State::builder().with_bundle_update().build();
+        state.insert_account_with_storage(
+            address1,
+            account_info.clone(),
+            HashMap::from_iter([(U256::ZERO, U256::from(1)), (U256::from(1), U256::from(2))]),
+        );
+
+        // Block #1: change storage.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account_info.clone(),
+                // 0x00 => 1 => 2
+                storage: HashMap::from_iter([(
+                    U256::ZERO,
+                    EvmStorageSlot {
+                        original_value: U256::from(1),
+                        present_value: U256::from(2),
+                        ..Default::default()
+                    },
+                )]),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::Reverts);
+
+        // Block #2: destroy account.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::SelfDestructed,
+                info: account_info.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::Reverts);
+
+        // Block #3: re-create account and change storage.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::Created,
+                info: account_info.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::Reverts);
+
+        // Block #4: change storage.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account_info.clone(),
+                // 0x00 => 0 => 2
+                // 0x02 => 0 => 4
+                // 0x06 => 0 => 6
+                storage: HashMap::from_iter([
+                    (
+                        U256::ZERO,
+                        EvmStorageSlot { present_value: U256::from(2), ..Default::default() },
+                    ),
+                    (
+                        U256::from(2),
+                        EvmStorageSlot { present_value: U256::from(4), ..Default::default() },
+                    ),
+                    (
+                        U256::from(6),
+                        EvmStorageSlot { present_value: U256::from(6), ..Default::default() },
+                    ),
+                ]),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::Reverts);
+
+        // Block #5: Destroy account again.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::SelfDestructed,
+                info: account_info.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::Reverts);
+
+        // Block #6: Create, change, destroy and re-create in the same block.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::Created,
+                info: account_info.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account_info.clone(),
+                // 0x00 => 0 => 2
+                storage: HashMap::from_iter([(
+                    U256::ZERO,
+                    EvmStorageSlot { present_value: U256::from(2), ..Default::default() },
+                )]),
+                transaction_id: 0,
+            },
+        )]));
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::SelfDestructed,
+                info: account_info.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::Created,
+                info: account_info.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::Reverts);
+
+        // Block #7: Change storage.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account_info,
+                // 0x00 => 0 => 9
+                storage: HashMap::from_iter([(
+                    U256::ZERO,
+                    EvmStorageSlot { present_value: U256::from(9), ..Default::default() },
+                )]),
+                transaction_id: 0,
+            },
+        )]));
+
+        state.merge_transitions(BundleRetention::Reverts);
+
+        let bundle = state.take_bundle();
+
+        let outcome: ExecutionOutcome =
+            ExecutionOutcome::new(bundle, Default::default(), 1, Vec::new());
+        provider
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
+            .expect("Could not write bundle state to DB");
+
+        let mut storage_changeset_cursor = provider
+            .tx_ref()
+            .cursor_dup_read::<tables::StorageChangeSets>()
+            .expect("Could not open plain storage state cursor");
+        let mut storage_changes = storage_changeset_cursor.walk_range(..).unwrap();
+
+        // Iterate through all storage changes
+
+        // Block <number>
+        // <slot>: <expected value before>
+        // ...
+
+        // Block #0
+        // 0x00: 0
+        // 0x01: 0
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((0, address1)),
+                StorageEntry { key: B256::with_last_byte(0), value: U256::ZERO }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((0, address1)),
+                StorageEntry { key: B256::with_last_byte(1), value: U256::ZERO }
+            )))
+        );
+
+        // Block #1
+        // 0x00: 1
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((1, address1)),
+                StorageEntry { key: B256::with_last_byte(0), value: U256::from(1) }
+            )))
+        );
+
+        // Block #2 (destroyed)
+        // 0x00: 2
+        // 0x01: 2
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((2, address1)),
+                StorageEntry { key: B256::with_last_byte(0), value: U256::from(2) }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((2, address1)),
+                StorageEntry { key: B256::with_last_byte(1), value: U256::from(2) }
+            )))
+        );
+
+        // Block #3
+        // no storage changes
+
+        // Block #4
+        // 0x00: 0
+        // 0x02: 0
+        // 0x06: 0
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((4, address1)),
+                StorageEntry { key: B256::with_last_byte(0), value: U256::ZERO }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((4, address1)),
+                StorageEntry { key: B256::with_last_byte(2), value: U256::ZERO }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((4, address1)),
+                StorageEntry { key: B256::with_last_byte(6), value: U256::ZERO }
+            )))
+        );
+
+        // Block #5 (destroyed)
+        // 0x00: 2
+        // 0x02: 4
+        // 0x06: 6
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((5, address1)),
+                StorageEntry { key: B256::with_last_byte(0), value: U256::from(2) }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((5, address1)),
+                StorageEntry { key: B256::with_last_byte(2), value: U256::from(4) }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((5, address1)),
+                StorageEntry { key: B256::with_last_byte(6), value: U256::from(6) }
+            )))
+        );
+
+        // Block #6
+        // no storage changes (only inter block changes)
+
+        // Block #7
+        // 0x00: 0
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((7, address1)),
+                StorageEntry { key: B256::with_last_byte(0), value: U256::ZERO }
+            )))
+        );
+        assert_eq!(storage_changes.next(), None);
+    }
+
+    #[test]
+    fn storage_change_after_selfdestruct_within_block() {
+        let factory = create_test_provider_factory();
+        let provider = factory.database_provider_rw().unwrap();
+
+        let address1 = Address::random();
+        let account1 = RevmAccountInfo { nonce: 1, ..Default::default() };
+
+        // Block #0: initial state.
+        let mut init_state = State::builder().with_bundle_update().build();
+        init_state.insert_not_existing(address1);
+        init_state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                info: account1.clone(),
+                status: AccountStatus::Touched | AccountStatus::Created,
+                // 0x00 => 0 => 1
+                // 0x01 => 0 => 2
+                storage: HashMap::from_iter([
+                    (
+                        U256::ZERO,
+                        EvmStorageSlot { present_value: U256::from(1), ..Default::default() },
+                    ),
+                    (
+                        U256::from(1),
+                        EvmStorageSlot { present_value: U256::from(2), ..Default::default() },
+                    ),
+                ]),
+                transaction_id: 0,
+            },
+        )]));
+        init_state.merge_transitions(BundleRetention::Reverts);
+        let outcome =
+            ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
+        provider
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
+            .expect("Could not write bundle state to DB");
+
+        let mut state = State::builder().with_bundle_update().build();
+        state.insert_account_with_storage(
+            address1,
+            account1.clone(),
+            HashMap::from_iter([(U256::ZERO, U256::from(1)), (U256::from(1), U256::from(2))]),
+        );
+
+        // Block #1: Destroy, re-create, change storage.
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::SelfDestructed,
+                info: account1.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::Created,
+                info: account1.clone(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account1,
+                // 0x01 => 0 => 5
+                storage: HashMap::from_iter([(
+                    U256::from(1),
+                    EvmStorageSlot { present_value: U256::from(5), ..Default::default() },
+                )]),
+                transaction_id: 0,
+            },
+        )]));
+
+        // Commit block #1 changes to the database.
+        state.merge_transitions(BundleRetention::Reverts);
+        let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
+        provider
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
+            .expect("Could not write bundle state to DB");
+
+        let mut storage_changeset_cursor = provider
+            .tx_ref()
+            .cursor_dup_read::<tables::StorageChangeSets>()
+            .expect("Could not open plain storage state cursor");
+        let range = BlockNumberAddress::range(1..=1);
+        let mut storage_changes = storage_changeset_cursor.walk_range(range).unwrap();
+
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((1, address1)),
+                StorageEntry { key: B256::with_last_byte(0), value: U256::from(1) }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((1, address1)),
+                StorageEntry { key: B256::with_last_byte(1), value: U256::from(2) }
+            )))
+        );
+        assert_eq!(storage_changes.next(), None);
+    }
+
+    #[test]
+    fn revert_to_indices() {
+        let base: ExecutionOutcome = ExecutionOutcome {
+            bundle: BundleState::default(),
+            receipts: vec![vec![Receipt::default(); 2]; 7],
+            first_block: 10,
+            requests: Vec::new(),
+        };
+
+        let mut this = base.clone();
+        assert!(this.revert_to(10));
+        assert_eq!(this.receipts.len(), 1);
+
+        let mut this = base.clone();
+        assert!(!this.revert_to(9));
+        assert_eq!(this.receipts.len(), 7);
+
+        let mut this = base.clone();
+        assert!(this.revert_to(15));
+        assert_eq!(this.receipts.len(), 6);
+
+        let mut this = base.clone();
+        assert!(this.revert_to(16));
+        assert_eq!(this.receipts.len(), 7);
+
+        let mut this = base;
+        assert!(!this.revert_to(17));
+        assert_eq!(this.receipts.len(), 7);
+    }
+
+    #[test]
+    fn bundle_state_state_root() {
+        type PreState = BTreeMap<Address, (Account, BTreeMap<B256, U256>)>;
+        let mut prestate: PreState = (0..10)
+            .map(|key| {
+                let account = Account { nonce: 1, balance: U256::from(key), bytecode_hash: None };
+                let storage =
+                    (1..11).map(|key| (B256::with_last_byte(key), U256::from(key))).collect();
+                (Address::with_last_byte(key), (account, storage))
+            })
+            .collect();
+
+        let provider_factory = create_test_provider_factory();
+        let provider_rw = provider_factory.database_provider_rw().unwrap();
+
+        // insert initial state to the database
+        let tx = provider_rw.tx_ref();
+        for (address, (account, storage)) in &prestate {
+            let hashed_address = keccak256(address);
+            tx.put::<tables::HashedAccounts>(hashed_address, *account).unwrap();
+            for (slot, value) in storage {
+                tx.put::<tables::HashedStorages>(
+                    hashed_address,
+                    StorageEntry { key: keccak256(slot), value: *value },
+                )
+                .unwrap();
+            }
+        }
+
+        type TestStateRoot<'a, TX, A> = StateRoot<
+            reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+            reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+        >;
+        let is_v2 = provider_rw.cached_storage_settings().is_v2();
+        let (_, updates) = if is_v2 {
+            TestStateRoot::<_, PackedKeyAdapter>::from_tx(tx).root_with_updates().unwrap()
+        } else {
+            TestStateRoot::<_, LegacyKeyAdapter>::from_tx(tx).root_with_updates().unwrap()
+        };
+        provider_rw.write_trie_updates(updates).unwrap();
+
+        let mut state = State::builder().with_bundle_update().build();
+
+        let assert_state_root = |state: &State<EmptyDB>, expected: &PreState, msg| {
+            let overlay_root = if is_v2 {
+                TestStateRoot::<_, PackedKeyAdapter>::overlay_root(
+                    tx,
+                    &provider_factory.hashed_post_state(&state.bundle_state).into_sorted(),
+                )
+                .unwrap()
+            } else {
+                TestStateRoot::<_, LegacyKeyAdapter>::overlay_root(
+                    tx,
+                    &provider_factory.hashed_post_state(&state.bundle_state).into_sorted(),
+                )
+                .unwrap()
+            };
+            assert_eq!(
+                overlay_root,
+                state_root(expected.clone().into_iter().map(|(address, (account, storage))| (
+                    address,
+                    (account, storage.into_iter())
+                ))),
+                "{msg}"
+            );
+        };
+
+        // database only state root is correct
+        assert_state_root(&state, &prestate, "empty");
+
+        // destroy account 1
+        let address1 = Address::with_last_byte(1);
+        let account1_old = prestate.remove(&address1).unwrap();
+        state.insert_account(address1, account1_old.0.into());
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::SelfDestructed,
+                info: RevmAccountInfo::default(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::PlainState);
+        assert_state_root(&state, &prestate, "destroyed account");
+
+        // change slot 2 in account 2
+        let address2 = Address::with_last_byte(2);
+        let slot2 = U256::from(2);
+        let slot2_key = B256::from(slot2);
+        let account2 = prestate.get_mut(&address2).unwrap();
+        let account2_slot2_old_value = *account2.1.get(&slot2_key).unwrap();
+        state.insert_account_with_storage(
+            address2,
+            account2.0.into(),
+            HashMap::from_iter([(slot2, account2_slot2_old_value)]),
+        );
+
+        let account2_slot2_new_value = U256::from(100);
+        account2.1.insert(slot2_key, account2_slot2_new_value);
+        state.commit(HashMap::from_iter([(
+            address2,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account2.0.into(),
+                storage: HashMap::from_iter([(
+                    slot2,
+                    EvmStorageSlot::new_changed(
+                        account2_slot2_old_value,
+                        account2_slot2_new_value,
+                        0,
+                    ),
+                )]),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::PlainState);
+        assert_state_root(&state, &prestate, "changed storage");
+
+        // change balance of account 3
+        let address3 = Address::with_last_byte(3);
+        let account3 = prestate.get_mut(&address3).unwrap();
+        state.insert_account(address3, account3.0.into());
+
+        account3.0.balance = U256::from(24);
+        state.commit(HashMap::from_iter([(
+            address3,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account3.0.into(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::PlainState);
+        assert_state_root(&state, &prestate, "changed balance");
+
+        // change nonce of account 4
+        let address4 = Address::with_last_byte(4);
+        let account4 = prestate.get_mut(&address4).unwrap();
+        state.insert_account(address4, account4.0.into());
+
+        account4.0.nonce = 128;
+        state.commit(HashMap::from_iter([(
+            address4,
+            RevmAccount {
+                status: AccountStatus::Touched,
+                info: account4.0.into(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::PlainState);
+        assert_state_root(&state, &prestate, "changed nonce");
+
+        // recreate account 1
+        let account1_new =
+            Account { nonce: 56, balance: U256::from(123), bytecode_hash: Some(B256::random()) };
+        prestate.insert(address1, (account1_new, BTreeMap::default()));
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::Created,
+                info: account1_new.into(),
+                storage: HashMap::default(),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::PlainState);
+        assert_state_root(&state, &prestate, "recreated");
+
+        // update storage for account 1
+        let slot20 = U256::from(20);
+        let slot20_key = B256::from(slot20);
+        let account1_slot20_value = U256::from(12345);
+        prestate.get_mut(&address1).unwrap().1.insert(slot20_key, account1_slot20_value);
+        state.commit(HashMap::from_iter([(
+            address1,
+            RevmAccount {
+                status: AccountStatus::Touched | AccountStatus::Created,
+                info: account1_new.into(),
+                storage: HashMap::from_iter([(
+                    slot20,
+                    EvmStorageSlot::new_changed(U256::ZERO, account1_slot20_value, 0),
+                )]),
+                transaction_id: 0,
+            },
+        )]));
+        state.merge_transitions(BundleRetention::PlainState);
+        assert_state_root(&state, &prestate, "recreated changed storage");
+    }
+
+    #[test]
+    fn prepend_state() {
+        let address1 = Address::random();
+        let address2 = Address::random();
+
+        let account1 = RevmAccountInfo { nonce: 1, ..Default::default() };
+        let account1_changed = RevmAccountInfo { nonce: 1, ..Default::default() };
+        let account2 = RevmAccountInfo { nonce: 1, ..Default::default() };
+
+        let present_state = BundleState::builder(2..=2)
+            .state_present_account_info(address1, account1_changed.clone())
+            .build();
+        assert_eq!(present_state.reverts.len(), 1);
+        let previous_state = BundleState::builder(1..=1)
+            .state_present_account_info(address1, account1)
+            .state_present_account_info(address2, account2.clone())
+            .build();
+        assert_eq!(previous_state.reverts.len(), 1);
+
+        let mut test: ExecutionOutcome = ExecutionOutcome {
+            bundle: present_state,
+            receipts: vec![vec![Receipt::default(); 2]; 1],
+            first_block: 2,
+            requests: Vec::new(),
+        };
+
+        test.prepend_state(previous_state);
+
+        assert_eq!(test.receipts.len(), 1);
+        let end_state = test.state();
+        assert_eq!(end_state.state.len(), 2);
+        // reverts num should stay the same.
+        assert_eq!(end_state.reverts.len(), 1);
+        // account1 is not overwritten.
+        assert_eq!(end_state.state.get(&address1).unwrap().info, Some(account1_changed));
+        // account2 got inserted
+        assert_eq!(end_state.state.get(&address2).unwrap().info, Some(account2));
+    }
+
+    #[test]
+    fn hashed_state_storage_root() {
+        let address = Address::random();
+        let hashed_address = keccak256(address);
+        let provider_factory = create_test_provider_factory();
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        let tx = provider_rw.tx_ref();
+
+        // insert initial account storage
+        let init_storage = HashedStorage::from_iter(
+            false,
+            [
+                "50000000000000000000000000000004253371b55351a08cb3267d4d265530b6",
+                "512428ed685fff57294d1a9cbb147b18ae5db9cf6ae4b312fa1946ba0561882e",
+                "51e6784c736ef8548f856909870b38e49ef7a4e3e77e5e945e0d5e6fcaa3037f",
+            ]
+            .into_iter()
+            .map(|str| (B256::from_str(str).unwrap(), U256::from(1))),
+        );
+        let mut state = HashedPostState::default();
+        state.storages.insert(hashed_address, init_storage.clone());
+        provider_rw.write_hashed_state(&state.clone().into_sorted()).unwrap();
+
+        // calculate database storage root and write intermediate storage nodes.
+        let StorageRootProgress::Complete(storage_root, _, storage_updates) =
+            StorageRoot::from_tx_hashed(tx, hashed_address)
+                .with_no_threshold()
+                .calculate(true)
+                .unwrap()
+        else {
+            panic!("no threshold for root");
+        };
+        assert_eq!(storage_root, storage_root_prehashed(init_storage.storage));
+        assert!(!storage_updates.is_empty());
+        provider_rw
+            .write_storage_trie_updates_sorted(core::iter::once((
+                &hashed_address,
+                &storage_updates.into_sorted(),
+            )))
+            .unwrap();
+
+        // destroy the storage and re-create with new slots
+        let updated_storage = HashedStorage::from_iter(
+            true,
+            [
+                "00deb8486ad8edccfdedfc07109b3667b38a03a8009271aac250cce062d90917",
+                "88d233b7380bb1bcdc866f6871c94685848f54cf0ee033b1480310b4ddb75fc9",
+            ]
+            .into_iter()
+            .map(|str| (B256::from_str(str).unwrap(), U256::from(1))),
+        );
+        let mut state = HashedPostState::default();
+        state.storages.insert(hashed_address, updated_storage.clone());
+        provider_rw.write_hashed_state(&state.clone().into_sorted()).unwrap();
+
+        // re-calculate database storage root
+        type TestStorageRoot<'a, TX, A> = StorageRoot<
+            reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
+            reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
+        >;
+        let is_v2 = provider_rw.cached_storage_settings().is_v2();
+        let storage_root = if is_v2 {
+            TestStorageRoot::<_, _, PackedKeyAdapter>::overlay_root(
+                tx,
+                address,
+                updated_storage.clone(),
+            )
+            .unwrap()
+        } else {
+            TestStorageRoot::<_, _, LegacyKeyAdapter>::overlay_root(
+                tx,
+                address,
+                updated_storage.clone(),
+            )
+            .unwrap()
+        };
+        assert_eq!(storage_root, storage_root_prehashed(updated_storage.storage));
+    }
+}


### PR DESCRIPTION
## Context

A database initialized via `init-state --without-evm` from a hashed-only state snapshot can contain accounts that exist only in `HashedAccounts` with no `PlainAccountState` entry (the snapshot carried no address preimage for them).

In the legacy layout (`storage_v2=false`), `LatestStateProvider` read only `PlainAccountState`, so it returned `None` for such accounts. This makes the execution/`latest` read path inconsistent with the historical/hashed representation for hashed-only-snapshot databases.

## Change

Marker-gated fallback in `LatestStateProviderRef::{basic_account, storage}`: when the `__hashed_only_state_snapshot__` marker is set and the plain lookup misses, read from the hashed tables (`HashedAccounts` / `HashedStorages`).

- Safe by construction: the marker is set only when a DB was built from a hashed-only snapshot; ordinary legacy DBs always hit plain state and never reach the fallback.
- Only affects `storage_v2=false`; `storage_v2=true` already reads the hashed tables.
- The historical read path (`HistoricalStateProviderRef`) is intentionally unchanged.
- Vendored via `[patch]` as `patches/reth-provider` (same mechanism as the existing `reth-trie-common` / `reth-transaction-pool` patches).

## Tests

Unit tests (`patches/reth-provider/src/providers/state/latest.rs`, `cargo test -p reth-provider` green): accounts present only in hashed tables / present in plain / absent, storage slots, marker on/off, plus the existing no-marker regression guard.

## Note for reviewers
The added `[workspace.dependencies]` entries (`reth-nippy-jar`, `reth-node-types`, `reth-ethereum-engine-primitives`, `reth-testing-utils`, `notify`, `rocksdb`) are transitive deps required by the vendored `reth-provider`; they pin rev `88505c7` to match the git dep. Drop the `[patch]` entry + these once the change lands upstream.