### PR TITLE
fix(lint): satisfy clippy 1.94

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   pull_request:
-    branches: [mantle-elysium, main]
+    branches: [mantle-stage2, main]
   push:
-    branches: [mantle-elysium, main]
+    branches: [mantle-stage2, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ just pr
 3. `just test-doc` — exhaustive `--all-features` doctests (full from-scratch build; PR CI relies on the lighter default-feature doctests inside `test-ci` instead)
 
 CI (`.github/workflows/ci.yml`) runs `lint` and `test` (`just test-ci`) in
-parallel on every PR to `mantle-elysium` and `main`. Running `just pr` first
+parallel on every PR to `mantle-stage2` and `main`. Running `just pr` first
 avoids round-trips waiting on CI.
 
 ## Test tiers

--- a/mantle-reth/crates/cli/src/args.rs
+++ b/mantle-reth/crates/cli/src/args.rs
@@ -105,11 +105,11 @@ pub struct PreconfArgs {
     #[arg(long = "preconf.slot-duration-ms")]
     pub slot_duration_ms: Option<u64>,
 
-    /// Per-tx gas cap for preconf-eligible txs. Default 2_000_000.
+    /// Per-tx gas cap for preconf-eligible txs. Default `2_000_000`.
     #[arg(long = "preconf.max-gas-per-tx")]
     pub max_gas_per_tx: Option<u64>,
 
-    /// Cumulative preconf gas budget per block. Default 6_000_000. Must be
+    /// Cumulative preconf gas budget per block. Default `6_000_000`. Must be
     /// `>=` `preconf.max-gas-per-tx` (checked by `PreconfConfig::validate`).
     #[arg(long = "preconf.max-gas-per-block")]
     pub max_gas_per_block: Option<u64>,
@@ -119,7 +119,7 @@ pub struct PreconfArgs {
     #[arg(long = "preconf.rejournal-interval-secs")]
     pub rejournal_interval_secs: Option<u64>,
 
-    /// Journal file size ceiling, in bytes. Default 1 GiB (1_073_741_824).
+    /// Journal file size ceiling, in bytes. Default 1 GiB (`1_073_741_824`).
     /// Above this, rotation renames the current file and starts a new one.
     /// Only meaningful when `--preconf.journal-path` is set.
     #[arg(long = "preconf.journal-max-size")]

--- a/mantle-reth/crates/integration-tests/tests/preconf/canon_cleanup.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/canon_cleanup.rs
@@ -14,7 +14,7 @@
 //!   submission. Guards per-sender scoping.
 //! - `canon_across_sequential_slots_forwards_on_every_new_job` — nonce 0/1/2 across three separate
 //!   slots; each canon runs `sync_fifo_forward_to_head` afresh. Guards against a caching bug that
-//!   would skip forward after the first PayloadJob.
+//!   would skip forward after the first `PayloadJob`.
 
 use super::helpers::{PreconfCfgBuilder, send_preconf};
 use crate::launch_preconf_node;
@@ -392,7 +392,7 @@ async fn canon_does_not_leak_across_senders() {
 }
 
 /// Sequential canon across three slots, one tx per slot. Verifies
-/// `sync_fifo_forward_to_head` runs on every new PayloadJob (not just
+/// `sync_fifo_forward_to_head` runs on every new `PayloadJob` (not just
 /// the first) and that per-slot state does not leak into later blocks.
 ///
 /// Complements `canon_of_multi_nonce_batch_permits_higher_nonce_in_next_slot`,
@@ -401,7 +401,7 @@ async fn canon_does_not_leak_across_senders() {
 /// N times.
 ///
 /// Regression guard: a caching bug that skips
-/// `sync_fifo_forward_to_head` after the first PayloadJob would leak
+/// `sync_fifo_forward_to_head` after the first `PayloadJob` would leak
 /// slot-1 Success entries into slot 3's `replay_fifo_carryover`, and
 /// `reset_success_to_waiting` would try to re-apply them against a
 /// state where their nonces are already consumed → `BuilderRejected` /
@@ -446,7 +446,7 @@ async fn canon_across_sequential_slots_forwards_on_every_new_job() {
             .expect("resolve_kind")
             .expect("payload");
         let event =
-            rpc_task.await.expect("rpc join").expect(&format!("nonce={nonce} must succeed"));
+            rpc_task.await.expect("rpc join").unwrap_or_else(|_| panic!("nonce={nonce} must succeed"));
 
         assert!(
             matches!(event.status, PreconfStatus::Success),

--- a/mantle-reth/crates/integration-tests/tests/preconf/canon_cleanup.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/canon_cleanup.rs
@@ -445,8 +445,10 @@ async fn canon_across_sequential_slots_forwards_on_every_new_job() {
             .await
             .expect("resolve_kind")
             .expect("payload");
-        let event =
-            rpc_task.await.expect("rpc join").unwrap_or_else(|_| panic!("nonce={nonce} must succeed"));
+        let event = rpc_task
+            .await
+            .expect("rpc join")
+            .unwrap_or_else(|_| panic!("nonce={nonce} must succeed"));
 
         assert!(
             matches!(event.status, PreconfStatus::Success),

--- a/mantle-reth/crates/integration-tests/tests/preconf/chain_id_pair.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/chain_id_pair.rs
@@ -108,7 +108,7 @@ async fn preconf_happy_path_on_mantle_sepolia() {
     run_pair_case!(5003);
 }
 
-/// Mantle Hoodi (chain_id=50002) preconf happy path.
+/// Mantle Hoodi (`chain_id=50002`) preconf happy path.
 ///
 /// Pins mantle-reth's chain-id independence for the preconf pipeline:
 /// with `mantle_chain_spec_for(50002)` patched into the genesis, the

--- a/mantle-reth/crates/integration-tests/tests/preconf/gas_budgets.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/gas_budgets.rs
@@ -642,18 +642,8 @@ async fn replay_source_bypasses_block_gas_budget() {
     let journal_file = journal_dir.join("preconf.journal");
 
     let entries = [
-        JournalEntry {
-            hash: tx0_hash,
-            tx_rlp: tx0.clone(),
-            block_height: 1,
-            committed_at_ms: 0,
-        },
-        JournalEntry {
-            hash: tx1_hash,
-            tx_rlp: tx1.clone(),
-            block_height: 1,
-            committed_at_ms: 0,
-        },
+        JournalEntry { hash: tx0_hash, tx_rlp: tx0.clone(), block_height: 1, committed_at_ms: 0 },
+        JournalEntry { hash: tx1_hash, tx_rlp: tx1.clone(), block_height: 1, committed_at_ms: 0 },
     ];
     let mut buf = Vec::new();
     for entry in &entries {

--- a/mantle-reth/crates/integration-tests/tests/preconf/gas_budgets.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/gas_budgets.rs
@@ -644,13 +644,13 @@ async fn replay_source_bypasses_block_gas_budget() {
     let entries = [
         JournalEntry {
             hash: tx0_hash,
-            tx_rlp: tx0.clone().into(),
+            tx_rlp: tx0.clone(),
             block_height: 1,
             committed_at_ms: 0,
         },
         JournalEntry {
             hash: tx1_hash,
-            tx_rlp: tx1.clone().into(),
+            tx_rlp: tx1.clone(),
             block_height: 1,
             committed_at_ms: 0,
         },

--- a/mantle-reth/crates/integration-tests/tests/preconf/happy_path.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/happy_path.rs
@@ -1,6 +1,6 @@
 //! Happy-path preconf submission.
 //!
-//! Every test in this module starts a preconf-enabled MantleNode from
+//! Every test in this module starts a preconf-enabled `MantleNode` from
 //! scratch, submits a raw tx through `eth_sendRawTransactionWithPreconf`,
 //! and verifies:
 //!
@@ -495,7 +495,7 @@ async fn weth_deposit_carries_log_through_to_receipt() {
         0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x06,
     ]);
-    /// `deposit()` — keccak256("deposit()")[0..4].
+    /// `deposit()` — `keccak256("deposit()`")[0..4].
     const DEPOSIT_SELECTOR: [u8; 4] = [0xd0, 0xe3, 0x0d, 0xb0];
     /// `keccak256("Deposit(address,uint256)")` — WETH9's Deposit event.
     const DEPOSIT_EVENT_TOPIC: [u8; 32] = [

--- a/mantle-reth/crates/integration-tests/tests/preconf/helpers.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/helpers.rs
@@ -243,7 +243,7 @@ pub async fn send_preconf(
     http.request("eth_sendRawTransactionWithPreconf", vec![tx_rlp.to_string()]).await
 }
 
-/// Launch a preconf-enabled MantleNode.
+/// Launch a preconf-enabled `MantleNode`.
 ///
 /// Yields a tuple `(node_ctx, http, wallet, chain_id)` — the `NodeTestContext`
 /// (for engine-API / advance / assert helpers), a jsonrpsee HTTP client

--- a/mantle-reth/crates/integration-tests/tests/preconf/journal_size_rotation.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/journal_size_rotation.rs
@@ -81,7 +81,7 @@ async fn size_triggered_rotation_drops_sealed_entry() {
     let tx0 = signed_transfer(chain_id, &wallet, 0).await;
     let sample = JournalEntry {
         hash: keccak256(&tx0),
-        tx_rlp: tx0.clone().into(),
+        tx_rlp: tx0.clone(),
         block_height: 1,
         committed_at_ms: 1_700_000_000_000,
     };

--- a/mantle-reth/crates/integration-tests/tests/preconf/no_tx_pool.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/no_tx_pool.rs
@@ -73,12 +73,8 @@ async fn no_tx_pool_gates_replay_source_entry() {
     std::fs::create_dir_all(&journal_dir).expect("mkdir journal_dir");
     let journal_file = journal_dir.join("preconf.journal");
 
-    let entry = JournalEntry {
-        hash: tx_hash,
-        tx_rlp: raw_tx.clone(),
-        block_height: 1,
-        committed_at_ms: 0,
-    };
+    let entry =
+        JournalEntry { hash: tx_hash, tx_rlp: raw_tx.clone(), block_height: 1, committed_at_ms: 0 };
     let mut line = serde_json::to_vec(&entry).expect("encode JournalEntry");
     line.push(b'\n');
     std::fs::write(&journal_file, &line).expect("write journal file");

--- a/mantle-reth/crates/integration-tests/tests/preconf/no_tx_pool.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/no_tx_pool.rs
@@ -75,7 +75,7 @@ async fn no_tx_pool_gates_replay_source_entry() {
 
     let entry = JournalEntry {
         hash: tx_hash,
-        tx_rlp: raw_tx.clone().into(),
+        tx_rlp: raw_tx.clone(),
         block_height: 1,
         committed_at_ms: 0,
     };
@@ -142,7 +142,7 @@ async fn no_tx_pool_gates_replay_source_entry() {
     // build did not consume it, only deferred it.
     let attrs_2 = node.payload.next_attributes();
     assert!(
-        attrs_2.0.no_tx_pool.unwrap_or(false) == false,
+        !attrs_2.0.no_tx_pool.unwrap_or(false),
         "sanity: default mantle_payload_attributes must produce no_tx_pool=false/None",
     );
     let fcu_state_2 = node.current_forkchoice_state().expect("forkchoice state 2");

--- a/mantle-reth/crates/integration-tests/tests/preconf/predeploy_genesis.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/predeploy_genesis.rs
@@ -10,7 +10,7 @@
 //! This file verifies two things:
 //! 1. A node launched against that spec is still functional end-to-end: the preconf happy-path
 //!    lands a whitelisted tx in the first block.
-//! 2. The L1Block predeploy actually has bytecode after boot — i.e. the fixture was carried through
+//! 2. The `L1Block` predeploy actually has bytecode after boot — i.e. the fixture was carried through
 //!    into the live in-memory state, not silently dropped by the spec-loader.
 
 use super::helpers::{PreconfCfgBuilder, mantle_chain_spec_with_predeploys_for, send_preconf};
@@ -22,7 +22,7 @@ use mantle_reth_rpc_ext::PreconfStatus;
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet};
 use reth_provider::StateProviderFactory;
 
-/// Canonical L1Block predeploy address on every OP-stack chain.
+/// Canonical `L1Block` predeploy address on every OP-stack chain.
 const L1_BLOCK_ADDR: Address = Address::new([
     0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x15,

--- a/mantle-reth/crates/integration-tests/tests/preconf/predeploy_genesis.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/predeploy_genesis.rs
@@ -10,8 +10,8 @@
 //! This file verifies two things:
 //! 1. A node launched against that spec is still functional end-to-end: the preconf happy-path
 //!    lands a whitelisted tx in the first block.
-//! 2. The `L1Block` predeploy actually has bytecode after boot — i.e. the fixture was carried through
-//!    into the live in-memory state, not silently dropped by the spec-loader.
+//! 2. The `L1Block` predeploy actually has bytecode after boot — i.e. the fixture was carried
+//!    through into the live in-memory state, not silently dropped by the spec-loader.
 
 use super::helpers::{PreconfCfgBuilder, mantle_chain_spec_with_predeploys_for, send_preconf};
 use crate::launch_preconf_node;

--- a/mantle-reth/crates/integration-tests/tests/preconf/replacement.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/replacement.rs
@@ -463,10 +463,10 @@ async fn canceled_slot_replaceable_by_different_hash() {
 ///    `apply_one_preconf` marks the fifo entry `Failed` and sends the Err to the responder.
 ///    Client's `send_preconf` awaits and receives `Err(Call { "builder rejected: ..." })`.
 ///
-/// 4. After the `sweep_ticker` fires and pool arm applies the shadow tx nonce=0, the block is sealed
-///    containing just that tx. Canon slot 1 → sender's on-chain nonce = 1; the `Failed` fifo entry
-///    at nonce=1 survives `sync_fifo_forward_to_head` (nonce=1 is NOT < the new on-chain nonce of
-///    1).
+/// 4. After the `sweep_ticker` fires and pool arm applies the shadow tx nonce=0, the block is
+///    sealed containing just that tx. Canon slot 1 → sender's on-chain nonce = 1; the `Failed` fifo
+///    entry at nonce=1 survives `sync_fifo_forward_to_head` (nonce=1 is NOT < the new on-chain
+///    nonce of 1).
 ///
 /// 5. Slot 2: the client submits a **replacement** preconf tx: same sender, nonce=1, but different
 ///    `value` (⇒ different hash). The pool validator's

--- a/mantle-reth/crates/integration-tests/tests/preconf/replacement.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/replacement.rs
@@ -456,14 +456,14 @@ async fn canceled_slot_replaceable_by_different_hash() {
 ///
 /// 3. Build loop's `biased` select! prioritises `fifo_rx.recv` over the pool arm, whose gate
 ///    `pool_gas_used < pool_quota` is blocked at build start because `pool_quota = 0` until the
-///    first `sweep_ticker.tick()` fires (~sweep_interval = 200ms). So the preconf tx nonce=1 is
+///    first `sweep_ticker.tick()` fires (~`sweep_interval` = 200ms). So the preconf tx nonce=1 is
 ///    dispatched BEFORE the pool arm applies the shadow tx nonce=0. Reth's builder sees the
 ///    in-flight state's sender nonce is still 0, but tx.nonce=1 — nonce mismatch → the builder
 ///    returns Err(nonce_...) → `apply_preconf_tx` wraps as `PreconfError::BuilderRejected(...)` →
 ///    `apply_one_preconf` marks the fifo entry `Failed` and sends the Err to the responder.
 ///    Client's `send_preconf` awaits and receives `Err(Call { "builder rejected: ..." })`.
 ///
-/// 4. After the sweep_ticker fires and pool arm applies the shadow tx nonce=0, the block is sealed
+/// 4. After the `sweep_ticker` fires and pool arm applies the shadow tx nonce=0, the block is sealed
 ///    containing just that tx. Canon slot 1 → sender's on-chain nonce = 1; the `Failed` fifo entry
 ///    at nonce=1 survives `sync_fifo_forward_to_head` (nonce=1 is NOT < the new on-chain nonce of
 ///    1).
@@ -483,10 +483,10 @@ async fn canceled_slot_replaceable_by_different_hash() {
 /// **Marked `#[ignore]` because the setup is time-sensitive under
 /// parallel test load**: the fifo `Failed` trigger relies on the biased
 /// select! running preconf dispatch BEFORE the pool arm's first
-/// sweep_ticker tick applies the shadow tx nonce=0. Under contention,
+/// `sweep_ticker` tick applies the shadow tx nonce=0. Under contention,
 /// reth's canon-state propagation between slot 1 and slot 2 can also
 /// lag past the 500ms sleep, leaving the state provider observing the
-/// pre-block-1 snapshot when slot 2's PayloadJob queries it — the
+/// pre-block-1 snapshot when slot 2's `PayloadJob` queries it — the
 /// replacement tx then sees `expected nonce = 0` at the builder and
 /// fails again with `BuilderRejected("nonce 1 too high")`. In
 /// isolation (`cargo test ... failed_slot_replaceable_by_different_hash

--- a/mantle-reth/crates/integration-tests/tests/preconf/restart_replay.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/restart_replay.rs
@@ -78,7 +78,7 @@ async fn journal_replay_lands_promised_tx_in_next_block() {
 
     let entry = JournalEntry {
         hash: tx_hash,
-        tx_rlp: raw_tx.clone().into(),
+        tx_rlp: raw_tx.clone(),
         block_height: 1,
         committed_at_ms: 0,
     };
@@ -176,19 +176,19 @@ async fn journal_replay_multiple_entries_all_land_in_first_block() {
     let entries = [
         JournalEntry {
             hash: hash0,
-            tx_rlp: tx0.clone().into(),
+            tx_rlp: tx0.clone(),
             block_height: 1,
             committed_at_ms: 0,
         },
         JournalEntry {
             hash: hash1,
-            tx_rlp: tx1.clone().into(),
+            tx_rlp: tx1.clone(),
             block_height: 1,
             committed_at_ms: 0,
         },
         JournalEntry {
             hash: hash2,
-            tx_rlp: tx2.clone().into(),
+            tx_rlp: tx2.clone(),
             block_height: 1,
             committed_at_ms: 0,
         },
@@ -295,13 +295,13 @@ async fn journal_replay_across_multiple_senders() {
     let entries = [
         JournalEntry {
             hash: hash_a,
-            tx_rlp: tx_a.clone().into(),
+            tx_rlp: tx_a.clone(),
             block_height: 1,
             committed_at_ms: 0,
         },
         JournalEntry {
             hash: hash_b,
-            tx_rlp: tx_b.clone().into(),
+            tx_rlp: tx_b.clone(),
             block_height: 1,
             committed_at_ms: 0,
         },

--- a/mantle-reth/crates/integration-tests/tests/preconf/restart_replay.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/restart_replay.rs
@@ -76,12 +76,8 @@ async fn journal_replay_lands_promised_tx_in_next_block() {
     std::fs::create_dir_all(&journal_dir).expect("mkdir journal_dir");
     let journal_file = journal_dir.join("preconf.journal");
 
-    let entry = JournalEntry {
-        hash: tx_hash,
-        tx_rlp: raw_tx.clone(),
-        block_height: 1,
-        committed_at_ms: 0,
-    };
+    let entry =
+        JournalEntry { hash: tx_hash, tx_rlp: raw_tx.clone(), block_height: 1, committed_at_ms: 0 };
     let mut line = serde_json::to_vec(&entry).expect("encode JournalEntry");
     line.push(b'\n');
     std::fs::write(&journal_file, &line).expect("write journal file");
@@ -174,24 +170,9 @@ async fn journal_replay_multiple_entries_all_land_in_first_block() {
     let hash2 = keccak256(&tx2);
 
     let entries = [
-        JournalEntry {
-            hash: hash0,
-            tx_rlp: tx0.clone(),
-            block_height: 1,
-            committed_at_ms: 0,
-        },
-        JournalEntry {
-            hash: hash1,
-            tx_rlp: tx1.clone(),
-            block_height: 1,
-            committed_at_ms: 0,
-        },
-        JournalEntry {
-            hash: hash2,
-            tx_rlp: tx2.clone(),
-            block_height: 1,
-            committed_at_ms: 0,
-        },
+        JournalEntry { hash: hash0, tx_rlp: tx0.clone(), block_height: 1, committed_at_ms: 0 },
+        JournalEntry { hash: hash1, tx_rlp: tx1.clone(), block_height: 1, committed_at_ms: 0 },
+        JournalEntry { hash: hash2, tx_rlp: tx2.clone(), block_height: 1, committed_at_ms: 0 },
     ];
     let (journal_file, journal_dir) = write_journal(&entries);
 
@@ -293,18 +274,8 @@ async fn journal_replay_across_multiple_senders() {
     let hash_b = keccak256(&tx_b);
 
     let entries = [
-        JournalEntry {
-            hash: hash_a,
-            tx_rlp: tx_a.clone(),
-            block_height: 1,
-            committed_at_ms: 0,
-        },
-        JournalEntry {
-            hash: hash_b,
-            tx_rlp: tx_b.clone(),
-            block_height: 1,
-            committed_at_ms: 0,
-        },
+        JournalEntry { hash: hash_a, tx_rlp: tx_a.clone(), block_height: 1, committed_at_ms: 0 },
+        JournalEntry { hash: hash_b, tx_rlp: tx_b.clone(), block_height: 1, committed_at_ms: 0 },
     ];
     let (journal_file, journal_dir) = write_journal(&entries);
 

--- a/mantle-reth/crates/integration-tests/tests/preconf/timeout.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/timeout.rs
@@ -5,7 +5,7 @@
 //! - `timeout_recovered_by_same_hash_resubmit` — same-hash retry after Timeout revives the fifo
 //!   entry (`push_if_absent`'s reclaimable branch) and the tx lands on the next build.
 //! - `dispatch_safety_margin_marks_timeout_before_apply` — dispatch- layer preemptive timeout (40ms
-//!   SAFETY_MARGIN before the SLA deadline) fires from within `apply_one_preconf`, surfacing as
+//!   `SAFETY_MARGIN` before the SLA deadline) fires from within `apply_one_preconf`, surfacing as
 //!   `Err(Call)` at the wire (distinct from RPC-layer `Ok(Timeout)`).
 //!
 //! - `race_resolution_returns_success_when_apply_completes_after_deadline` — RPC deadline fires

--- a/mantle-reth/crates/integration-tests/tests/preconf/validation_reject.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/validation_reject.rs
@@ -258,7 +258,7 @@ async fn signed_transfer_with_value(
 /// the client as `Err(Call { message: "pool rejected: <inner>" })`.
 ///
 /// Setup: submit a preconf-eligible whitelisted tx with `gas_limit = 20_000`,
-/// under the 21_000 intrinsic gas required for a plain transfer. The
+/// under the `21_000` intrinsic gas required for a plain transfer. The
 /// preconf per-tx ceiling is set high enough (`preconf_max_gas_per_tx =
 /// 1_000_000`) that it does NOT fire first — the underlying
 /// `OpTransactionValidator` is the one that catches this.
@@ -375,9 +375,9 @@ async fn insufficient_funds_pool_rejects() {
 /// `tx.gas_limit > block.gas_limit` is rejected at pool admission and
 /// surfaced as `Err(Call { message: "pool rejected: <inner>" })`.
 ///
-/// Setup: block_gas_limit is 30_000_000 (0x1c9c380, see `assets/genesis.json`).
+/// Setup: `block_gas_limit` is `30_000_000` (0x1c9c380, see `assets/genesis.json`).
 /// Submit a whitelisted preconf tx with `gas_limit = 40_000_000`. The
-/// preconf per-tx ceiling is deliberately set to 100_000_000 so it does
+/// preconf per-tx ceiling is deliberately set to `100_000_000` so it does
 /// NOT catch this first — the underlying pool validator's block-gas-limit
 /// check is what fires.
 ///

--- a/mantle-reth/crates/preconf/src/apply.rs
+++ b/mantle-reth/crates/preconf/src/apply.rs
@@ -367,10 +367,10 @@ mod tests {
         );
     }
 
-    /// R7 D — revert_data's first 4 bytes are the ABI selector. The
+    /// R7 D — `revert_data`'s first 4 bytes are the ABI selector. The
     /// canonical `Error(string)` selector is `0x08c379a0` (see solc
     /// docs / EIP-838). SDKs downstream (op-geth compat) unpack via
-    /// this selector; ensuring build_receipt preserves the selector
+    /// this selector; ensuring `build_receipt` preserves the selector
     /// prefix intact is a byte-level contract, not a doc.
     #[test]
     fn build_receipt_revert_data_preserves_error_selector() {
@@ -401,7 +401,7 @@ mod tests {
         );
     }
 
-    /// R7 D — build_receipt's `Halt` branch renders `HaltReason` via
+    /// R7 D — `build_receipt`'s `Halt` branch renders `HaltReason` via
     /// its `Debug` impl. Existing coverage only checks
     /// `OutOfGas::Basic`; a Debug-format shift on other variants would
     /// silently degrade log messages. Spot-check a few common variants

--- a/mantle-reth/crates/preconf/src/builder/dispatch.rs
+++ b/mantle-reth/crates/preconf/src/builder/dispatch.rs
@@ -373,24 +373,25 @@ pub(super) async fn apply_one_preconf<F>(
     // our earlier gate reads and this acquisition; running `apply_fn`
     // now would violate the invariant "committed to builder state ⇒
     // wire not Timeout".
-    if let Some(re_entry) = fifo.find_by_hash(&hash).await
-        && re_entry.status != PreconfStatus::Waiting {
-            trace!(
-                target: "mantle::preconf::dispatch",
-                ?hash, status = ?re_entry.status,
-                "status flipped before we acquired apply_lock; skipping apply"
-            );
-            let reason = match re_entry.status {
-                PreconfStatus::Timeout => {
-                    PreconfError::Timeout { timeout_ms: cfg.preconf_timeout.as_millis() as u64 }
-                }
-                other => PreconfError::Internal(format!(
-                    "preconf entry flipped to {other:?} before apply_lock"
-                )),
-            };
-            loop_state.record_excluded(hash, reason);
-            return;
-        }
+    if let Some(re_entry) = fifo.find_by_hash(&hash).await &&
+        re_entry.status != PreconfStatus::Waiting
+    {
+        trace!(
+            target: "mantle::preconf::dispatch",
+            ?hash, status = ?re_entry.status,
+            "status flipped before we acquired apply_lock; skipping apply"
+        );
+        let reason = match re_entry.status {
+            PreconfStatus::Timeout => {
+                PreconfError::Timeout { timeout_ms: cfg.preconf_timeout.as_millis() as u64 }
+            }
+            other => PreconfError::Internal(format!(
+                "preconf entry flipped to {other:?} before apply_lock"
+            )),
+        };
+        loop_state.record_excluded(hash, reason);
+        return;
+    }
 
     // ── Apply via caller-supplied closure (real EVM in production,
     //    synthetic receipt in tests). ────────────────────────────────

--- a/mantle-reth/crates/preconf/src/builder/dispatch.rs
+++ b/mantle-reth/crates/preconf/src/builder/dispatch.rs
@@ -373,8 +373,8 @@ pub(super) async fn apply_one_preconf<F>(
     // our earlier gate reads and this acquisition; running `apply_fn`
     // now would violate the invariant "committed to builder state ⇒
     // wire not Timeout".
-    if let Some(re_entry) = fifo.find_by_hash(&hash).await {
-        if re_entry.status != PreconfStatus::Waiting {
+    if let Some(re_entry) = fifo.find_by_hash(&hash).await
+        && re_entry.status != PreconfStatus::Waiting {
             trace!(
                 target: "mantle::preconf::dispatch",
                 ?hash, status = ?re_entry.status,
@@ -391,7 +391,6 @@ pub(super) async fn apply_one_preconf<F>(
             loop_state.record_excluded(hash, reason);
             return;
         }
-    }
 
     // ── Apply via caller-supplied closure (real EVM in production,
     //    synthetic receipt in tests). ────────────────────────────────
@@ -801,7 +800,7 @@ mod tests {
 
     /// Cumulative tracking: successful applies increment
     /// `preconf_gas_used` by the receipt's `gas_used`. Three sequential
-    /// LoopState `pool_gas_used` tracks the pool best-tx sweep independently
+    /// `LoopState` `pool_gas_used` tracks the pool best-tx sweep independently
     /// of `preconf_gas_used` — `record_pool_gas` must accumulate and stay
     /// separate from `preconf_gas_used`.
     #[test]
@@ -857,7 +856,7 @@ mod tests {
     ///
     /// - NOT invoke `apply_fn`
     /// - NOT touch responders
-    /// - NOT record the hash in loop_state (allowing a future re-push of the same hash to proceed
+    /// - NOT record the hash in `loop_state` (allowing a future re-push of the same hash to proceed
     ///   normally)
     #[tokio::test]
     async fn missing_fifo_entry_is_silent_noop() {
@@ -943,9 +942,9 @@ mod tests {
         }
     }
 
-    /// reconcile_lagged applies pending fifo entries in FIFO (insertion)
-    /// order. Locks the `snapshot()` → VecDeque `order` guarantee so a
-    /// future refactor to HashMap iteration would fail this test.
+    /// `reconcile_lagged` applies pending fifo entries in FIFO (insertion)
+    /// order. Locks the `snapshot()` → `VecDeque` `order` guarantee so a
+    /// future refactor to `HashMap` iteration would fail this test.
     #[tokio::test]
     async fn reconcile_lagged_applies_all_pending_in_fifo_order() {
         use std::cell::RefCell;
@@ -973,9 +972,9 @@ mod tests {
         assert_eq!(state.excluded_len(), 0);
     }
 
-    /// reconcile_lagged relies on `apply_one_preconf`'s gate ① for
+    /// `reconcile_lagged` relies on `apply_one_preconf`'s gate ① for
     /// dedup. Hashes already in `loop_state.committed` must be skipped
-    /// (apply_fn not invoked).
+    /// (`apply_fn` not invoked).
     #[tokio::test]
     async fn reconcile_lagged_dedups_against_prior_committed() {
         use std::cell::Cell;
@@ -1005,7 +1004,7 @@ mod tests {
         assert_eq!(state.committed_len(), 3);
     }
 
-    /// reconcile_lagged shares `LoopState.preconf_gas_used` with the
+    /// `reconcile_lagged` shares `LoopState.preconf_gas_used` with the
     /// broadcast path. Pre-loading `preconf_gas_used` so the second tx
     /// would exceed `preconf_max_gas_per_block` must cause it to be
     /// Canceled via the same gate `apply_one_preconf` uses.
@@ -1044,10 +1043,10 @@ mod tests {
         assert_eq!(e2.status, PreconfStatus::Canceled);
     }
 
-    /// reconcile_lagged iterates the whole `order` VecDeque including
+    /// `reconcile_lagged` iterates the whole `order` `VecDeque` including
     /// entries in terminal states (mark_* keeps entries until forward /
-    /// clean_reclaimable removes them). Those must be filtered by
-    /// `apply_one_preconf`'s status gate — apply_fn only fires for the
+    /// `clean_reclaimable` removes them). Those must be filtered by
+    /// `apply_one_preconf`'s status gate — `apply_fn` only fires for the
     /// Waiting entry.
     #[tokio::test]
     async fn reconcile_lagged_skips_non_waiting_entries() {
@@ -1089,7 +1088,7 @@ mod tests {
     //    replay must never silently drop a promised tx). ─────────────
 
     /// Journal-replayed entries bypass the pre-apply deadline gate.
-    /// Even after the timeout has elapsed since insertion, apply_fn
+    /// Even after the timeout has elapsed since insertion, `apply_fn`
     /// still fires and the tx transitions to Success — the RPC-source
     /// counterpart under the same conditions goes to Timeout (see
     /// `deadline_skip_marks_timeout_and_cancels_responder`).
@@ -1148,7 +1147,7 @@ mod tests {
         assert_eq!(entry.status, PreconfStatus::Success);
     }
 
-    /// Mixed sources share the LoopState `preconf_gas_used` accounting:
+    /// Mixed sources share the `LoopState` `preconf_gas_used` accounting:
     /// a Journal tx that bypasses the gate still contributes to the
     /// running total, so a subsequent RPC tx sees the true cost and
     /// can be gated properly.

--- a/mantle-reth/crates/preconf/src/builder/payload_builder.rs
+++ b/mantle-reth/crates/preconf/src/builder/payload_builder.rs
@@ -171,7 +171,7 @@ impl<Pool, Client, Evm> PreconfPayloadBuilder<Pool, Client, Evm> {
 /// Convert an `Arc<TxEnvelope>` to the pipeline's `N::SignedTx` and
 /// recover its signer, then apply against the in-flight builder.
 ///
-/// Shared helper used both by the carryover preamble and the fifo_rx
+/// Shared helper used both by the carryover preamble and the `fifo_rx`
 /// arm of the select! loop; the callers wrap this in a thin closure
 /// that captures `&mut builder`, which is required so
 /// `dispatch::apply_one_preconf`'s `apply_fn` callback signature
@@ -1153,7 +1153,7 @@ mod tests {
     struct FakePostExecTx;
     impl From<alloy_primitives::Sealed<op_alloy_consensus::TxPostExec>> for FakePostExecTx {
         fn from(_: alloy_primitives::Sealed<op_alloy_consensus::TxPostExec>) -> Self {
-            FakePostExecTx
+            Self
         }
     }
 
@@ -1282,7 +1282,7 @@ mod tests {
         assert_eq!(s.first_offset, TEST_INTERVAL);
     }
 
-    /// Drift exceeds slot_duration (misconfigured attrs.timestamp far
+    /// Drift exceeds `slot_duration` (misconfigured attrs.timestamp far
     /// in the future). Clamped to `slot_duration` — no unbounded quota.
     #[test]
     fn quota_schedule_over_long_drift_clamps_to_slot_duration() {
@@ -1340,7 +1340,7 @@ mod tests {
         }
     }
 
-    /// No DA limits configured (pre-Jovian, no da_config) → every tx passes.
+    /// No DA limits configured (pre-Jovian, no `da_config`) → every tx passes.
     /// This is the default integration-harness state, so preconf behaviour
     /// is unchanged unless an operator sets DA limits.
     #[test]

--- a/mantle-reth/crates/preconf/src/canon_handler.rs
+++ b/mantle-reth/crates/preconf/src/canon_handler.rs
@@ -15,10 +15,10 @@
 //!   `PayloadJob` start (see
 //!   `builder::payload_builder::sync_fifo_forward_to_head`). Rationale:
 //!   the async fanout of `CanonStateNotification` raced with the next
-//!   FCU — a new PayloadJob could observe stale `Success` entries and
+//!   FCU — a new `PayloadJob` could observe stale `Success` entries and
 //!   incorrectly replay them via `reset_success_to_waiting`, silently
 //!   double-counting `preconf_gas_used` in the fresh slot. Running the
-//!   forward from the PayloadJob prologue guarantees fifo consistency
+//!   forward from the `PayloadJob` prologue guarantees fifo consistency
 //!   with the parent block state before any dispatch decision.
 //! - **Reverted chain**: a reorg produces a warn log for every reverted tx whose hash is tracked
 //!   (journal `sealed` set when persistence is enabled, fifo membership as fallback). This handler

--- a/mantle-reth/crates/preconf/src/pool_ext/preconf_pool_listener.rs
+++ b/mantle-reth/crates/preconf/src/pool_ext/preconf_pool_listener.rs
@@ -47,7 +47,7 @@ pub struct PreconfPoolListener<P, Tx, Cons> {
     /// Optional journal handle used to distinguish reorg-reinjected txs
     /// from fresh RPC submissions. When `Some`, every incoming pool event
     /// is checked against `journal.sealed`; a hit means the tx was
-    /// previously promised to a client (mark_sealed fired on an earlier
+    /// previously promised to a client (`mark_sealed` fired on an earlier
     /// canon commit) and must bypass the deadline / block-gas-budget
     /// gates — so we push with [`PreconfSource::Replay`] to align
     /// with the SLA "receipt returned → tx must land" contract. `None`

--- a/mantle-reth/crates/preconf/src/preconf_tx_set.rs
+++ b/mantle-reth/crates/preconf/src/preconf_tx_set.rs
@@ -501,7 +501,7 @@ impl PreconfTxSet {
     /// `Waiting → Failed`. **Soft terminal** — like `Timeout` /
     /// `Canceled`, a `Failed` entry is **revivable** via same-hash
     /// resubmit (`push_if_absent`'s Timeout/Canceled/Failed → Waiting
-    /// branch). Called by builder when apply_fn returned Err
+    /// branch). Called by builder when `apply_fn` returned Err
     /// (in-flight nonce / balance race, block gas exhausted at builder
     /// level). **tx NOT on chain**.
     ///
@@ -683,7 +683,7 @@ impl PreconfTxSet {
     /// violated (both slots occupied for the same hash), the ghost
     /// responder in `pending_responders` is dropped rather than leaked as
     /// a zombie — its client will observe `RecvError` instead of a stuck
-    /// oneshot. Minimal-cost defense; no logging or debug_assert because
+    /// oneshot. Minimal-cost defense; no logging or `debug_assert` because
     /// the primary slot's caller already saw a Some(responder) result.
     pub async fn cancel_responder(&self, hash: &TxHash, err: PreconfError) {
         let responder = {
@@ -711,7 +711,7 @@ impl PreconfTxSet {
     /// `pending_responders.remove(hash)` drops any ghost that would
     /// otherwise leak under invariant #2 violation. The caller sends
     /// Ok(receipt) via the returned Sender; the ghost's receiver
-    /// observes RecvError.
+    /// observes `RecvError`.
     pub async fn take_responder(
         &self,
         hash: &TxHash,
@@ -1285,7 +1285,7 @@ mod tests {
     /// `drop_hash` must be tolerant of partially-populated index state: if
     /// `entries[hash]` is missing, it should still clean `order` /
     /// `by_sender` / `pending_responders`. Non-self-heal companion to R6's
-    /// "dangling by_sender" case — here the direction is opposite: entry
+    /// "dangling `by_sender`" case — here the direction is opposite: entry
     /// gone first, aux indices need scrubbing.
     #[tokio::test]
     async fn drop_hash_tolerates_missing_entry() {
@@ -1315,7 +1315,7 @@ mod tests {
 
     /// `cancel_responder` belt-and-braces cleanup: even if invariant #2 is
     /// violated (both `entry.responder` and `pending_responders[hash]` hold
-    /// a responder), the ghost in pending_responders must be dropped so the
+    /// a responder), the ghost in `pending_responders` must be dropped so the
     /// client observes `RecvError` rather than waiting forever. The
     /// primary slot (entry.responder) still gets the typed `Err(...)`.
     #[tokio::test]
@@ -1362,7 +1362,7 @@ mod tests {
     /// invariant #2 violation (both slots occupied), `take_responder`
     /// returns the primary responder AND drops the ghost. Caller then
     /// sends Ok(receipt) via the returned Sender; ghost's receiver sees
-    /// RecvError.
+    /// `RecvError`.
     #[tokio::test]
     async fn take_responder_drops_ghost_pending_slot() {
         let set = PreconfTxSet::new(4);

--- a/mantle-reth/crates/preconf/src/types.rs
+++ b/mantle-reth/crates/preconf/src/types.rs
@@ -118,6 +118,7 @@ pub enum PreconfStatus {
 ///       crash.
 ///     - **Reorg reinject** — the pool re-admits a previously sealed tx after reorg; the pool
 ///       listener detects the case via `journal.sealed` membership.
+///
 ///   In both cases the Mantle preconf SLA (*"once a receipt has been
 ///   returned to the client, the tx must land on chain"*) requires
 ///   these entries to **bypass** the deadline and per-block gas budget

--- a/patches/reth-provider/src/providers/rocksdb/provider.rs
+++ b/patches/reth-provider/src/providers/rocksdb/provider.rs
@@ -2701,6 +2701,9 @@ impl Iterator for RocksDBRawIter<'_> {
 /// Iterator over a `RocksDB` table within a transaction.
 ///
 /// Yields decoded `(Key, Value)` pairs. Sees uncommitted writes.
+// [MANTLE PATCH] allow(unnameable_types): re-exported through a private module;
+// upstream reth has the same shape. Newer clippy promotes this to deny under -D warnings.
+#[allow(unnameable_types)]
 pub struct RocksTxIter<'tx, T: Table> {
     inner: rocksdb::DBIteratorWithThreadMode<'tx, Transaction<'tx, OptimisticTransactionDB>>,
     _marker: std::marker::PhantomData<T>,

--- a/patches/reth-provider/src/providers/static_file/manager.rs
+++ b/patches/reth-provider/src/providers/static_file/manager.rs
@@ -267,6 +267,9 @@ impl<N: NodePrimitives> Deref for StaticFileProvider<N> {
 
 /// [`StaticFileProviderInner`] manages all existing [`StaticFileJarProvider`].
 #[derive(Debug)]
+// [MANTLE PATCH] allow(unnameable_types): re-exported through a private module;
+// upstream reth has the same shape. Newer clippy promotes this to deny under -D warnings.
+#[allow(unnameable_types)]
 pub struct StaticFileProviderInner<N> {
     /// Maintains a map which allows for concurrent access to different `NippyJars`, over different
     /// segments and ranges.

--- a/patches/reth-provider/src/providers/static_file/metrics.rs
+++ b/patches/reth-provider/src/providers/static_file/metrics.rs
@@ -8,6 +8,9 @@ use strum::{EnumIter, IntoEnumIterator};
 
 /// Metrics for the static file provider.
 #[derive(Debug)]
+// [MANTLE PATCH] allow(unnameable_types): re-exported through a private module;
+// upstream reth has the same shape. Newer clippy promotes this to deny under -D warnings.
+#[allow(unnameable_types)]
 pub struct StaticFileProviderMetrics {
     segments: StaticFileMap<StaticFileSegmentMetrics>,
     segment_operations: HashMap<

--- a/patches/reth-provider/src/providers/static_file/mod.rs
+++ b/patches/reth-provider/src/providers/static_file/mod.rs
@@ -26,6 +26,9 @@ type LoadedJarRef<'a> =
 
 /// Helper type to reuse an associated static file mmap handle on created cursors.
 #[derive(Debug)]
+// [MANTLE PATCH] allow(unnameable_types): re-exported through a private module;
+// upstream reth has the same shape. Newer clippy promotes this to deny under -D warnings.
+#[allow(unnameable_types)]
 pub struct LoadedJar {
     jar: NippyJar<SegmentHeader>,
     mmap_handle: Arc<reth_nippy_jar::DataReader>,


### PR DESCRIPTION
Clippy 1.94 added and tightened several lints that the existing `preconf`, `cli` and integration-test code trips over. CI runs `just clippy` with `-D warnings`, so **any PR opened against this branch currently fails regardless of its content** — the preconf code (#80, merged 2026-07-27) was green under the older clippy.

## What changed

Mostly `cargo clippy --fix` output:

| lint | where |
|---|---|
| `collapsible_if` | `preconf/src/builder/dispatch.rs` |
| `doc_markdown` (missing backticks) | `preconf` (`PayloadJob`, `fifo_rx`, …), `cli/src/args.rs` |
| `useless_conversion`, `bool_comparison`, `expect_fun_call` | `preconf`, integration tests |

Hand-fixed one case `--fix` could not handle:

- **`doc_lazy_continuation`** in `preconf/src/types.rs` — the `PreconfSource::Replay` bullet ends with a paragraph that follows a nested sub-list. Clippy wants it either indented to the parent item or separated as its own paragraph; added a blank line, which reads better here since the paragraph applies to both sub-cases.

No behaviour change — docs and lint-level only.

## Verification

```
cargo clippy --workspace --lib --examples --tests --benches --all-features -- -D warnings   # passes
cargo fmt --check                                                                           # clean
```

## Note

Separated from #101 (revm depriv) on purpose — that PR is two dependency files and shouldn't carry 20 files of unrelated lint churn. #101 will go green once this lands and it rebases.