### PR TITLE
chore(deps): repoint revm family from the private GHSA fork to public mantle-xyz/revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "bitvec",
  "phf",
@@ -10263,7 +10263,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10279,7 +10279,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10294,7 +10294,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -10307,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "auto_impl",
  "either",
@@ -10320,7 +10320,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "auto_impl",
  "either",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10386,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10422,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf?rev=99707e9f#99707e9f21a7c32255c9072be25814ab1b8d913d"
+source = "git+https://github.com/mantle-xyz/revm?branch=mantle-elysium#3c984f31107fe6f41d12424e91e8dff790631c01"
 dependencies = [
  "alloy-eip7928",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,19 +224,21 @@ reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdeb
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4", default-features = false }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7fcbfdebfd3b56d88c86b62e950043c6c4" }
 
-# ==================== REVM (Mantle fork: revm-ghsa private fork, pinned by rev) ====================
-# Release-line pin: revm family points at the private GHSA fork (embargoed advisory fixes),
-# fixed by rev to keep the pin reproducible. revm-inspectors stays on the public fork below.
-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+# ==================== REVM (Mantle fork: public mantle-xyz/revm, branch mantle-elysium, pinned by rev) ====================
+# The embargoed advisory fixes have been folded into the public mantle-elysium branch
+# (mantle-xyz/revm#36 et al.), so the private GHSA fork is no longer needed. Branch (not rev)
+# keeps this source unified with revm-inspectors' transitive mantle-xyz/revm dependency —
+# one revm in the graph — and Cargo.lock pins the exact commit for reproducibility.
+revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-database = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-state = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-context = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
 
 # ==================== REVM-INSPECTORS (Mantle fork: mantle-elysium branch) ====================
 # TODO: Switch to tag once mantle-elysium is tagged
@@ -250,8 +252,8 @@ alloy-evm = { version = "0.34.0", default-features = false }
 alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
 alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
 
-# ==================== OP-REVM (Mantle fork: revm-ghsa private fork, same repo as revm) ====================
-op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f", default-features = false }
+# ==================== OP-REVM (Mantle fork: public mantle-xyz/revm, same repo as revm) ====================
+op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium", default-features = false }
 
 # ==================== OP-ALLOY (Mantle: mantle-xyz/mantle-v2) ====================
 # TODO: Switch to tag once mantle-v2 Rust crates are tagged
@@ -418,21 +420,21 @@ reth-transaction-pool = { path = "patches/reth-transaction-pool" }
 # Without this, paradigmxyz/reth uses crates.io revm while we use git revm,
 # creating incompatible duplicate types in the dependency graph.
 [patch.crates-io]
-# revm family: revm-ghsa private fork, pinned by rev
-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+# revm family: public mantle-xyz/revm (branch mantle-elysium), pinned by rev
+revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-bytecode = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-database = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-state = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-primitives = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-interpreter = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-database-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-inspector = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-context = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
+revm-context-interface = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
 # revm-inspectors: mantle-xyz/revm-inspectors mantle-elysium branch
 revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", branch = "mantle-elysium" }
-# op-revm: revm-ghsa private fork (same as workspace dep)
-op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+# op-revm: public mantle-xyz/revm (same as workspace dep)
+op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
 # alloy-op-evm / alloy-op-hardforks: mantle-xyz/mantle-v2 (Mantle version)
 alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
@@ -443,22 +445,7 @@ op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/mantle-v2", branch =
 op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 op-alloy-rpc-jsonrpsee = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
 
-# ==================== [patch."https://github.com/mantle-xyz/revm"] — transitive pin ====================
-# revm-inspectors (a separate repo) still depends on mantle-xyz/revm branch mantle-elysium
-# transitively. Without redirecting that source too, cargo pulls a SECOND public revm into the
-# graph and reth-rpc-eth-api fails with Inspector trait-bound errors. Pin the transitive source
-# to the same revm-ghsa rev so exactly one revm exists in the graph.
-[patch."https://github.com/mantle-xyz/revm"]
-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-bytecode = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-state = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-primitives = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-interpreter = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-database-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-inspector = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-context-interface = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-handler = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-revm-precompile = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
-op-revm = { git = "https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf", rev = "99707e9f" }
+# NOTE: the former [patch."https://github.com/mantle-xyz/revm"] transitive-pin table is gone:
+# with every revm dependency now on the public repo's mantle-elysium branch — the same source
+# revm-inspectors reaches transitively — the graph already contains exactly one revm, and cargo
+# rejects a patch table whose entries point back at the source they patch.


### PR DESCRIPTION
## Why

`release.yml` has failed on **every tag since ~June** and shipped **zero binary assets**: the cross container has no git credentials, so `just build-cross` cannot fetch the private GHSA fork the revm deps point at. Freshly reproduced today on the `op-reth-v2.2.1-mantle-arsia.1` tag ([run 29714009572](https://github.com/mantle-xyz/reth/actions/runs/29714009572)):

```
Updating git repository `https://github.com/mantle-xyz/revm-ghsa-5vfr-x84h-hmvf`
error: failed to load source for dependency `op-revm`
  failed to authenticate when downloading repository
error: recipe `build-cross` failed with exit code 101
```

The private fork is no longer needed: the embargoed advisory fixes have been folded into the **public** `mantle-xyz/revm` `mantle-elysium` branch (pushed 2026-08-04). Commit-by-commit mapping of the old GHSA pin (`advisory-fix-elysium` @ `99707e9f`) into the public branch:

| GHSA commit | In public `mantle-elysium` as |
|---|---|
| `99707e9f` treat zero BVM_ETH eth_value/eth_tx_value as None in deposit | `1ac02c340` (PR #33, same fix) |
| `12bfc01ec` gate CanTransfer and EIP-3860 on deposits | folded into `11b77ca1c` (#36) |
| `1f621ca82` drop OP input-size limits from Isthmus precompiles | folded into `11b77ca1c` (#36) |
| `87fbc749e` bn254 pairing e2e regression | folded into `11b77ca1c` (#36) (testdata json included) |
| `e8f148188` / `e85c58215` / `5d5ac4988` | same SHAs (shared history) |

## What changed

- **Cargo.toml**: all revm-family deps and `[patch.crates-io]` entries now point at `mantle-xyz/revm` **branch `mantle-elysium`**. Branch (not rev) unifies this source with revm-inspectors' transitive `mantle-xyz/revm` dependency, so exactly one revm exists in the graph — which is also why the former `[patch."https://github.com/mantle-xyz/revm"]` transitive-pin table is **dropped**: with the main deps on the same source it becomes self-referential, and cargo rejects a patch pointing back at the source it patches. Reproducibility is preserved by the lockfile.
- **Cargo.lock**: relocked the 13 revm-family packages to `mantle-elysium#3c984f31`. **Crate versions unchanged** (revm 38.0.0, op-revm 19.0.0) — a source swap, not an upgrade.

## Note for the revm owner (please confirm)

The public branch head `3c984f311` is a **superset** of the old GHSA pin — it additionally contains the `origin/main` merge (`7e954fa25`), the #36 parity work, the ARSIA test restore (`3427f3d28`) and CI/docs fixes. Please confirm this is the intended content for the next release; if a more conservative rev is preferred, the lock can be pinned to it.

## Verified locally

- `cargo metadata` resolves cleanly (one revm source in the graph; no duplicate-crate Inspector trait errors).
- Unauthenticated fetch of `mantle-xyz/revm` works — this is exactly the step that fails in `release.yml`.
- Lock diff is confined to the 13 revm-family `source` lines.

## After merge

Tag `op-reth-v2.2.1-mantle-arsia.2` → `release.yml` should now produce binaries → mantle-v2 CI consumes them via its `OP_RETH_VERSION` pin (one-line bump). The `mantle-elysium` branch carries the same GHSA pins and needs the same repoint (or a merge-back of main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
