### PR TITLE
docs(preconf): fix inaccurate default timeout in --preconf.timeout-ms help

### DIFF
--- a/mantle-reth/crates/cli/src/args.rs
+++ b/mantle-reth/crates/cli/src/args.rs
@@ -87,7 +87,7 @@ pub struct PreconfArgs {
     pub to: Vec<Address>,
 
     /// Client-visible RPC oneshot timeout, in milliseconds. Default matches
-    /// [`mantle_reth_preconf::config::DEFAULT_PRECONF_TIMEOUT`] (200ms).
+    /// [`mantle_reth_preconf::config::DEFAULT_PRECONF_TIMEOUT`] (1s).
     #[arg(long = "preconf.timeout-ms")]
     pub timeout_ms: Option<u64>,
 


### PR DESCRIPTION
## What

The `--preconf.timeout-ms` doc comment in `mantle-reth/crates/cli/src/args.rs` claimed the default (`DEFAULT_PRECONF_TIMEOUT`) is **200ms**, but the constant is actually defined as `Duration::from_secs(1)` (**1s**).

```rust
// mantle-reth/crates/preconf/src/config.rs:12
pub const DEFAULT_PRECONF_TIMEOUT: Duration = Duration::from_secs(1);
```

The `config.rs` docstring already says "default 1s"; only the CLI help was wrong — likely confused with the neighbouring `--preconf.sweep-interval-ms` (which genuinely defaults to 200ms).

## Change

One-line doc fix: `(200ms)` → `(1s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)