### PR TITLE
fix(evm): default simulated block parentBeaconBlockRoot to zero

### DIFF
--- a/op-reth/crates/evm/src/config.rs
+++ b/op-reth/crates/evm/src/config.rs
@@ -31,7 +31,19 @@ impl<H: alloy_consensus::BlockHeader> reth_rpc_eth_api::helpers::pending_block::
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),
-            parent_beacon_block_root: parent.parent_beacon_block_root(),
+            // Default the parent beacon block root to zero rather than inheriting the parent's
+            // value. A pending/simulated block is not a real block, so it has no parent beacon
+            // block root of its own; carrying the parent's value over reports a root that never
+            // belonged to this block. Zeroing matches op-geth, which initializes the field to the
+            // zero hash for `eth_simulateV1` and only fills it from an explicit `beaconRoot`
+            // block override (`internal/ethapi/simulate.go`, `makeHeaders`).
+            //
+            // Upstream reth made the same change for its Ethereum `NextBlockEnvAttributes` in
+            // paradigmxyz/reth#24652, citing go-ethereum as the reference. That PR did not touch
+            // this OP-specific implementation, so we mirror it here. `.map()` preserves the
+            // `Option` (i.e. "is this field present at all", gated on Cancun) and only replaces
+            // the inner value.
+            parent_beacon_block_root: parent.parent_beacon_block_root().map(|_| B256::ZERO),
             extra_data: parent.extra_data().clone(),
         }
     }
@@ -47,5 +59,41 @@ impl From<OpFlashblockPayloadBase> for OpNextBlockEnvAttributes {
             parent_beacon_block_root: Some(base.parent_beacon_block_root),
             extra_data: base.extra_data,
         }
+    }
+}
+
+#[cfg(all(test, feature = "rpc"))]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use reth_primitives_traits::SealedHeader;
+    use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
+
+    /// A pending/simulated block must not inherit the parent's beacon block root: it is not a real
+    /// block, so it has no such root. Zeroing matches op-geth's `eth_simulateV1` and upstream
+    /// paradigmxyz/reth#24652.
+    #[test]
+    fn pending_env_defaults_parent_beacon_root_to_zero() {
+        let header = Header {
+            parent_beacon_block_root: Some(B256::repeat_byte(0x42)),
+            ..Default::default()
+        };
+        let sealed = SealedHeader::new(header, B256::ZERO);
+
+        let attrs = OpNextBlockEnvAttributes::build_pending_env(&sealed);
+
+        assert_eq!(attrs.parent_beacon_block_root, Some(B256::ZERO));
+    }
+
+    /// Zeroing must not turn `None` into `Some`: the `Option` encodes whether the field exists at
+    /// all (gated on Cancun), which is independent of its value. A pre-Cancun parent stays `None`.
+    #[test]
+    fn pending_env_keeps_absent_parent_beacon_root_absent() {
+        let header = Header { parent_beacon_block_root: None, ..Default::default() };
+        let sealed = SealedHeader::new(header, B256::ZERO);
+
+        let attrs = OpNextBlockEnvAttributes::build_pending_env(&sealed);
+
+        assert_eq!(attrs.parent_beacon_block_root, None);
     }
 }


### PR DESCRIPTION
## Problem

`OpNextBlockEnvAttributes::build_pending_env` inherited the parent header's `parent_beacon_block_root`. A pending/simulated block is not a real block and has no beacon block root of its own, so carrying the parent's value over reports a root that never belonged to that block.

Concretely, `eth_simulateV1` returned a non-zero `parentBeaconBlockRoot` where op-geth returns the zero hash, which also made the simulated block `hash` differ across clients. This was one of three header fields diverging between op-geth and op-reth for the same request.

## Fix

Zero the value while preserving the `Option`:

```rust
parent_beacon_block_root: parent.parent_beacon_block_root().map(|_| B256::ZERO),
```

The `Option` encodes whether the field is present at all (gated on Cancun); `.map()` only replaces the inner value, so a pre-Cancun parent still yields `None`.

## Why this shape

op-geth initializes the field to the zero hash in `makeHeaders` (`internal/ethapi/simulate.go`) and only fills it from an explicit `beaconRoot` block override. Upstream reth made the same change for its Ethereum `NextBlockEnvAttributes` in paradigmxyz/reth#24652, citing go-ethereum as the reference — that PR did not touch this OP-specific implementation, so it is mirrored here.

## Blast radius

**Block production is unaffected.** The payload builder (`op-reth/crates/payload/`) and preconf (`mantle-reth/crates/preconf/`) paths do not go through `build_pending_env`; they take the beacon root from the engine API payload attributes (`payload.rs:145`).

`build_pending_env` is shared by three RPC paths, so this **does** change `eth_getBlockByNumber("pending")` to report a zero root. That matches op-geth's pending-block behavior and is the same side effect upstream #24652 accepted for the shared helper.

## Testing

- 2 new unit tests: zeroing a non-zero parent, and `None` staying `None` (pre-Cancun).
- Reverse-verified: reverting the one-line change makes the first test fail (`left: Some(0x4242…42), right: Some(0x00…00)`), so the assertion is not vacuous.
- `just test-ci` on this branch: **966 passed, 0 failed**.
- Real devnet, geth (with op-geth#173) vs reth cross-check on a block whose `parentBeaconBlockRoot` is genuinely non-zero (`0xaf4fc4c6…`): both clients now return `0x0000…`. Field-by-field header diff confirms this field no longer differs; the only remaining diffs are `stateRoot`/`withdrawalsRoot` (deliberately out of scope — they need proofdb, and upstream's switch for them defaults to off).

Self-test report: `docs/test/「2026_08」「fix」eth_simulateV1 跨端差异修复研发自测报告.md`