### PR TITLE
chore(deps): drop the private revm-ghsa fork, pin revm + revm-inspectors by tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1389,12 +1389,6 @@ name = "asn1_der"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
-
-[[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
@@ -3138,7 +3132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5654,7 +5648,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5981,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",
@@ -9437,13 +9431,11 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "assert_matches",
  "eyre",
  "itertools 0.15.0",
  "metrics",
  "notify",
  "parking_lot",
- "rand 0.9.4",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9465,16 +9457,12 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tasks",
- "reth-testing-utils",
- "reth-tracing",
  "reth-trie",
  "reth-trie-db",
  "revm-database",
- "revm-database-interface",
  "revm-state",
  "rocksdb",
  "strum",
- "tempfile",
  "tokio",
  "tracing",
 ]
@@ -10313,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10331,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "bitvec",
  "phf",
@@ -10342,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10358,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10373,7 +10361,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -10386,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "auto_impl",
  "either",
@@ -10399,7 +10387,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10417,7 +10405,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "auto_impl",
  "either",
@@ -10434,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.39.0"
-source = "git+https://github.com/mantle-xyz/revm-inspectors?branch=mantle-elysium#e635cd090d616a4415ce8dbe35f4f9478c9304f5"
+source = "git+https://github.com/mantle-xyz/revm-inspectors?tag=v0.39.0-mantle-arsia.1#d82824fbeb47cc50b37ea6f344831b65866508d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10453,7 +10441,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10465,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10490,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10501,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?tag=v107-mantle-arsia.1#1ed03aace7313c8f52a7282983a0c46cc8691d0e"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -10750,7 +10738,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10830,7 +10818,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11438,7 +11426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11636,7 +11624,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12852,7 +12840,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@
 #
 # Dependency strategy:
 #   reth crates    → paradigmxyz/reth rev 88505c7f (= v2.2.0, same as upstream op-reth pins)
-#   revm/op-revm   → mantle-xyz/revm branch mantle-elysium (Mantle fee model patches)
-#   revm-inspectors → mantle-xyz/revm-inspectors branch mantle-elysium
+#   revm/op-revm   → mantle-xyz/revm tag v107-mantle-arsia.1 (Mantle fee model + op-geth parity)
+#   revm-inspectors → mantle-xyz/revm-inspectors tag v0.39.0-mantle-arsia.1
 #   alloy-evm      → crates.io 0.34.0 (upstream, no Mantle patches; see mantle-v2#359)
 #   alloy-op-evm   → mantle-xyz/mantle-v2 branch mantle-elysium
 #   alloy-op-hardforks → mantle-xyz/mantle-v2 branch mantle-elysium
@@ -236,23 +236,23 @@ reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdeb
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4", default-features = false }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4" }
 
-# ==================== REVM (Mantle fork: revm-ghsa private fork, pinned by rev) ====================
+# ==================== REVM (Mantle fork: mantle-xyz/revm, pinned by tag) ====================
 # Release-line pin: revm family points at the private GHSA fork (embargoed advisory fixes),
 # fixed by rev to keep the pin reproducible. revm-inspectors stays on the public fork below.
-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-database = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-state = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-context = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
 
 # ==================== REVM-INSPECTORS (Mantle fork: mantle-elysium branch) ====================
 # TODO: Switch to tag once mantle-elysium is tagged
-revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "mantle-elysium" }
+revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", tag = "v0.39.0-mantle-arsia.1" }
 
 # ==================== ALLOY-EVM (upstream crates.io, no Mantle patches; see mantle-v2#359) ====================
 alloy-evm = { version = "0.34.0", default-features = false }
@@ -262,8 +262,8 @@ alloy-evm = { version = "0.34.0", default-features = false }
 alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
 alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
 
-# ==================== OP-REVM (Mantle fork: revm-ghsa private fork, same repo as revm) ====================
-op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+# ==================== OP-REVM (Mantle fork: mantle-xyz/revm, same repo as revm) ====================
+op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
 
 # ==================== OP-ALLOY (Mantle: mantle-xyz/mantle-v2) ====================
 # TODO: Switch to tag once mantle-v2 Rust crates are tagged
@@ -431,21 +431,21 @@ reth-provider = { path = "patches/reth-provider" }
 # Without this, paradigmxyz/reth uses crates.io revm while we use git revm,
 # creating incompatible duplicate types in the dependency graph.
 [patch.crates-io]
-# revm family: revm-ghsa private fork, pinned by rev
-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+# revm family: mantle-xyz/revm, pinned by tag v107-mantle-arsia.1 (= mainnet baseline)
+revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-database = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-state = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-context = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
 # revm-inspectors: mantle-xyz/revm-inspectors mantle-elysium branch
-revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "mantle-elysium" }
-# op-revm: revm-ghsa private fork (same as workspace dep)
-op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", tag = "v0.39.0-mantle-arsia.1" }
+# op-revm: mantle-xyz/revm (same as workspace dep)
+op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
 # alloy-op-evm / alloy-op-hardforks: mantle-xyz/mantle-v2 (Mantle version)
 alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
@@ -455,23 +455,3 @@ op-alloy-network = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "
 op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 op-alloy-rpc-jsonrpsee = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
-
-# ==================== [patch."https://github.com/mantle-xyz/revm"] — transitive pin ====================
-# revm-inspectors (a separate repo) still depends on mantle-xyz/revm branch mantle-elysium
-# transitively. Without redirecting that source too, cargo pulls a SECOND public revm into the
-# graph and reth-rpc-eth-api fails with Inspector trait-bound errors. Pin the transitive source
-# to the same revm-ghsa rev so exactly one revm exists in the graph.
-[patch."https://github.com/mantle-xyz/revm"]
-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-handler = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-precompile = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }


### PR DESCRIPTION
Removes op-reth's dependency on the private advisory fork `revm-ghsa-5vfr-x84h-hmvf`. `GHSA-5vfr-x84h-hmvf` is now public and its fixes are merged into `mantle-xyz/revm`.

## Why this was blocking

The revm compiled into **`op-reth-v2.2.1-mantle-arsia.1` — the build running on mainnet — came entirely from a private repository** (all 13 revm crates pinned to `revm-ghsa…@99707e9f` in `Cargo.lock`). Two consequences:

1. **Node operators could not reproduce mainnet execution from public code.** Three consensus-relevant commits (deposit `CanTransfer`/EIP-3860 gates, Isthmus precompile input-size limits) existed only in the private fork, so a build from public `mantle-xyz/revm` diverged from mainnet.
2. **CI could not clone the private repo**, which is why checks on this repo's PRs have been failing.

## Changes

| dependency | before | after |
|---|---|---|
| revm family (13 crates) | `revm-ghsa-5vfr-x84h-hmvf` rev `99707e9f` | [`mantle-xyz/revm` tag `v107-mantle-arsia.1`](https://github.com/mantle-xyz/revm/releases/tag/v107-mantle-arsia.1) |
| revm-inspectors | branch `mantle-elysium` (floating) | [tag `v0.39.0-mantle-arsia.1`](https://github.com/mantle-xyz/revm-inspectors/releases/tag/v0.39.0-mantle-arsia.1) |
| `[patch."…/mantle-xyz/revm"]` block | 14 entries | **removed** |

The redirect block existed solely to force revm-inspectors' transitive *branch* reference onto the private fork. With both pinned by tag, exactly one revm resolves and the redirect is dead weight — see the note it carried about `reth-rpc-eth-api` failing with Inspector trait-bound errors when two revm sources coexist.

`v107-mantle-arsia.1` is **content-identical** to the revm in `op-reth-v2.2.1-mantle-arsia.1` (verified: `git diff v107-mantle-arsia.1 99707e9f` is empty), so this is a source change, not a behaviour change.

## Verification

```
# one revm source, no private references
Cargo.lock: 13x revm?tag=v107-mantle-arsia.1#1ed03aac
            0 occurrences of revm-ghsa

cargo check -p reth-rpc-eth-api   # passes (the duplicate-revm failure point)
cargo check --workspace           # clean
cargo test --workspace --no-run   # clean
```

Prerequisites, both merged: mantle-xyz/revm#26 + #36, mantle-xyz/revm-inspectors#12 + #13.

## Out of scope

`alloy-op-*` / `op-alloy-*` still track `mantle-xyz/mantle-v2` branch `mantle-elysium` — public repo, no private dependency, and pinning them is a separate change. `mantle-v2`, `kona` and `op-succinct` consume other revm version lines (revm-40, `v2.2.2`); aligning those is also separate.