### PR TITLE
test(preconf): regression + property-based coverage for fifo & journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,6 +5259,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-flz",
  "op-revm",
+ "proptest",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",

--- a/mantle-reth/crates/integration-tests/tests/preconf/helpers.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/helpers.rs
@@ -91,6 +91,26 @@ pub fn mantle_chain_spec_with_predeploys_for(chain_id: u64) -> Arc<OpChainSpec> 
     Arc::new(mantle_reth_chainspec::from_mantle_genesis(genesis))
 }
 
+/// Like [`mantle_chain_spec_for`] but with an **always-reverting** contract at
+/// `addr` (runtime code `0x60006000fd` = `PUSH1 0; PUSH1 0; REVERT`). A tx to
+/// `addr` is valid but its execution reverts, so it still lands with an EIP-658
+/// `status = 0` receipt — the shape needed to exercise journaling of a
+/// reverted-but-sealed tx (a plain transfer always succeeds, so the happy-path
+/// helpers can't produce it).
+pub fn mantle_chain_spec_with_reverting_contract(chain_id: u64, addr: Address) -> Arc<OpChainSpec> {
+    let raw = include_str!("../assets/genesis.json");
+    let mut value: serde_json::Value = serde_json::from_str(raw).expect("valid genesis JSON");
+    value["config"]["chainId"] = serde_json::Value::from(chain_id);
+    let alloc = value["alloc"].as_object_mut().expect("genesis.json `alloc` must be an object");
+    // Runtime bytecode only (genesis `code` is the deployed code, not initcode).
+    alloc.insert(
+        format!("{addr:#x}"),
+        serde_json::json!({ "code": "0x60006000fd", "balance": "0x0" }),
+    );
+    let genesis: Genesis = serde_json::from_value(value).expect("patched genesis deserialises");
+    Arc::new(mantle_reth_chainspec::from_mantle_genesis(genesis))
+}
+
 /// Payload attributes generator for Mantle test chains — matches the
 /// shared helper in `tests/helpers.rs` but scoped to this test binary.
 pub fn mantle_payload_attributes(timestamp: u64) -> OpPayloadAttrs {

--- a/mantle-reth/crates/integration-tests/tests/preconf/journal_write.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/journal_write.rs
@@ -2,21 +2,28 @@
 //!
 //! `restart_replay.rs` covers the *read* half of durability (hand-written
 //! journal → restore → land). This module covers the *write* half — the
-//! part the RPC handler owns — plus the op-geth-aligned persistence scope
-//! (only RPC-path + `Success` commitments are journaled):
+//! part the RPC handler owns — plus the persistence scope: **every RPC-path
+//! commitment that lands on chain is journaled, whether it succeeded or
+//! reverted**; only the plain-listener path (no waiting client) is excluded.
 //!
 //! - `rpc_success_appends_to_journal_file` — a live `eth_sendRawTransactionWithPreconf` that
 //!   returns `Success` must leave a matching `JournalEntry` on disk. Guards `rpc.rs`'s
 //!   `journal.append_promised` call + the on-disk format.
+//! - `rpc_revert_but_sealed_is_journaled` — a preconf tx that **reverts** but still lands must ALSO
+//!   be journaled. Regression guard: the write used to be gated on wire `Success`, which dropped
+//!   reverted-but-sealed commitments.
 //! - `listener_path_preconf_not_journaled` — a whitelisted tx admitted via the **plain**
 //!   `eth_sendRawTransaction` path (listener → fifo, no RPC responder) lands on chain but must
-//!   **not** be journaled. Guards the "only RPC + Success is persisted" scope: the listener path
-//!   has no 1:1 waiting client, so there is no commitment to protect.
+//!   **not** be journaled. Guards the "only the RPC path persists" scope: the listener path has no
+//!   1:1 waiting client, so there is no commitment to protect.
 //!
 //! Together these pin the write side end-to-end without needing to
 //! actually restart a process (the disk file is the observable boundary).
 
-use super::helpers::{PreconfCfgBuilder, mantle_test_chain_spec, send_preconf};
+use super::helpers::{
+    PreconfCfgBuilder, mantle_chain_spec_with_reverting_contract, mantle_test_chain_spec,
+    send_preconf,
+};
 use crate::launch_preconf_node;
 use alloy_network::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
@@ -27,6 +34,10 @@ use reth_chainspec::EthChainSpec;
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet};
 
 const RECIPIENT: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+/// Address carrying always-reverting runtime code (see
+/// `mantle_chain_spec_with_reverting_contract`). A call here reverts.
+const REVERT_CONTRACT: &str = "0x00000000000000000000000000000000000000ff";
 
 async fn signed_transfer(chain_id: u64, wallet: &Wallet, nonce: u64) -> alloy_primitives::Bytes {
     let request = TransactionRequest {
@@ -127,6 +138,111 @@ async fn rpc_success_appends_to_journal_file() {
     assert_eq!(entry.hash, tx_hash, "journaled hash must match the submitted tx");
     assert_eq!(entry.block_height, event.block_height, "journaled height matches receipt");
     assert!(!entry.tx_rlp.is_empty(), "journaled entry carries the raw tx bytes");
+    assert_eq!(
+        keccak256(&entry.tx_rlp),
+        tx_hash,
+        "journaled tx_rlp must re-hash to the committed tx hash"
+    );
+
+    let _ = std::fs::remove_dir_all(&journal_dir);
+}
+
+/// A valid preconf tx whose execution **reverts** (call to the always-reverting
+/// contract). Still lands with an EIP-658 `status = 0` receipt.
+async fn signed_reverting_call(
+    chain_id: u64,
+    wallet: &Wallet,
+    nonce: u64,
+) -> alloy_primitives::Bytes {
+    let request = TransactionRequest {
+        chain_id: Some(chain_id),
+        nonce: Some(nonce),
+        to: Some(TxKind::Call(REVERT_CONTRACT.parse().unwrap())),
+        gas: Some(100_000),
+        max_fee_per_gas: Some(20e9 as u128),
+        max_priority_fee_per_gas: Some(20e9 as u128),
+        value: Some(U256::ZERO),
+        input: TransactionInput::default(),
+        ..Default::default()
+    };
+    TransactionTestContext::sign_tx(wallet.inner.clone(), request).await.encoded_2718().into()
+}
+
+/// A preconf tx that **reverts** but still lands MUST be journaled. The write
+/// used to be gated on wire `Success`, so a reverted-but-sealed commitment was
+/// dropped — lost on restart (the tx is
+/// `TransactionOrigin::External`, so not in reth's local-tx backup either),
+/// even though the client already holds a receipt. The fix journals on *any*
+/// receipt.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rpc_revert_but_sealed_is_journaled() {
+    let contract: Address = REVERT_CONTRACT.parse().unwrap();
+    let chain_id = mantle_test_chain_spec().chain().id();
+    let sender = Wallet::default().with_chain_id(chain_id).inner.address();
+
+    let (journal_file, journal_dir) = fresh_journal_path();
+    let cfg = PreconfCfgBuilder::new()
+        .whitelist_from(sender)
+        .whitelist_to(contract)
+        .journal_path(journal_file.clone())
+        .build();
+
+    let (mut node, http, wallet, _chain_id) =
+        launch_preconf_node!(cfg, mantle_chain_spec_with_reverting_contract(chain_id, contract))
+            .await;
+
+    let raw_tx = signed_reverting_call(chain_id, &wallet, 0).await;
+    let tx_hash = keccak256(&raw_tx);
+
+    let attrs = node.payload.next_attributes();
+    let fcu_state = node.current_forkchoice_state().expect("forkchoice state");
+    let payload_id = node
+        .inner
+        .add_ons_handle
+        .beacon_engine_handle
+        .fork_choice_updated(fcu_state, Some(attrs))
+        .await
+        .expect("FCU must succeed")
+        .payload_id
+        .expect("payload_id present");
+
+    let http_clone = http.clone();
+    let rpc_task = tokio::spawn(async move { send_preconf(&http_clone, raw_tx).await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let payload = node
+        .inner
+        .payload_builder_handle
+        .resolve_kind(payload_id, reth_node_api::PayloadKind::Earliest)
+        .await
+        .expect("resolve_kind")
+        .expect("payload build");
+
+    let event = rpc_task.await.expect("rpc join").expect("preconf call must return a receipt");
+
+    // Reverted ⇒ Failed, but a receipt exists (it landed) — the case the old gate dropped.
+    assert!(
+        matches!(event.status, PreconfStatus::Failed),
+        "expected revert ⇒ Failed, got {:?} reason={:?}",
+        event.status,
+        event.reason
+    );
+
+    // Sanity: the reverted tx actually landed (so "must journal" isn't a no-op).
+    let sealed: Vec<B256> =
+        payload.block().body().transactions().map(|tx| keccak256(tx.encoded_2718())).collect();
+    assert!(
+        sealed.contains(&tx_hash),
+        "reverted preconf tx must still land on chain; sealed={sealed:?}"
+    );
+
+    // The reverted-but-sealed commitment MUST be journaled.
+    let entries = read_journal(&journal_file);
+    assert_eq!(entries.len(), 1, "the reverted-but-sealed commitment must be journaled");
+    let entry = &entries[0];
+    assert_eq!(entry.hash, tx_hash, "journaled hash must match the submitted tx");
+    assert_eq!(entry.block_height, event.block_height, "journaled height matches receipt");
     assert_eq!(
         keccak256(&entry.tx_rlp),
         tx_hash,

--- a/mantle-reth/crates/preconf/Cargo.toml
+++ b/mantle-reth/crates/preconf/Cargo.toml
@@ -134,6 +134,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "macros", "rt", "time", "test-util", "fs"] }
 tempfile.workspace = true
+proptest.workspace = true
 
 # P6 e2e harness — in-process EVM tests for build_payload (see
 # `docs/design/preconf-dev-plan.md` §P6).

--- a/mantle-reth/crates/preconf/src/journal.rs
+++ b/mantle-reth/crates/preconf/src/journal.rs
@@ -1029,6 +1029,20 @@ mod tests {
                 "entry {i} lost across concurrent rotate"
             );
         }
+
+        // Same race, second failure mode: the in-memory `size_bytes` counter
+        // must not be clobbered by a rotate that raced an append — it must
+        // still equal the file's true length. If rotate's
+        // `size_bytes.store(kept_bytes)` (computed from the pre-append
+        // snapshot) dropped the racing append's byte contribution, the counter
+        // would sit short of the real file and silently mistune the
+        // size-rotation trigger even though the entry itself survived on disk.
+        let on_disk_bytes = tokio::fs::metadata(&path).await.unwrap().len();
+        assert_eq!(
+            j.size_bytes.load(Ordering::Relaxed),
+            on_disk_bytes,
+            "size_bytes counter drifted from true on-disk size across concurrent rotate"
+        );
     }
 
     #[tokio::test]
@@ -1564,6 +1578,180 @@ mod tests {
                 .await
                 .is_ok();
             assert!(!armed, "a file one byte under the cap must NOT arm the size trigger");
+        }
+    }
+}
+
+/// Stateful property model for [`PreconfJournal`].
+///
+/// Replays random `append` / `mark_sealed` / `rotate` sequences against the
+/// real journal and an independent reference model, checking after every step
+/// that the on-disk file, the `size_bytes` counter, and the in-memory
+/// `sealed` / `promised` sets all agree. Exercises the rotate retention rules
+/// (drop sealed, keep the rest) and the `sealed ⊆ promised == set(file)` shrink
+/// invariant — guarding against retention / accounting changes that leak
+/// entries or drift the counter. Deterministic behind the writer lock.
+#[cfg(test)]
+mod proptest_journal_model {
+    use super::*;
+    use proptest::prelude::*;
+    use std::collections::BTreeSet;
+    use tempfile::TempDir;
+
+    // Small identity space so seal/rotate collisions are frequent.
+    const IDS: u8 = 6;
+
+    fn hash(byte: u8) -> TxHash {
+        TxHash::from([byte; 32])
+    }
+
+    /// Fixed 1:1 identity per byte — a signed tx's hash derives from its
+    /// content, so a given hash always carries the same entry bytes.
+    fn entry_for(byte: u8) -> JournalEntry {
+        JournalEntry {
+            hash: hash(byte),
+            tx_rlp: Bytes::from(vec![byte; 4]),
+            block_height: u64::from(byte),
+            committed_at_ms: 1_000 + u64::from(byte),
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    enum Op {
+        Append(u8),
+        MarkSealed(Vec<u8>),
+        Rotate,
+    }
+
+    fn byte() -> impl Strategy<Value = u8> {
+        0..IDS
+    }
+
+    fn op() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            byte().prop_map(Op::Append),
+            prop::collection::vec(byte(), 0..4).prop_map(Op::MarkSealed),
+            Just(Op::Rotate),
+        ]
+    }
+
+    /// Reference model. `file` mirrors the on-disk line sequence (by identity
+    /// byte); `promised` / `sealed` mirror the in-memory sets.
+    #[derive(Default)]
+    struct Model {
+        file: Vec<u8>,
+        promised: BTreeSet<u8>,
+        sealed: BTreeSet<u8>,
+    }
+
+    impl Model {
+        fn apply(&mut self, op: &Op) {
+            match op {
+                Op::Append(b) => {
+                    self.file.push(*b);
+                    self.promised.insert(*b);
+                }
+                Op::MarkSealed(bytes) => {
+                    for b in bytes {
+                        // `mark_sealed` only admits already-promised hashes.
+                        if self.promised.contains(b) {
+                            self.sealed.insert(*b);
+                        }
+                    }
+                }
+                Op::Rotate => {
+                    // Drop every file line whose hash is sealed; the dropped
+                    // hashes leave both `sealed` and `promised` (no abandon
+                    // TTL is configured, so that is the only drop rule).
+                    let sealed = self.sealed.clone();
+                    self.file.retain(|b| !sealed.contains(b));
+                    for b in &sealed {
+                        self.sealed.remove(b);
+                        self.promised.remove(b);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn fresh() -> (TempDir, PreconfJournal) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("preconf.jsonl");
+        // Large cap so appends never auto-arm the size trigger during replay.
+        let j = PreconfJournal::open(&path, u64::MAX).await.unwrap();
+        (dir, j)
+    }
+
+    async fn run_and_check(ops: &[Op]) {
+        let (dir, j) = fresh().await;
+        let path = dir.path().join("preconf.jsonl");
+        let mut model = Model::default();
+
+        for (i, op) in ops.iter().enumerate() {
+            match op {
+                Op::Append(b) => j.append_promised(&entry_for(*b)).await.unwrap(),
+                Op::MarkSealed(bytes) => j.mark_sealed_batch(bytes.iter().map(|b| hash(*b))).await,
+                Op::Rotate => {
+                    // Stats computed from the pre-rotate model.
+                    let before = model.file.len();
+                    let kept_expected =
+                        model.file.iter().filter(|b| !model.sealed.contains(b)).count();
+                    let stats = j.rotate().await.unwrap();
+                    assert_eq!(stats.kept, kept_expected, "step {i}: rotate kept mismatch");
+                    assert_eq!(
+                        stats.dropped,
+                        before - kept_expected,
+                        "step {i}: rotate dropped mismatch"
+                    );
+                }
+            }
+            model.apply(op);
+
+            // (A) On-disk contents match the model's file, in order.
+            let (loaded, bad) = j.load().await.unwrap();
+            assert_eq!(bad, 0, "step {i}: unexpected corrupt lines");
+            let expected: Vec<JournalEntry> = model.file.iter().map(|b| entry_for(*b)).collect();
+            assert_eq!(loaded, expected, "step {i}: journal file diverged after {op:?}");
+
+            // (B) `size_bytes` equals the true on-disk file size.
+            let disk = tokio::fs::metadata(&path).await.unwrap().len();
+            assert_eq!(
+                j.size_bytes.load(Ordering::Relaxed),
+                disk,
+                "step {i}: size_bytes drifted from disk after {op:?}"
+            );
+
+            // (C) `sealed` matches (public API).
+            assert_eq!(j.sealed_len().await, model.sealed.len(), "step {i}: sealed_len mismatch");
+            for b in 0..IDS {
+                assert_eq!(
+                    j.contains(&hash(b)).await,
+                    model.sealed.contains(&b),
+                    "step {i}: sealed membership mismatch for {b}"
+                );
+            }
+
+            // (D) `promised == set(file)` — the shrink invariant: rotate must
+            // evict dropped commitments from `promised`, not leak them forever.
+            let real_promised: BTreeSet<TxHash> = j.promised.lock().await.iter().copied().collect();
+            let model_promised: BTreeSet<TxHash> =
+                model.promised.iter().map(|b| hash(*b)).collect();
+            assert_eq!(real_promised, model_promised, "step {i}: promised set diverged");
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 192, ..ProptestConfig::default() })]
+
+        /// Any sequence of append / mark_sealed / rotate keeps the on-disk
+        /// journal, the `size_bytes` counter, and the in-memory
+        /// `sealed` / `promised` sets in lock-step with the reference model —
+        /// in particular rotate drops exactly the sealed commitments and
+        /// shrinks `promised` / `sealed` (no unbounded growth).
+        #[test]
+        fn preconf_journal_matches_reference_model(ops in prop::collection::vec(op(), 1..30)) {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            rt.block_on(run_and_check(&ops));
         }
     }
 }

--- a/mantle-reth/crates/preconf/src/preconf_tx_set.rs
+++ b/mantle-reth/crates/preconf/src/preconf_tx_set.rs
@@ -1723,3 +1723,586 @@ mod tests {
         assert!(second_evicted.lock().unwrap().is_empty());
     }
 }
+
+/// Stateful property model for [`PreconfTxSet`].
+///
+/// Replays random push / mark / remove / clean / forward sequences against the
+/// real fifo and an independent reference model, checking after every step that
+/// they agree and that structural invariants hold (slot uniqueness, index
+/// consistency). Explores same-`(sender, nonce)` / same-hash collisions that
+/// hand-written cases hit only sparsely. Deterministic: all mutations serialise
+/// behind one lock, so one run per sequence is representative.
+#[cfg(test)]
+mod proptest_model {
+    use super::*;
+    use alloy_consensus::{Signed, TxEip1559};
+    use alloy_primitives::{B256, Signature};
+    use proptest::prelude::*;
+    use std::collections::{BTreeMap, HashSet};
+
+    // Small domains so slot/hash collisions are frequent.
+    const SENDERS: u8 = 2;
+    const NONCES: u8 = 3;
+    const VARIANTS: u8 = 2;
+
+    fn addr(byte: u8) -> Address {
+        Address::from([byte; 20])
+    }
+    fn h(byte: u8) -> TxHash {
+        TxHash::from([byte; 32])
+    }
+    fn make_tx(nonce: u64, hash_byte: u8) -> Arc<TxEnvelope> {
+        let inner = TxEip1559 { nonce, ..Default::default() };
+        let sig = Signature::test_signature();
+        Arc::new(TxEnvelope::Eip1559(Signed::new_unchecked(
+            inner,
+            sig,
+            B256::from([hash_byte; 32]),
+        )))
+    }
+
+    /// A synthetic tx identity. Maps 1:1 to a hash byte, so a given hash
+    /// always carries the same `(sender, nonce)` — matching reality, where a
+    /// signed tx's hash is derived from its content. `variant` lets two txs
+    /// share a `(sender, nonce)` slot with different hashes (the replacement
+    /// case).
+    #[derive(Clone, Copy, Debug)]
+    struct TxId {
+        sender: u8,
+        nonce: u8,
+        variant: u8,
+    }
+
+    impl TxId {
+        /// Unique in `0..(SENDERS * NONCES * VARIANTS)`.
+        fn hash_byte(self) -> u8 {
+            (self.sender * NONCES + self.nonce) * VARIANTS + self.variant
+        }
+        fn tx(self) -> Arc<TxEnvelope> {
+            make_tx(self.nonce as u64, self.hash_byte())
+        }
+        fn addr(self) -> Address {
+            addr(self.sender)
+        }
+        fn hash(self) -> TxHash {
+            h(self.hash_byte())
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    enum Op {
+        Push(TxId),
+        MarkSucceeded(TxId),
+        MarkFailed(TxId),
+        MarkTimeout(TxId),
+        MarkCanceled(TxId),
+        RemoveReclaimable(TxId),
+        CleanReclaimable,
+        Forward { sender: u8, new_nonce: u8 },
+    }
+
+    fn txid() -> impl Strategy<Value = TxId> {
+        (0..SENDERS, 0..NONCES, 0..VARIANTS).prop_map(|(sender, nonce, variant)| TxId {
+            sender,
+            nonce,
+            variant,
+        })
+    }
+
+    fn op() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            txid().prop_map(Op::Push),
+            txid().prop_map(Op::MarkSucceeded),
+            txid().prop_map(Op::MarkFailed),
+            txid().prop_map(Op::MarkTimeout),
+            txid().prop_map(Op::MarkCanceled),
+            txid().prop_map(Op::RemoveReclaimable),
+            Just(Op::CleanReclaimable),
+            // `new_nonce` up to NONCES+1 so a forward can clear the whole sender.
+            (0..SENDERS, 0..(NONCES + 1))
+                .prop_map(|(sender, new_nonce)| Op::Forward { sender, new_nonce }),
+        ]
+    }
+
+    /// Reference model: `hash_byte -> (sender, nonce, status)`. Maintains "at
+    /// most one entry per `(sender, nonce)`" by construction — the property
+    /// the real fifo must also hold.
+    type Model = BTreeMap<u8, (u8, u8, PreconfStatus)>;
+
+    fn reclaimable(s: PreconfStatus) -> bool {
+        matches!(s, PreconfStatus::Timeout | PreconfStatus::Canceled | PreconfStatus::Failed)
+    }
+
+    fn model_mark(model: &mut Model, hb: u8, target: PreconfStatus) {
+        // `transition_from_waiting`: only Waiting moves; anything else is a no-op.
+        if let Some((_, _, st)) = model.get_mut(&hb) &&
+            *st == PreconfStatus::Waiting
+        {
+            *st = target;
+        }
+    }
+
+    fn model_apply(model: &mut Model, op: &Op) {
+        match op {
+            Op::Push(id) => {
+                let hb = id.hash_byte();
+                if let Some((_, _, st)) = model.get_mut(&hb) {
+                    // Same hash: reclaimable revives to Waiting; active is a no-op.
+                    if reclaimable(*st) {
+                        *st = PreconfStatus::Waiting;
+                    }
+                    return;
+                }
+                // Same (sender, nonce), different hash?
+                let slot = model
+                    .iter()
+                    .find(|(_, (s, n, _))| *s == id.sender && *n == id.nonce)
+                    .map(|(hb, (_, _, st))| (*hb, *st));
+                match slot {
+                    // Active slot blocks the replacement (ConflictActive) — no insert.
+                    Some((_, st)) if !reclaimable(st) => {}
+                    // Reclaimable slot is evicted, then the new tx takes it.
+                    Some((old, _)) => {
+                        model.remove(&old);
+                        model.insert(hb, (id.sender, id.nonce, PreconfStatus::Waiting));
+                    }
+                    None => {
+                        model.insert(hb, (id.sender, id.nonce, PreconfStatus::Waiting));
+                    }
+                }
+            }
+            Op::MarkSucceeded(id) => model_mark(model, id.hash_byte(), PreconfStatus::Success),
+            Op::MarkFailed(id) => model_mark(model, id.hash_byte(), PreconfStatus::Failed),
+            Op::MarkTimeout(id) => model_mark(model, id.hash_byte(), PreconfStatus::Timeout),
+            Op::MarkCanceled(id) => model_mark(model, id.hash_byte(), PreconfStatus::Canceled),
+            Op::RemoveReclaimable(id) => {
+                let hb = id.hash_byte();
+                if matches!(model.get(&hb), Some((_, _, st)) if reclaimable(*st)) {
+                    model.remove(&hb);
+                }
+            }
+            Op::CleanReclaimable => model.retain(|_, (_, _, st)| !reclaimable(*st)),
+            Op::Forward { sender, new_nonce } => {
+                model.retain(|_, (s, n, _)| !(*s == *sender && *n < *new_nonce))
+            }
+        }
+    }
+
+    async fn apply_real(set: &PreconfTxSet, op: &Op) {
+        match op {
+            Op::Push(id) => {
+                set.push_if_absent(id.tx(), id.addr(), PreconfSource::Rpc).await;
+            }
+            Op::MarkSucceeded(id) => {
+                let _ = set.mark_succeeded(&id.hash()).await;
+            }
+            Op::MarkFailed(id) => {
+                let _ = set.mark_failed(&id.hash()).await;
+            }
+            Op::MarkTimeout(id) => {
+                let _ = set.mark_timeout(&id.hash()).await;
+            }
+            Op::MarkCanceled(id) => {
+                let _ = set.mark_canceled(&id.hash()).await;
+            }
+            Op::RemoveReclaimable(id) => {
+                set.remove_reclaimable(&id.hash()).await;
+            }
+            Op::CleanReclaimable => {
+                set.clean_reclaimable().await;
+            }
+            Op::Forward { sender, new_nonce } => {
+                set.forward(&addr(*sender), *new_nonce as u64).await;
+            }
+        }
+    }
+
+    async fn run_and_check(ops: &[Op]) {
+        let set = PreconfTxSet::new(64);
+        let mut model = Model::new();
+
+        for (i, op) in ops.iter().enumerate() {
+            apply_real(&set, op).await;
+            model_apply(&mut model, op);
+
+            let views = set.entries().await;
+
+            // (A) Real fifo agrees with the reference model, hash by hash.
+            assert_eq!(views.len(), model.len(), "step {i}: entry count diverged after {op:?}");
+            for v in &views {
+                let hb = v.hash.0[0]; // h(byte) has every byte == byte
+                let (s, n, st) = *model.get(&hb).unwrap_or_else(|| {
+                    panic!("step {i}: real has hash {hb} not in model ({op:?})")
+                });
+                assert_eq!(v.from, addr(s), "step {i}: sender mismatch for hash {hb}");
+                assert_eq!(v.nonce, u64::from(n), "step {i}: nonce mismatch for hash {hb}");
+                assert_eq!(v.status, st, "step {i}: status mismatch for hash {hb}");
+            }
+
+            // (B) Slot uniqueness — at most one entry per (sender, nonce);
+            // a duplicate is the "pool ghost" that breaks replacement safety.
+            let mut slots = HashSet::new();
+            for v in &views {
+                assert!(
+                    slots.insert((v.from, v.nonce)),
+                    "step {i}: duplicate (sender, nonce) slot after {op:?}"
+                );
+            }
+
+            // (C) Index consistency: `order` (snapshot) and `entries` hold the
+            // exact same hash set with no duplicates, and every entry is
+            // reachable via both by-hash and by-(sender,nonce) lookups.
+            let snap = set.snapshot().await;
+            assert_eq!(snap.len(), views.len(), "step {i}: snapshot/entries length diverged");
+            let snap_set: HashSet<_> = snap.iter().copied().collect();
+            assert_eq!(snap_set.len(), snap.len(), "step {i}: duplicate hash in order");
+            for v in &views {
+                assert!(snap_set.contains(&v.hash), "step {i}: entry missing from order index");
+                assert_eq!(
+                    set.find_by_sender_nonce(&v.from, v.nonce).await.map(|x| x.hash),
+                    Some(v.hash),
+                    "step {i}: by_sender index disagrees for {:?}",
+                    v.hash
+                );
+                assert!(
+                    set.find_by_hash(&v.hash).await.is_some(),
+                    "step {i}: find_by_hash missing"
+                );
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+        /// Any sequence of fifo operations keeps the real `PreconfTxSet` in
+        /// lock-step with the reference model and never violates slot
+        /// uniqueness or index consistency.
+        #[test]
+        fn preconf_tx_set_matches_reference_model(ops in prop::collection::vec(op(), 1..40)) {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            rt.block_on(run_and_check(&ops));
+        }
+    }
+}
+
+/// Stateful property model for [`PreconfTxSet`]'s **responder** machine — the
+/// half the fifo model skips.
+///
+/// Holds a real `oneshot::Receiver` per attached responder and checks, after
+/// each op, that a hash has at most one responder (in `entry.responder` xor
+/// `pending_responders`), that `push` migrates a pending responder onto its
+/// entry, and that a responder leaving the set resolves its receiver exactly
+/// once (Ok via `take`, Err via `cancel`, `RecvError` when dropped) — never
+/// silently leaked. A final `expire_pending_responders` must GC every pending
+/// slot. Each hash owns its slot, isolating this from the replacement logic.
+#[cfg(test)]
+mod proptest_responder_model {
+    use super::*;
+    use alloy_consensus::{Signed, TxEip1559};
+    use alloy_primitives::{B256, Bytes, Log, Signature};
+    use proptest::prelude::*;
+    use tokio::sync::oneshot::error::TryRecvError;
+
+    const HASHES: u8 = 4;
+
+    fn h(byte: u8) -> TxHash {
+        TxHash::from([byte; 32])
+    }
+    fn make_tx(nonce: u64, hash_byte: u8) -> Arc<TxEnvelope> {
+        let inner = TxEip1559 { nonce, ..Default::default() };
+        let sig = Signature::test_signature();
+        Arc::new(TxEnvelope::Eip1559(Signed::new_unchecked(
+            inner,
+            sig,
+            B256::from([hash_byte; 32]),
+        )))
+    }
+    fn receipt(hash_byte: u8) -> PreconfReceipt {
+        PreconfReceipt {
+            tx_hash: h(hash_byte),
+            block_height: 0,
+            status: true,
+            logs: Vec::<Log>::new(),
+            gas_used: 0,
+            reason: String::new(),
+            revert_data: Bytes::new(),
+        }
+    }
+    fn some_err() -> PreconfError {
+        PreconfError::Internal("model".into())
+    }
+
+    type Rx = oneshot::Receiver<Result<PreconfReceipt, PreconfError>>;
+
+    #[derive(Clone, Copy, PartialEq, Debug)]
+    enum Loc {
+        Pending,
+        Entry,
+    }
+
+    /// Per-hash model: entry status (if any) and the currently-held responder
+    /// (location + its receiver, so we can observe the receiver's fate).
+    #[derive(Default)]
+    struct HashState {
+        entry: Option<PreconfStatus>,
+        held: Option<(Loc, Rx)>,
+    }
+
+    #[derive(Clone, Debug)]
+    enum Op {
+        Attach(u8),
+        Push(u8),
+        MarkTimeout(u8),
+        MarkFailed(u8),
+        MarkCanceled(u8),
+        MarkSucceeded(u8),
+        Take(u8),
+        Cancel(u8),
+        Forward(u8),
+        CleanReclaimable,
+    }
+
+    fn hb() -> impl Strategy<Value = u8> {
+        0..HASHES
+    }
+    fn op() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            hb().prop_map(Op::Attach),
+            hb().prop_map(Op::Push),
+            hb().prop_map(Op::MarkTimeout),
+            hb().prop_map(Op::MarkFailed),
+            hb().prop_map(Op::MarkCanceled),
+            hb().prop_map(Op::MarkSucceeded),
+            hb().prop_map(Op::Take),
+            hb().prop_map(Op::Cancel),
+            (0..=HASHES).prop_map(Op::Forward),
+            Just(Op::CleanReclaimable),
+        ]
+    }
+
+    fn reclaimable(s: PreconfStatus) -> bool {
+        matches!(s, PreconfStatus::Timeout | PreconfStatus::Canceled | PreconfStatus::Failed)
+    }
+    fn assert_closed(mut rx: Rx, ctx: &str) {
+        assert!(
+            matches!(rx.try_recv(), Err(TryRecvError::Closed)),
+            "{ctx}: receiver must be Closed"
+        );
+    }
+    fn assert_value(mut rx: Rx, ctx: &str) {
+        assert!(rx.try_recv().is_ok(), "{ctx}: receiver must have a value");
+    }
+
+    async fn run_and_check(ops: &[Op]) {
+        let set = PreconfTxSet::new(64);
+        let sender = Address::from([0u8; 20]);
+        let mut model: Vec<HashState> = (0..HASHES).map(|_| HashState::default()).collect();
+
+        for (i, op) in ops.iter().enumerate() {
+            match op {
+                Op::Attach(b) => {
+                    let b = *b;
+                    let (tx, rx) = oneshot::channel();
+                    let r = set.attach_responder(h(b), Instant::now(), tx).await;
+                    let st = &mut model[b as usize];
+                    match st.entry {
+                        Some(PreconfStatus::Success) => {
+                            assert!(r.is_err(), "step {i}: attach on Success must reject");
+                            assert_closed(rx, &format!("step {i}: rejected attach"));
+                        }
+                        Some(PreconfStatus::Waiting) => {
+                            if st.held.is_some() {
+                                assert!(
+                                    r.is_err(),
+                                    "step {i}: attach over live responder must reject"
+                                );
+                                assert_closed(rx, &format!("step {i}: rejected attach"));
+                            } else {
+                                assert!(r.is_ok(), "step {i}: attach on bare Waiting must succeed");
+                                st.held = Some((Loc::Entry, rx));
+                            }
+                        }
+                        Some(_) => {
+                            // Reclaimable: installs onto the entry, overwriting any prior
+                            // responder.
+                            assert!(r.is_ok(), "step {i}: attach on reclaimable must succeed");
+                            if let Some((_, old)) = st.held.take() {
+                                assert_closed(old, &format!("step {i}: overwritten responder"));
+                            }
+                            st.held = Some((Loc::Entry, rx));
+                        }
+                        None => {
+                            if st.held.is_some() {
+                                assert!(r.is_err(), "step {i}: attach over pending must reject");
+                                assert_closed(rx, &format!("step {i}: rejected attach"));
+                            } else {
+                                assert!(r.is_ok(), "step {i}: first attach must succeed");
+                                st.held = Some((Loc::Pending, rx));
+                            }
+                        }
+                    }
+                }
+                Op::Push(b) => {
+                    let b = *b;
+                    set.push_if_absent(make_tx(u64::from(b), b), sender, PreconfSource::Rpc).await;
+                    let st = &mut model[b as usize];
+                    match st.entry {
+                        None => {
+                            st.entry = Some(PreconfStatus::Waiting);
+                            // A pending responder migrates onto the fresh entry.
+                            if let Some((Loc::Pending, rx)) = st.held.take() {
+                                st.held = Some((Loc::Entry, rx));
+                            }
+                        }
+                        Some(s) if reclaimable(s) => {
+                            st.entry = Some(PreconfStatus::Waiting); // revived; responder unchanged
+                        }
+                        Some(_) => { /* Waiting/Success: AlreadyExists, no change */ }
+                    }
+                }
+                Op::MarkTimeout(b) => mark(&set, &mut model, *b, PreconfStatus::Timeout).await,
+                Op::MarkFailed(b) => mark(&set, &mut model, *b, PreconfStatus::Failed).await,
+                Op::MarkCanceled(b) => mark(&set, &mut model, *b, PreconfStatus::Canceled).await,
+                Op::MarkSucceeded(b) => mark(&set, &mut model, *b, PreconfStatus::Success).await,
+                Op::Take(b) => {
+                    let b = *b;
+                    let r = set.take_responder(&h(b)).await;
+                    let st = &mut model[b as usize];
+                    if let Some((_, rx)) = st.held.take() {
+                        let s = r.unwrap_or_else(|| {
+                            panic!("step {i}: take must return the held responder")
+                        });
+                        let _ = s.send(Ok(receipt(b)));
+                        assert_value(rx, &format!("step {i}: taken responder delivered"));
+                    } else {
+                        assert!(r.is_none(), "step {i}: take with no responder must be None");
+                    }
+                }
+                Op::Cancel(b) => {
+                    let b = *b;
+                    set.cancel_responder(&h(b), some_err()).await;
+                    let st = &mut model[b as usize];
+                    if let Some((_, rx)) = st.held.take() {
+                        assert_value(rx, &format!("step {i}: canceled responder got error"));
+                    }
+                }
+                Op::Forward(new_nonce) => {
+                    set.forward(&sender, u64::from(*new_nonce)).await;
+                    for b in 0..HASHES {
+                        let st = &mut model[b as usize];
+                        // forward only drops *entries* (nonce == b) below new_nonce.
+                        if st.entry.is_some() && u64::from(b) < u64::from(*new_nonce) {
+                            st.entry = None;
+                            if let Some((_, rx)) = st.held.take() {
+                                assert_closed(rx, &format!("step {i}: forward-dropped responder"));
+                            }
+                        }
+                    }
+                }
+                Op::CleanReclaimable => {
+                    set.clean_reclaimable().await;
+                    for b in 0..HASHES {
+                        let st = &mut model[b as usize];
+                        if matches!(st.entry, Some(s) if reclaimable(s)) {
+                            st.entry = None;
+                            if let Some((_, rx)) = st.held.take() {
+                                assert_closed(rx, &format!("step {i}: clean-dropped responder"));
+                            }
+                        }
+                    }
+                }
+            }
+
+            check_invariants(&set, &mut model, i).await;
+        }
+
+        // Final GC: every lingering *pending* responder must be expired (its
+        // receiver Closed); entry-held responders are untouched.
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        let expired = set.expire_pending_responders(Duration::ZERO).await;
+        let mut expected = 0usize;
+        for st in &mut model {
+            if let Some((Loc::Pending, rx)) = st.held.take() {
+                expected += 1;
+                assert_closed(rx, "final expire");
+            }
+        }
+        assert_eq!(expired, expected, "expire count must match lingering pending responders");
+        assert!(
+            set.inner.lock().await.pending_responders.is_empty(),
+            "no pending responder may survive expire"
+        );
+    }
+
+    async fn mark(set: &PreconfTxSet, model: &mut [HashState], b: u8, target: PreconfStatus) {
+        let _ = match target {
+            PreconfStatus::Success => set.mark_succeeded(&h(b)).await,
+            PreconfStatus::Failed => set.mark_failed(&h(b)).await,
+            PreconfStatus::Timeout => set.mark_timeout(&h(b)).await,
+            PreconfStatus::Canceled => set.mark_canceled(&h(b)).await,
+            PreconfStatus::Waiting => unreachable!(),
+        };
+        let st = &mut model[b as usize];
+        if st.entry == Some(PreconfStatus::Waiting) {
+            st.entry = Some(target); // responder untouched by mark_*
+        }
+    }
+
+    async fn check_invariants(set: &PreconfTxSet, model: &mut [HashState], step: usize) {
+        {
+            let inner = set.inner.lock().await;
+            for hash in inner.pending_responders.keys() {
+                assert!(
+                    !inner.entries.contains_key(hash),
+                    "step {step}: hash in both pending_responders and entries"
+                );
+            }
+            for b in 0..model.len() as u8 {
+                let hash = h(b);
+                let has_pending = inner.pending_responders.contains_key(&hash);
+                let entry_resp = inner.entries.get(&hash).is_some_and(|e| e.responder.is_some());
+                // Invariant #2 within one hash: at most one responder location.
+                assert!(!(has_pending && entry_resp), "step {step}: two responders for {b}");
+                let expect = match model[b as usize].held {
+                    None => (false, false),
+                    Some((Loc::Pending, _)) => (true, false),
+                    Some((Loc::Entry, _)) => (false, true),
+                };
+                assert_eq!(
+                    (has_pending, entry_resp),
+                    expect,
+                    "step {step}: responder location mismatch for {b}"
+                );
+                assert_eq!(
+                    inner.entries.get(&hash).map(|e| e.status),
+                    model[b as usize].entry,
+                    "step {step}: entry status mismatch for {b}"
+                );
+            }
+        }
+        // Held responders must not have resolved yet (no premature send/drop).
+        for (b, st) in model.iter_mut().enumerate() {
+            if let Some((_, rx)) = st.held.as_mut() {
+                assert!(
+                    matches!(rx.try_recv(), Err(TryRecvError::Empty)),
+                    "step {step}: held responder for {b} resolved prematurely"
+                );
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 192, ..ProptestConfig::default() })]
+
+        /// Any sequence of responder operations keeps every `oneshot` responder
+        /// singly-located, correctly migrated on push, and delivered/dropped
+        /// exactly once — no responder is silently leaked, and every pending
+        /// slot is GC-able.
+        #[test]
+        fn preconf_tx_set_responder_lifecycle(ops in prop::collection::vec(op(), 1..40)) {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            rt.block_on(run_and_check(&ops));
+        }
+    }
+}


### PR DESCRIPTION
- journal_write: `rpc_revert_but_sealed_is_journaled` — a preconf tx that reverts but still lands must be journaled. The write used to be gated on wire Success, so a reverted-but-sealed commitment was dropped and lost on restart (the tx is TransactionOrigin::External, not in reth's local-tx backup either). Adds a `mantle_chain_spec_with_reverting_contract` helper to produce the revert-but-land shape.

- proptest stateful models (test-only; adds a `proptest` dev-dependency):
  - PreconfTxSet fifo: replays random push/mark/remove/clean/forward against a reference model, checking slot uniqueness + index consistency.
  - PreconfTxSet responder lifecycle: tracks real oneshot receivers to assert at-most-one responder per hash, pending->entry migration on push, exactly-once delivery (Ok/Err/RecvError), no leak, and final GC.
  - PreconfJournal: rotate retention + `size_bytes == on-disk size` + the `sealed subseteq promised == set(file)` shrink invariant.

- journal: assert `size_bytes` stays equal to the true on-disk size across a concurrent rotate/append race (rotate_does_not_lose_concurrent_appends).

Each model was validated by injecting a fault and confirming it fails, then reverting; no production logic is changed.

## Summary

<!-- What does this PR do? -->

## Test plan

- [ ] `just pr` passed locally (fmt + clippy + test + test-doc)
