### PR TITLE
chore(deps): pin mantle-v2 crates to tag v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.5.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -5848,7 +5848,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "op-alloy"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5890,7 +5890,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5917,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5947,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "2.0.0"
-source = "git+https://github.com/mantle-xyz/mantle-v2?branch=mantle-elysium#9eecb9e905adffb32aff26115cd108b801475be4"
+source = "git+https://github.com/mantle-xyz/mantle-v2?tag=v1.6.0#710dbc40b295a93e0c7eb474615faa1c3b8ae368"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@
 #   revm/op-revm   → mantle-xyz/revm tag v107-mantle-arsia.1 (Mantle fee model + op-geth parity)
 #   revm-inspectors → mantle-xyz/revm-inspectors tag v0.39.0-mantle-arsia.1
 #   alloy-evm      → crates.io 0.34.0 (upstream, no Mantle patches; see mantle-v2#359)
-#   alloy-op-evm   → mantle-xyz/mantle-v2 branch mantle-elysium
-#   alloy-op-hardforks → mantle-xyz/mantle-v2 branch mantle-elysium
-#   op-alloy       → mantle-xyz/mantle-v2 branch mantle-elysium
+#   alloy-op-evm   → mantle-xyz/mantle-v2 tag v1.6.0
+#   alloy-op-hardforks → mantle-xyz/mantle-v2 tag v1.6.0
+#   op-alloy       → mantle-xyz/mantle-v2 tag v1.6.0
 #   alloy base     → crates.io 2.0.4
 
 [workspace.package]
@@ -259,21 +259,21 @@ alloy-evm = { version = "0.34.0", default-features = false }
 
 # ==================== ALLOY-OP-EVM / ALLOY-OP-HARDFORKS (Mantle: mantle-xyz/mantle-v2) ====================
 # TODO: Switch to tag once mantle-v2 Rust crates are tagged
-alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
-alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
+alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
+alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
 
 # ==================== OP-REVM (Mantle fork: mantle-xyz/revm, same repo as revm) ====================
 op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1", default-features = false }
 
 # ==================== OP-ALLOY (Mantle: mantle-xyz/mantle-v2) ====================
 # TODO: Switch to tag once mantle-v2 Rust crates are tagged
-op-alloy = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
-op-alloy-consensus = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
-op-alloy-network = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
-op-alloy-provider = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
-op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
-op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
-op-alloy-rpc-jsonrpsee = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium", default-features = false }
+op-alloy = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
+op-alloy-consensus = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
+op-alloy-network = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
+op-alloy-provider = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
+op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
+op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
+op-alloy-rpc-jsonrpsee = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0", default-features = false }
 op-alloy-flz = { version = "0.13.1", default-features = false }
 
 # ==================== ALLOY ====================
@@ -447,11 +447,11 @@ revm-inspectors = { git = "https://github.com/mantle-xyz/revm-inspectors", tag =
 # op-revm: mantle-xyz/revm (same as workspace dep)
 op-revm = { git = "https://github.com/mantle-xyz/revm", tag = "v107-mantle-arsia.1" }
 # alloy-op-evm / alloy-op-hardforks: mantle-xyz/mantle-v2 (Mantle version)
-alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
-alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
+alloy-op-evm = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0" }
+alloy-op-hardforks = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0" }
 # op-alloy: mantle-xyz/mantle-v2 (Mantle version)
-op-alloy-consensus = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
-op-alloy-network = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
-op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
-op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
-op-alloy-rpc-jsonrpsee = { git = "https://github.com/mantle-xyz/mantle-v2", branch = "mantle-elysium" }
+op-alloy-consensus = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0" }
+op-alloy-network = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0" }
+op-alloy-rpc-types = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0" }
+op-alloy-rpc-types-engine = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0" }
+op-alloy-rpc-jsonrpsee = { git = "https://github.com/mantle-xyz/mantle-v2", tag = "v1.6.0" }


### PR DESCRIPTION
## What

Repoint the `mantle-xyz/mantle-v2` git dependencies from `branch = "mantle-elysium"` to `tag = "v1.6.0"`:

- `alloy-op-evm`, `alloy-op-hardforks`
- `op-alloy`, `op-alloy-consensus`, `op-alloy-network`, `op-alloy-provider`, `op-alloy-rpc-types`, `op-alloy-rpc-types-engine`, `op-alloy-rpc-jsonrpsee`

Touches `[workspace.dependencies]`, `[patch.crates-io]`, and the dependency-strategy header comment.

## Why

The pin was a **branch**, so it only held because `Cargo.lock` happened to be frozen at `9eecb9e9`. The branch head had since moved to `c778ba467` — anyone running `cargo update` would have silently pulled in 10 unreviewed commits. A tag makes the pin mean what it already looked like it meant.

It also lines up with the `src/mantle-v2` submodule baseline in the rde-v3 superproject, which is already checked out at `v1.6.0`.

## No functional change

`v1.6.0` (`710dbc40`) is a descendant of both the old lock commit and the `mantle-elysium` head — pure fast-forward, no divergence. The four crate trees this workspace consumes are **byte-identical** across the move:

| path | tree hash (both sides) |
|---|---|
| `rust/alloy-op-evm` | `dd1b5205` |
| `rust/alloy-op-hardforks` | `b5b51f15` |
| `rust/op-alloy` | `409a5752` |
| `rust/op-revm` | `d37bb8e1` |

The 11 intervening commits land in `rust/kona/` (not used here) and in mantle-v2's own `[patch.crates-io]` revm redirect — which Cargo ignores for git dependencies, since only the root workspace's patch section applies. This workspace's revm pin (`v107-mantle-arsia.1`) is untouched.

`Cargo.lock` changes are `source =` lines only — same versions, same checksums, nothing added or removed:

```
Adding   alloy-op-evm v0.32.0 (…mantle-v2?tag=v1.6.0#710dbc40)
Removing alloy-op-evm v0.32.0 (…mantle-v2?branch=mantle-elysium#9eecb9e9)
```

## Test plan

- [x] `just pr` green locally — `lint` (fmt + clippy `-D warnings`), `test-ci` (unit + all integration suites + doctests), `test-doc` (`--all-features`)
- [x] `cargo update` resolves the tag to `710dbc40`, the expected commit
- [x] `cargo fmt --all` is a no-op on this diff