### PR TITLE
fix(preconf): freeze the pool best-tx iterator at build start

### DIFF
--- a/mantle-reth/crates/integration-tests/tests/preconf/race_pool_arm.rs
+++ b/mantle-reth/crates/integration-tests/tests/preconf/race_pool_arm.rs
@@ -17,9 +17,12 @@
 //! - `preconf_and_pool_txs_coexist_in_one_block` — a preconf-RPC tx and a regular-sendTx tx (from
 //!   independent senders) target the same slot; both land in that block, and the `select!`-biased
 //!   preconf arm ensures the preconf tx precedes the pool-arm tx.
+//! - `pool_tx_arriving_after_build_start_waits_for_the_next_block` — the pool iterator is a
+//!   snapshot, so a tx that reaches the pool after the build began is not in this block; it is not
+//!   lost either, and lands in the next one.
 
 use super::helpers::PreconfCfgBuilder;
-use crate::launch_preconf_node;
+use crate::{canonize_built, launch_preconf_node};
 use alloy_network::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
 use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
@@ -171,6 +174,12 @@ async fn non_preconf_eligible_regular_sendtx_lands_via_pool_arm() {
 /// pool-arm tx does NOT match the whitelist (`is_preconf_tx=false`) —
 /// otherwise it would also be routed into the fifo and both txs would
 /// land through the preconf path, which is not what we're testing.
+///
+/// **The pool tx is injected before the FCU, and has to be:** `build_payload`
+/// freezes its pool iterator at the start of Stage 3, so a tx admitted after
+/// that is a candidate for the *next* block (see
+/// `pool_tx_arriving_after_build_start_waits_for_the_next_block`). This test is
+/// about arm ordering within one block, so both txs must be candidates for it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn preconf_and_pool_txs_coexist_in_one_block() {
     use super::helpers::{mantle_test_chain_spec, send_preconf};
@@ -194,19 +203,8 @@ async fn preconf_and_pool_txs_coexist_in_one_block() {
     let (mut node, http, preconf_wallet, chain_id) = launch_preconf_node!(cfg).await;
     assert_eq!(preconf_wallet.inner.address(), preconf_sender_addr);
 
-    let attrs = node.payload.next_attributes();
-    let fcu_state = node.current_forkchoice_state().expect("forkchoice state");
-    let payload_id = node
-        .inner
-        .add_ons_handle
-        .beacon_engine_handle
-        .fork_choice_updated(fcu_state, Some(attrs))
-        .await
-        .expect("FCU must succeed")
-        .payload_id
-        .expect("payload_id present");
-
-    // Pool-arm tx: submit via `inject_tx` (plain `eth_sendRawTransaction`).
+    // Pool-arm tx: submit via `inject_tx` (plain `eth_sendRawTransaction`),
+    // **before** the FCU so it is in the pool when the build snapshots it.
     // `pool_sender_signer.address()` misses the whitelist ⇒ preconf listener
     // filter drops it ⇒ never enters fifo ⇒ pool arm is its only path.
     let pool_tx: alloy_primitives::Bytes = {
@@ -224,6 +222,18 @@ async fn preconf_and_pool_txs_coexist_in_one_block() {
         TransactionTestContext::sign_tx(pool_sender_signer, request).await.encoded_2718().into()
     };
     let pool_hash: B256 = node.rpc.inject_tx(pool_tx).await.expect("pool sendTx accepted");
+
+    let attrs = node.payload.next_attributes();
+    let fcu_state = node.current_forkchoice_state().expect("forkchoice state");
+    let payload_id = node
+        .inner
+        .add_ons_handle
+        .beacon_engine_handle
+        .fork_choice_updated(fcu_state, Some(attrs))
+        .await
+        .expect("FCU must succeed")
+        .payload_id
+        .expect("payload_id present");
 
     // Preconf-RPC tx: submitted through the preconf handler; parks a
     // responder, waits for dispatch to apply.
@@ -261,5 +271,104 @@ async fn preconf_and_pool_txs_coexist_in_one_block() {
     assert!(
         idx_preconf < idx_pool,
         "biased select! must place preconf arm ahead of pool arm; idx_preconf={idx_preconf}, idx_pool={idx_pool}",
+    );
+}
+
+/// **The pool iterator is a snapshot taken at build start.** A tx that reaches
+/// the pool after that is not a candidate for the block being built; it stays
+/// pooled and lands in the next one.
+///
+/// Regression guard for `without_updates()` in `build_payload` — without it the
+/// iterator keeps a live subscription to the pending pool and pulls the tx into
+/// block 1, failing the first assertion.
+///
+/// Both halves matter: block 1 proves the snapshot holds, block 2 proves the tx
+/// was **deferred, not dropped**.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pool_tx_arriving_after_build_start_waits_for_the_next_block() {
+    // Whitelist an unrelated placeholder so the config validates while the test
+    // wallet misses the list — `is_preconf_tx` is false, so the pool arm is this
+    // tx's only route and the preconf pipeline is not in the picture.
+    let placeholder = Address::from([0xFE; 20]);
+    let cfg =
+        PreconfCfgBuilder::new().whitelist_from(placeholder).whitelist_to(placeholder).build();
+
+    let (mut node, _http, wallet, chain_id) = launch_preconf_node!(cfg).await;
+
+    // ── Block 1: build starts against an empty pool ──────────────────
+    let attrs = node.payload.next_attributes();
+    let fcu_state = node.current_forkchoice_state().expect("forkchoice state");
+    let payload_id = node
+        .inner
+        .add_ons_handle
+        .beacon_engine_handle
+        .fork_choice_updated(fcu_state, Some(attrs))
+        .await
+        .expect("FCU must succeed")
+        .payload_id
+        .expect("payload_id present");
+
+    // The FCU returns once the job is registered, not once it reaches Stage 3 —
+    // this is what makes the tx provably later than the snapshot.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let raw_tx = signed_transfer(chain_id, &wallet, 0).await;
+    let tx_hash: B256 =
+        node.rpc.inject_tx(raw_tx).await.expect("plain sendRawTransaction accepted");
+
+    // Two `sweep_interval`s (200ms default): the pool arm has had its quota and
+    // run, so a miss below is the snapshot, not a ceiling that never opened.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let payload = node
+        .inner
+        .payload_builder_handle
+        .resolve_kind(payload_id, reth_node_api::PayloadKind::Earliest)
+        .await
+        .expect("resolve_kind")
+        .expect("payload build");
+
+    assert_eq!(payload.block().number, 1);
+    let sealed_1: Vec<B256> =
+        payload.block().body().transactions().map(|tx| keccak256(tx.encoded_2718())).collect();
+    assert!(
+        !sealed_1.contains(&tx_hash),
+        "a tx admitted to the pool after the build snapshotted it must not be in that block; \
+         hash {tx_hash:?} leaked into sealed block 1: {sealed_1:?}"
+    );
+
+    // ── Block 2: still pooled, and now inside the snapshot ───────────
+    canonize_built!(node, payload);
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let attrs = node.payload.next_attributes();
+    let fcu_state = node.current_forkchoice_state().expect("forkchoice state");
+    let payload_id = node
+        .inner
+        .add_ons_handle
+        .beacon_engine_handle
+        .fork_choice_updated(fcu_state, Some(attrs))
+        .await
+        .expect("FCU must succeed")
+        .payload_id
+        .expect("payload_id present");
+
+    // One sweep tick is enough for a single 21k tx (gas_per_batch >> 21k).
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    let payload = node
+        .inner
+        .payload_builder_handle
+        .resolve_kind(payload_id, reth_node_api::PayloadKind::Earliest)
+        .await
+        .expect("resolve_kind")
+        .expect("payload build");
+
+    let sealed_2: Vec<B256> =
+        payload.block().body().transactions().map(|tx| keccak256(tx.encoded_2718())).collect();
+    assert!(
+        sealed_2.contains(&tx_hash),
+        "the tx was deferred, not dropped — it must land in the next block; \
+         hash {tx_hash:?} not in sealed block 2: {sealed_2:?}"
     );
 }

--- a/mantle-reth/crates/preconf/src/builder/payload_builder.rs
+++ b/mantle-reth/crates/preconf/src/builder/payload_builder.rs
@@ -50,7 +50,7 @@ use reth_revm::{
     State, cancelled::CancelOnDrop, context::Block as RevmBlockTrait,
     database::StateProviderDatabase,
 };
-use reth_transaction_pool::PoolTransaction;
+use reth_transaction_pool::{BestTransactions, PoolTransaction};
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
@@ -899,7 +899,9 @@ impl<Pool, Client, Evm> PreconfPayloadBuilder<Pool, Client, Evm> {
         // Pool iterator — one-shot snapshot at build start.
         let best_txs_iter_opt = (!ctx.attributes().no_tx_pool()).then(|| {
             let attrs = ctx.best_transaction_attributes(builder.evm_mut().block());
-            BestPayloadTransactions::new(self.pool.best_transactions_with_attributes(attrs))
+            BestPayloadTransactions::new(
+                self.pool.best_transactions_with_attributes(attrs).without_updates(),
+            )
         });
 
         // Snapshot per-block limits (constant across the build).


### PR DESCRIPTION
`PendingPool::best` returns more than the snapshot the comment claimed: alongside a clone of `by_id` it hands back a live subscription to the pending pool's broadcast notifier, which `BestTransactions::next` drains on every call. `BestPayloadTransactions` forwards `next` unchanged and nothing here called `no_updates()`, so the iterator was half-live.

`without_updates()` drops that subscription. The live feed was mostly unusable anyway — `BestTxStep::Done` disables the pool arm for the rest of the build, and `Done` is exactly "the iterator returned `None`", so on any chain that drains its pool early in the slot the subscription is dropped on the floor for the remaining seconds; a new payload job per FCU rebuilds the iterator regardless. What it did deliver was priority-dependent and silent: a late arrival whose priority is *higher* than the last transaction already yielded is stashed rather than emitted, to keep the descending-priority order intact, and a `Lagged` receiver is ignored outright. Freezing the set makes one build a function of the pool state at t0, which `derive_pool_quota_schedule` already assumes.

`preconf_and_pool_txs_coexist_in_one_block` injected its pool tx *after* the FCU and so depended on the live feed. That ordering was incidental: its docs spell out the sender-choice constraint but never mention arrival timing, both sibling tests inject before the FCU, and its 400ms sleep is documented as waiting for `pool_quota`. Moved the injection ahead of the FCU; the stated coverage (both arms land in one block, biased `select!` orders preconf first) is unchanged, and the preconf tx still arrives mid-build, so the interleaving it exercises is intact.

`pool_tx_arriving_after_build_start_waits_for_the_next_block` is the new guard. Block 1 must not contain a tx that reached the pool after the snapshot; block 2 must, so the tx is provably deferred rather than dropped — without that second half the test would pass just as well if the pool arm had silently lost it. Verified red without `without_updates()`.

## Summary

<!-- What does this PR do? -->

## Test plan

- [ ] `just pr` passed locally (fmt + clippy + test + test-doc)
