### PR TITLE
feat(flashblocks): producer foundations — wire format, config, slice budget, publisher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,7 +5268,9 @@ dependencies = [
  "either",
  "eyre",
  "futures",
+ "futures-util",
  "jsonrpsee",
+ "mantle-reth-flashblocks-types",
  "mantle-reth-rpc-ext",
  "metrics",
  "op-alloy-consensus",
@@ -5306,6 +5308,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
  "tracing",
 ]
 

--- a/mantle-reth/crates/cli/src/args.rs
+++ b/mantle-reth/crates/cli/src/args.rs
@@ -17,16 +17,20 @@
 //! upstream `RollupArgs` convention — every configuration knob lives on the
 //! command line and is discoverable via `--help`.
 
-use std::{path::PathBuf, time::Duration};
+use std::{net::IpAddr, path::PathBuf, time::Duration};
 
 use alloy_primitives::Address;
 use clap::Args;
 use mantle_reth_preconf::{
-    PreconfConfig,
+    FlashblockProducerConfig, FlashblockProducerConfigError, PreconfConfig,
     config::{
         DEFAULT_BROADCAST_CAP, DEFAULT_JOURNAL_MAX_SIZE, DEFAULT_PRECONF_MAX_GAS_PER_BLOCK,
         DEFAULT_PRECONF_MAX_GAS_PER_TX, DEFAULT_PRECONF_TIMEOUT, DEFAULT_REJOURNAL_INTERVAL,
         DEFAULT_SLOT_DURATION, DEFAULT_SWEEP_INTERVAL,
+    },
+    flashblocks::{
+        DEFAULT_FLASHBLOCK_ADDR, DEFAULT_FLASHBLOCK_BLOCK_TIME, DEFAULT_FLASHBLOCK_LEEWAY,
+        DEFAULT_FLASHBLOCK_PORT,
     },
 };
 use reth_optimism_node::args::RollupArgs;
@@ -42,6 +46,93 @@ pub struct MantleArgs {
     /// Mantle preconf subsystem arguments (`--preconf.*`).
     #[command(flatten)]
     pub preconf: PreconfArgs,
+
+    /// Mantle flashblocks publisher arguments (`--flashblocks.*`).
+    #[command(flatten)]
+    pub flashblocks: FlashblocksArgs,
+}
+
+impl MantleArgs {
+    /// Resolve both Mantle subsystem configs, rejecting combinations that
+    /// cannot work before the node starts.
+    ///
+    /// Either config is `None` when its subsystem is off.
+    pub fn into_configs(
+        self,
+    ) -> Result<
+        (Option<PreconfConfig>, Option<FlashblockProducerConfig>),
+        FlashblockProducerConfigError,
+    > {
+        let preconf = self.preconf.into_config();
+        let flashblocks =
+            self.flashblocks.into_config().map(|cfg| cfg.validate(preconf.as_ref())).transpose()?;
+
+        Ok((preconf, flashblocks))
+    }
+}
+
+/// Flashblocks publisher CLI flags.
+///
+/// Sequencer-side only. `--flashblocks.enable` requires `--preconf.enable`;
+/// the check lives in [`FlashblockProducerConfig::validate`] rather than in
+/// clap, because the two flags come from different flattened groups.
+///
+/// Every flag sets an explicit `id`: clap derives the id from the field
+/// name, and `enable` alone would collide with the preconf group.
+#[derive(Debug, Clone, PartialEq, Eq, Args, Default)]
+pub struct FlashblocksArgs {
+    /// Slice each block as it is built and publish the slices.
+    ///
+    /// Off by default: leaving it off keeps the payload builder's
+    /// pre-flashblock behaviour byte for byte, which is the rollback path.
+    #[arg(id = "flashblocks.enable", long = "flashblocks.enable")]
+    pub enable: bool,
+
+    /// Address the flashblocks publisher binds. Default `127.0.0.1`.
+    #[arg(id = "flashblocks.addr", long = "flashblocks.addr")]
+    pub addr: Option<IpAddr>,
+
+    /// Port the flashblocks publisher binds. Default `1111`.
+    #[arg(id = "flashblocks.port", long = "flashblocks.port")]
+    pub port: Option<u16>,
+
+    /// Interval between slices, in milliseconds. Default 200ms.
+    ///
+    /// When flashblocks are enabled this also becomes the payload builder's
+    /// ticker cadence, superseding `--preconf.sweep-interval-ms`.
+    #[arg(id = "flashblocks.block-time", long = "flashblocks.block-time")]
+    pub block_time_ms: Option<u64>,
+
+    /// How far ahead of the slot deadline the budgeted slice grid finishes,
+    /// in milliseconds. Default 50ms.
+    #[arg(id = "flashblocks.leeway-time", long = "flashblocks.leeway-time")]
+    pub leeway_time_ms: Option<u64>,
+}
+
+impl FlashblocksArgs {
+    /// Convert CLI args into a [`FlashblockProducerConfig`] if
+    /// `--flashblocks.enable` was given; otherwise return `None`.
+    ///
+    /// Ring and broadcast capacities are not exposed on the CLI; they take
+    /// their defaults.
+    pub fn into_config(self) -> Option<FlashblockProducerConfig> {
+        if !self.enable {
+            return None;
+        }
+        Some(FlashblockProducerConfig {
+            addr: self.addr.unwrap_or(DEFAULT_FLASHBLOCK_ADDR),
+            port: self.port.unwrap_or(DEFAULT_FLASHBLOCK_PORT),
+            block_time: self
+                .block_time_ms
+                .map(Duration::from_millis)
+                .unwrap_or(DEFAULT_FLASHBLOCK_BLOCK_TIME),
+            leeway_time: self
+                .leeway_time_ms
+                .map(Duration::from_millis)
+                .unwrap_or(DEFAULT_FLASHBLOCK_LEEWAY),
+            ..Default::default()
+        })
+    }
 }
 
 /// Preconfirmation subsystem CLI flags.
@@ -286,6 +377,117 @@ mod tests {
         assert_eq!(cfg.rejournal_interval, Duration::from_secs(30));
         assert_eq!(cfg.journal_max_size, 2_147_483_648);
         assert_eq!(cfg.broadcast_cap, 8192);
+    }
+
+    /// Test helper mirroring [`parse`] for the flashblocks group.
+    #[derive(Parser, Debug)]
+    struct TestFlashblocksCli {
+        #[command(flatten)]
+        args: FlashblocksArgs,
+    }
+
+    fn parse_flashblocks(argv: &[&str]) -> FlashblocksArgs {
+        TestFlashblocksCli::parse_from(std::iter::once(&"reth").chain(argv.iter())).args
+    }
+
+    #[test]
+    fn flashblocks_default_parse_yields_disabled() {
+        // No flags → into_config() returns None → flashblocks stay off,
+        // matching how the preconf group signals the same thing.
+        assert!(parse_flashblocks(&[]).into_config().is_none());
+    }
+
+    #[test]
+    fn flashblocks_numeric_overrides_replace_defaults() {
+        let cfg = parse_flashblocks(&[
+            "--flashblocks.enable",
+            "--flashblocks.addr",
+            "0.0.0.0",
+            "--flashblocks.port",
+            "2222",
+            "--flashblocks.block-time",
+            "250",
+            "--flashblocks.leeway-time",
+            "0",
+        ])
+        .into_config()
+        .expect("enabled");
+
+        assert_eq!(cfg.addr, IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+        assert_eq!(cfg.port, 2222);
+        assert_eq!(cfg.block_time, Duration::from_millis(250));
+        assert_eq!(cfg.leeway_time, Duration::ZERO);
+    }
+
+    #[test]
+    fn flashblocks_omitted_flags_keep_defaults() {
+        let cfg = parse_flashblocks(&["--flashblocks.enable"]).into_config().expect("enabled");
+
+        assert_eq!(cfg.addr, DEFAULT_FLASHBLOCK_ADDR);
+        assert_eq!(cfg.port, DEFAULT_FLASHBLOCK_PORT);
+        assert_eq!(cfg.block_time, DEFAULT_FLASHBLOCK_BLOCK_TIME);
+        assert_eq!(cfg.leeway_time, DEFAULT_FLASHBLOCK_LEEWAY);
+    }
+
+    /// The two groups are validated against each other, and enabling
+    /// flashblocks without preconf is rejected before the node starts.
+    #[test]
+    fn flashblocks_without_preconf_is_rejected_at_startup() {
+        let flashblocks =
+            parse_flashblocks(&["--flashblocks.enable"]).into_config().expect("enabled");
+        let preconf = parse(&["--preconf.enable", "--preconf.all"]).into_config();
+
+        assert!(flashblocks.clone().validate(preconf.as_ref()).is_ok());
+        assert!(flashblocks.validate(None).is_err());
+    }
+
+    /// Test helper covering the whole arg surface, so the startup gate is
+    /// exercised the way `main` reaches it.
+    #[derive(Parser, Debug)]
+    struct TestMantleCli {
+        #[command(flatten)]
+        args: MantleArgs,
+    }
+
+    fn parse_mantle(argv: &[&str]) -> MantleArgs {
+        TestMantleCli::parse_from(std::iter::once(&"reth").chain(argv.iter())).args
+    }
+
+    #[test]
+    fn enabling_flashblocks_alone_fails_the_startup_gate() {
+        let err = parse_mantle(&["--flashblocks.enable"]).into_configs().unwrap_err();
+
+        assert_eq!(err, FlashblockProducerConfigError::RequiresPreconfEnabled);
+    }
+
+    #[test]
+    fn enabling_both_passes_the_startup_gate() {
+        let (preconf, flashblocks) =
+            parse_mantle(&["--preconf.enable", "--preconf.all", "--flashblocks.enable"])
+                .into_configs()
+                .expect("both enabled is a valid combination");
+
+        assert!(preconf.is_some());
+        assert!(flashblocks.is_some());
+    }
+
+    /// Today's production shape: preconf on, flashblocks not yet rolled out.
+    #[test]
+    fn enabling_preconf_alone_leaves_flashblocks_absent() {
+        let (preconf, flashblocks) = parse_mantle(&["--preconf.enable", "--preconf.all"])
+            .into_configs()
+            .expect("preconf alone is a valid combination");
+
+        assert!(preconf.is_some());
+        assert!(flashblocks.is_none());
+    }
+
+    #[test]
+    fn enabling_neither_passes_the_startup_gate() {
+        let (preconf, flashblocks) = parse_mantle(&[]).into_configs().expect("defaults are valid");
+
+        assert!(preconf.is_none());
+        assert!(flashblocks.is_none());
     }
 
     #[test]

--- a/mantle-reth/crates/cli/src/main.rs
+++ b/mantle-reth/crates/cli/src/main.rs
@@ -40,8 +40,28 @@ fn main() {
         async move |builder, args| {
             info!(target: "reth::cli", "Launching Mantle node");
             let mut node = MantleNode::new(args.rollup.clone());
-            let preconf_cfg = args.preconf.into_config();
+            let rollup = args.rollup.clone();
+            let sweep_interval_given = args.preconf.sweep_interval_ms.is_some();
+            let (preconf_cfg, flashblocks_cfg) = args.into_configs()?;
             let preconf_enabled = preconf_cfg.is_some();
+            if let Some(fb) = flashblocks_cfg.as_ref() {
+                info!(
+                    target: "reth::cli",
+                    "Mantle flashblocks ENABLED (publish={}:{}, block_time={:?}, leeway={:?})",
+                    fb.addr, fb.port, fb.block_time, fb.leeway_time,
+                );
+                if sweep_interval_given {
+                    info!(
+                        target: "reth::cli",
+                        "--preconf.sweep-interval-ms is superseded by --flashblocks.block-time while flashblocks are enabled",
+                    );
+                }
+            } else {
+                info!(
+                    target: "reth::cli",
+                    "Mantle flashblocks DISABLED (pass --flashblocks.enable to opt in)",
+                );
+            }
             match preconf_cfg {
                 Some(mut cfg) => {
                     let all = cfg.all_preconfs;
@@ -76,7 +96,7 @@ fn main() {
                     );
                 }
             }
-            launch_node(builder, node, args.rollup, preconf_enabled).await
+            launch_node(builder, node, rollup, preconf_enabled).await
         },
     ) {
         eprintln!("Error: {err:?}");

--- a/mantle-reth/crates/preconf/Cargo.toml
+++ b/mantle-reth/crates/preconf/Cargo.toml
@@ -12,6 +12,9 @@ description = "Mantle preconfirmation core types for op-reth"
 workspace = true
 
 [dependencies]
+# The flashblock wire format, shared with the RPC-side consumer.
+mantle-reth-flashblocks-types.workspace = true
+
 # Alloy
 alloy-primitives = { workspace = true, features = ["std", "serde"] }
 alloy-consensus = { workspace = true, features = ["std"] }
@@ -118,7 +121,7 @@ async-trait.workspace = true
 reth-rpc-eth-types.workspace = true
 
 # Async runtime + sync primitives + async fs for the journal
-tokio = { workspace = true, features = ["sync", "macros", "time", "fs", "io-util", "rt"] }
+tokio = { workspace = true, features = ["sync", "macros", "time", "fs", "io-util", "rt", "net"] }
 
 # Sync RwLock for `PreconfClassifier`'s allowlists and verdict cache.
 # Deliberately NOT tokio's: both are read from the payload builder's
@@ -126,6 +129,13 @@ tokio = { workspace = true, features = ["sync", "macros", "time", "fs", "io-util
 # `blocking_read` would panic. parking_lot also has no poisoning, so a panicking
 # writer cannot wedge that hot read path.
 parking_lot.workspace = true
+
+# WebSocket publisher for flashblocks: `tokio-tungstenite` for the server-side
+# handshake and framing, `tokio-util` for the cancellation token that shuts the
+# listener and its per-client loops down together.
+tokio-tungstenite.workspace = true
+tokio-util.workspace = true
+futures-util.workspace = true
 
 # Error handling
 thiserror.workspace = true
@@ -144,7 +154,7 @@ metrics.workspace = true
 serde = { workspace = true, features = ["derive", "std"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["sync", "macros", "rt", "time", "test-util", "fs"] }
+tokio = { workspace = true, features = ["sync", "macros", "rt", "rt-multi-thread", "time", "test-util", "fs", "net"] }
 tempfile.workspace = true
 proptest.workspace = true
 

--- a/mantle-reth/crates/preconf/src/flashblocks/broadcast.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/broadcast.rs
@@ -1,0 +1,566 @@
+//! Serving one subscriber: catch it up from the archive, then hand it the
+//! live stream.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use futures_util::{SinkExt, StreamExt};
+use parking_lot::RwLock;
+use tokio::{net::TcpStream, sync::broadcast};
+use tokio_tungstenite::{
+    WebSocketStream, accept_hdr_async,
+    tungstenite::{
+        Message,
+        handshake::server::{Request, Response},
+    },
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::flashblocks::{FlashblockPosition, FlashblockRingBuffer, publisher::PositionedSlice};
+
+/// How long a subscriber gets to complete the `WebSocket` handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long a single catch-up send may take before the subscriber is treated
+/// as unable to keep up.
+const REPLAY_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What catching a subscriber up achieved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayOutcome {
+    /// Slices handed over before joining the live stream.
+    pub sent: usize,
+    /// The requested position had already fallen out of the archive, so the
+    /// subscriber is missing slices that no longer exist here. It has to close
+    /// that gap from the canonical chain instead.
+    pub preceded_by_gap: bool,
+    /// The requested position sits past everything published. The subscriber's
+    /// block was rebuilt out from under it, or it is not talking to this
+    /// producer. Nothing is owed either way, but neither cause is routine.
+    pub ahead_of_archive: bool,
+}
+
+/// Why a subscription ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscriptionExit {
+    /// The publisher is shutting down.
+    Cancelled,
+    /// The subscriber fell far enough behind that slices were dropped, so it
+    /// is disconnected to reconnect and replay rather than served a stream
+    /// with holes in it.
+    Lagged(u64),
+    /// The subscriber went away.
+    ClientClosed,
+    /// Nothing will be published again.
+    ChannelClosed,
+    /// Writing to the subscriber failed.
+    SendFailed,
+}
+
+/// Read the slice a reconnecting subscriber last received from its handshake
+/// URI: `?block_number=X&flashblock_index=Y`.
+///
+/// Returns `None` for a first-time connection, and for anything malformed —
+/// the query arrives from the network, so an unusable one means "start from
+/// live" rather than an error.
+pub fn parse_resume_position(uri: &str) -> Option<FlashblockPosition> {
+    let query = uri.split_once('?').map(|(_, query)| query)?;
+
+    let param = |name: &str| {
+        query
+            .split('&')
+            .filter_map(|pair| pair.split_once('='))
+            .find(|(key, _)| *key == name)
+            .and_then(|(_, value)| value.parse::<u64>().ok())
+    };
+
+    Some(FlashblockPosition {
+        block_number: param("block_number")?,
+        flashblock_index: param("flashblock_index")?,
+    })
+}
+
+/// Serve one subscriber for the life of its connection.
+///
+/// Takes the sender rather than a receiver so the subscription can only be
+/// opened once the handshake is done. Subscribing earlier would let a slow
+/// handshake accumulate more slices than the channel holds, and the
+/// subscriber would be dropped as lagging the moment it started reading —
+/// then reconnect into the same trap. Anything published before this point
+/// is the archive's job.
+pub(crate) async fn serve_subscriber(
+    connection: TcpStream,
+    pipe: &broadcast::Sender<PositionedSlice>,
+    ring: Arc<RwLock<FlashblockRingBuffer>>,
+    cancel: CancellationToken,
+) {
+    // The resume position lives in the upgrade request, which the handshake
+    // consumes: once it returns, the stream no longer carries it. The callback
+    // writes it out on the way past.
+    let mut resume_from = None;
+    let handshake = accept_hdr_async(connection, |request: &Request, response: Response| {
+        resume_from = parse_resume_position(&request.uri().to_string());
+        Ok(response)
+    });
+
+    let mut stream = match tokio::time::timeout(HANDSHAKE_TIMEOUT, handshake).await {
+        Ok(Ok(stream)) => stream,
+        Ok(Err(error)) => {
+            warn!(target: "mantle::preconf::flashblocks", %error, "subscriber handshake failed");
+            return;
+        }
+        Err(_) => {
+            warn!(target: "mantle::preconf::flashblocks", "subscriber handshake timed out");
+            return;
+        }
+    };
+
+    let mut receiver = pipe.subscribe();
+
+    if let Some(cutoff) = resume_from {
+        let replayed = tokio::select! {
+            () = cancel.cancelled() => return,
+            outcome = replay(&mut stream, &mut receiver, &ring, cutoff) => outcome,
+        };
+        match replayed {
+            Ok(outcome) => {
+                if outcome.preceded_by_gap {
+                    warn!(
+                        target: "mantle::preconf::flashblocks",
+                        block_number = cutoff.block_number,
+                        flashblock_index = cutoff.flashblock_index,
+                        "subscriber resumed from before the archive; it must close the gap from canonical",
+                    );
+                }
+                if outcome.ahead_of_archive {
+                    warn!(
+                        target: "mantle::preconf::flashblocks",
+                        block_number = cutoff.block_number,
+                        flashblock_index = cutoff.flashblock_index,
+                        "subscriber resumed from past everything published; its block was rebuilt or it is on the wrong producer",
+                    );
+                }
+                debug!(
+                    target: "mantle::preconf::flashblocks",
+                    sent = outcome.sent,
+                    "caught subscriber up",
+                );
+            }
+            Err(exit) => {
+                debug!(target: "mantle::preconf::flashblocks", ?exit, "catch-up abandoned");
+                return;
+            }
+        }
+    }
+
+    let exit = pump_live(&mut stream, &mut receiver, &cancel).await;
+    debug!(target: "mantle::preconf::flashblocks", ?exit, "subscription ended");
+}
+
+/// Hand over everything published after `cutoff`, in two phases.
+///
+/// The archive is snapshotted first, then whatever arrived live while that
+/// snapshot was being sent is drained and deduplicated against it. Without the
+/// second phase a slice published mid-catch-up would be missed: it is too late
+/// for the snapshot and too early for the live loop.
+async fn replay(
+    stream: &mut WebSocketStream<TcpStream>,
+    receiver: &mut broadcast::Receiver<PositionedSlice>,
+    ring: &RwLock<FlashblockRingBuffer>,
+    cutoff: FlashblockPosition,
+) -> Result<ReplayOutcome, SubscriptionExit> {
+    let (snapshot, preceded_by_gap, ahead_of_archive) = {
+        let ring = ring.read();
+        (ring.entries_after(&cutoff), ring.precedes_window(&cutoff), ring.exceeds_window(&cutoff))
+    };
+
+    let mut delivered: HashSet<FlashblockPosition> =
+        HashSet::with_capacity(snapshot.len().saturating_add(receiver.len()));
+    let mut sent = 0usize;
+
+    for (position, text) in snapshot {
+        delivered.insert(position);
+        send_with_timeout(stream, text).await?;
+        sent += 1;
+    }
+
+    // Drain without awaiting, so nothing new can interleave: an empty channel
+    // is the termination condition, not a fixed count.
+    let mut pending = Vec::new();
+    loop {
+        match receiver.try_recv() {
+            Ok((position, text)) => {
+                if delivered.insert(position) {
+                    pending.push(text);
+                }
+            }
+            Err(broadcast::error::TryRecvError::Empty) => break,
+            Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                return Err(SubscriptionExit::Lagged(skipped));
+            }
+            Err(broadcast::error::TryRecvError::Closed) => {
+                return Err(SubscriptionExit::ChannelClosed);
+            }
+        }
+    }
+
+    for text in pending {
+        send_with_timeout(stream, text).await?;
+        sent += 1;
+    }
+
+    Ok(ReplayOutcome { sent, preceded_by_gap, ahead_of_archive })
+}
+
+async fn send_with_timeout(
+    stream: &mut WebSocketStream<TcpStream>,
+    text: tokio_tungstenite::tungstenite::Utf8Bytes,
+) -> Result<(), SubscriptionExit> {
+    match tokio::time::timeout(REPLAY_SEND_TIMEOUT, stream.send(Message::Text(text))).await {
+        Ok(Ok(())) => Ok(()),
+        _ => Err(SubscriptionExit::SendFailed),
+    }
+}
+
+/// Forward live slices until something ends the subscription.
+pub(crate) async fn pump_live(
+    stream: &mut WebSocketStream<TcpStream>,
+    receiver: &mut broadcast::Receiver<PositionedSlice>,
+    cancel: &CancellationToken,
+) -> SubscriptionExit {
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => return SubscriptionExit::Cancelled,
+
+            published = receiver.recv() => match published {
+                Ok((_, text)) => {
+                    if stream.send(Message::Text(text)).await.is_err() {
+                        return SubscriptionExit::SendFailed;
+                    }
+                }
+                // Dropping a lagging subscriber is deliberate: a stream with
+                // holes in it is worse than no stream, and reconnecting
+                // replays from the archive.
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    return SubscriptionExit::Lagged(skipped);
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return SubscriptionExit::ChannelClosed;
+                }
+            },
+
+            incoming = stream.next() => match incoming {
+                Some(Ok(Message::Close(_))) | None => return SubscriptionExit::ClientClosed,
+                Some(Err(_)) => return SubscriptionExit::ClientClosed,
+                Some(Ok(_)) => {}
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, num::NonZeroUsize, sync::Arc, time::Duration};
+
+    use futures_util::StreamExt;
+    use parking_lot::RwLock;
+    use tokio::{
+        net::{TcpListener, TcpStream},
+        sync::broadcast,
+    };
+    use tokio_tungstenite::{
+        MaybeTlsStream, WebSocketStream, accept_async, client_async,
+        tungstenite::{Message, Utf8Bytes},
+    };
+    use tokio_util::sync::CancellationToken;
+
+    use super::{
+        FlashblockRingBuffer, PositionedSlice, SubscriptionExit, parse_resume_position, pump_live,
+        replay,
+    };
+    use crate::flashblocks::FlashblockPosition;
+
+    fn pos(block_number: u64, flashblock_index: u64) -> FlashblockPosition {
+        FlashblockPosition { block_number, flashblock_index }
+    }
+
+    fn slice(position: FlashblockPosition) -> PositionedSlice {
+        (
+            position,
+            Utf8Bytes::from(format!("{}-{}", position.block_number, position.flashblock_index)),
+        )
+    }
+
+    /// A connected `WebSocket` pair over loopback: the server half is what the
+    /// publisher writes to, the client half is what a subscriber reads.
+    async fn socket_pair()
+    -> (WebSocketStream<TcpStream>, WebSocketStream<MaybeTlsStream<TcpStream>>) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (connection, _) = listener.accept().await.expect("accept");
+            accept_async(connection).await.expect("server handshake")
+        });
+
+        let connection = TcpStream::connect(addr).await.expect("connect");
+        let (client, _) = client_async(format!("ws://{addr}/"), MaybeTlsStream::Plain(connection))
+            .await
+            .expect("client handshake");
+
+        (server.await.expect("server task"), client)
+    }
+
+    /// Drain what the subscriber has actually been sent, stopping once the
+    /// stream goes quiet.
+    async fn drain(
+        client: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        expected: usize,
+    ) -> Vec<String> {
+        let mut seen = Vec::with_capacity(expected);
+        for _ in 0..expected {
+            match tokio::time::timeout(Duration::from_millis(500), client.next()).await {
+                Ok(Some(Ok(Message::Text(text)))) => seen.push(text.as_str().to_owned()),
+                _ => break,
+            }
+        }
+        seen
+    }
+
+    fn ring_with(
+        positions: impl IntoIterator<Item = FlashblockPosition>,
+    ) -> Arc<RwLock<FlashblockRingBuffer>> {
+        let ring = FlashblockRingBuffer::new(NonZeroUsize::new(16).expect("non-zero"));
+        let ring = Arc::new(RwLock::new(ring));
+        for position in positions {
+            let (position, text) = slice(position);
+            ring.write().push(position, text);
+        }
+        ring
+    }
+
+    /// A slice published while the archive is still being replayed belongs to
+    /// neither phase on its own: too late for the snapshot, too early for the
+    /// live loop. The drain is what keeps it from being dropped.
+    #[tokio::test]
+    async fn catch_up_delivers_what_arrived_while_the_archive_was_replayed() {
+        let (mut server, mut client) = socket_pair().await;
+        let ring = ring_with([pos(10, 1), pos(10, 2)]);
+        let (pipe, mut receiver) = broadcast::channel(8);
+        // Published after this subscriber's receiver existed, but before its
+        // catch-up ran.
+        pipe.send(slice(pos(10, 3))).expect("receiver is alive");
+
+        let outcome = replay(&mut server, &mut receiver, &ring, pos(10, 0))
+            .await
+            .expect("catch-up completes");
+
+        assert_eq!(outcome.sent, 3);
+        assert_eq!(drain(&mut client, 4).await, ["10-1", "10-2", "10-3"]);
+    }
+
+    /// The same slice can sit in the archive and in the channel at once. It
+    /// must be handed over once.
+    #[tokio::test]
+    async fn catch_up_does_not_repeat_a_slice_held_in_both_phases() {
+        let (mut server, mut client) = socket_pair().await;
+        let ring = ring_with([pos(10, 1), pos(10, 2)]);
+        let (pipe, mut receiver) = broadcast::channel(8);
+        pipe.send(slice(pos(10, 2))).expect("receiver is alive");
+        pipe.send(slice(pos(10, 3))).expect("receiver is alive");
+
+        let outcome = replay(&mut server, &mut receiver, &ring, pos(10, 0))
+            .await
+            .expect("catch-up completes");
+
+        assert_eq!(outcome.sent, 3, "10-2 is in both the archive and the channel");
+        assert_eq!(drain(&mut client, 4).await, ["10-1", "10-2", "10-3"]);
+    }
+
+    #[tokio::test]
+    async fn a_resume_position_inside_the_archive_reports_no_gap() {
+        let (mut server, _client) = socket_pair().await;
+        let ring = ring_with([pos(10, 1), pos(10, 2)]);
+        let (_pipe, mut receiver) = broadcast::channel(8);
+
+        let outcome = replay(&mut server, &mut receiver, &ring, pos(10, 1))
+            .await
+            .expect("catch-up completes");
+
+        assert!(!outcome.preceded_by_gap);
+    }
+
+    /// The subscriber asked to resume from before anything still held. It is
+    /// given the whole window, but the gap in front of that window is real and
+    /// only it can close it, from the canonical chain.
+    #[tokio::test]
+    async fn a_resume_position_older_than_the_archive_is_reported_as_a_gap() {
+        let (mut server, mut client) = socket_pair().await;
+        let ring = ring_with([pos(10, 5), pos(10, 6)]);
+        let (_pipe, mut receiver) = broadcast::channel(8);
+
+        let outcome = replay(&mut server, &mut receiver, &ring, pos(10, 1))
+            .await
+            .expect("catch-up completes");
+
+        assert!(outcome.preceded_by_gap);
+        assert!(!outcome.ahead_of_archive);
+        assert_eq!(
+            drain(&mut client, 3).await,
+            ["10-5", "10-6"],
+            "what is still held is handed over rather than withheld",
+        );
+    }
+
+    /// A subscriber naming the newest slice it holds is up to date: there is
+    /// nothing after it to hand over, and it simply joins the live stream.
+    #[tokio::test]
+    async fn a_resume_position_at_the_head_of_the_archive_replays_nothing() {
+        let (mut server, _client) = socket_pair().await;
+        let ring = ring_with([pos(10, 1), pos(10, 2)]);
+        let (_pipe, mut receiver) = broadcast::channel(8);
+
+        let outcome = replay(&mut server, &mut receiver, &ring, pos(10, 2))
+            .await
+            .expect("catch-up completes");
+
+        assert_eq!(outcome.sent, 0);
+        assert!(!outcome.preceded_by_gap);
+        assert!(!outcome.ahead_of_archive, "being level with the head is not being ahead of it");
+    }
+
+    /// A subscriber can name a slice ahead of anything published: its block was
+    /// rebuilt and the slices it holds were abandoned, or it is talking to a
+    /// different producer. There is nothing to replay either way.
+    #[tokio::test]
+    async fn a_resume_position_ahead_of_the_archive_replays_nothing() {
+        let (mut server, _client) = socket_pair().await;
+        let ring = ring_with([pos(10, 1), pos(10, 2)]);
+        let (_pipe, mut receiver) = broadcast::channel(8);
+
+        let outcome = replay(&mut server, &mut receiver, &ring, pos(99, 0))
+            .await
+            .expect("catch-up completes");
+
+        assert_eq!(outcome.sent, 0);
+        assert!(
+            !outcome.preceded_by_gap,
+            "the gap flag reports a window that moved past the subscriber, not one ahead of it",
+        );
+        assert!(outcome.ahead_of_archive, "nothing published reaches that position");
+    }
+
+    /// After a restart the archive is empty, so there is nothing to replay
+    /// whatever the subscriber asks for. It joins live and finds out from the
+    /// first slice's predecessor that the producer started over.
+    #[tokio::test]
+    async fn an_empty_archive_replays_nothing_for_any_position() {
+        let (mut server, _client) = socket_pair().await;
+        let ring = ring_with([]);
+        let (_pipe, mut receiver) = broadcast::channel(8);
+
+        let outcome = replay(&mut server, &mut receiver, &ring, pos(10, 5))
+            .await
+            .expect("catch-up completes");
+
+        assert_eq!(outcome.sent, 0);
+        assert!(!outcome.preceded_by_gap);
+        assert!(!outcome.ahead_of_archive, "with nothing archived there is no head to be ahead of",);
+    }
+
+    /// A subscriber slow enough to be dropped from the channel is disconnected
+    /// rather than served a stream with holes in it; reconnecting replays from
+    /// the archive.
+    #[tokio::test]
+    async fn a_subscriber_that_falls_behind_the_channel_is_disconnected() {
+        let (mut server, _client) = socket_pair().await;
+        let (pipe, mut receiver) = broadcast::channel(2);
+        for index in 0..5 {
+            pipe.send(slice(pos(10, index))).expect("receiver is alive");
+        }
+
+        let exit = pump_live(&mut server, &mut receiver, &CancellationToken::new()).await;
+
+        assert!(matches!(exit, SubscriptionExit::Lagged(_)), "got {exit:?}");
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_publisher_ends_the_subscription() {
+        let (mut server, _client) = socket_pair().await;
+        let (_pipe, mut receiver) = broadcast::channel::<PositionedSlice>(8);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        assert_eq!(
+            pump_live(&mut server, &mut receiver, &cancel).await,
+            SubscriptionExit::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn a_subscriber_going_away_ends_the_subscription() {
+        let (mut server, client) = socket_pair().await;
+        let (_pipe, mut receiver) = broadcast::channel::<PositionedSlice>(8);
+        drop(client);
+
+        assert_eq!(
+            pump_live(&mut server, &mut receiver, &CancellationToken::new()).await,
+            SubscriptionExit::ClientClosed
+        );
+    }
+
+    #[test]
+    fn a_resume_position_is_read_from_the_query() {
+        let position = parse_resume_position("/?block_number=12&flashblock_index=3");
+
+        assert_eq!(position, Some(FlashblockPosition { block_number: 12, flashblock_index: 3 }));
+    }
+
+    #[test]
+    fn the_parameters_may_arrive_in_either_order() {
+        let position = parse_resume_position("/ws?flashblock_index=3&block_number=12");
+
+        assert_eq!(position, Some(FlashblockPosition { block_number: 12, flashblock_index: 3 }));
+    }
+
+    /// A subscriber connecting for the first time names no position and just
+    /// joins the live stream.
+    #[test]
+    fn a_connection_without_parameters_asks_for_no_replay() {
+        assert_eq!(parse_resume_position("/"), None);
+        assert_eq!(parse_resume_position(""), None);
+        assert_eq!(parse_resume_position("/ws"), None);
+    }
+
+    /// Both halves are needed to name a position, so half a request is not
+    /// silently rounded into a whole one.
+    #[test]
+    fn half_a_position_is_not_a_position() {
+        assert_eq!(parse_resume_position("/?block_number=12"), None);
+        assert_eq!(parse_resume_position("/?flashblock_index=3"), None);
+    }
+
+    /// The query is attacker-controlled, so nothing in it may panic.
+    #[test]
+    fn unparseable_parameters_are_ignored_rather_than_fatal() {
+        for query in [
+            "/?block_number=abc&flashblock_index=3",
+            "/?block_number=12&flashblock_index=-1",
+            "/?block_number=99999999999999999999999&flashblock_index=0",
+            "/?block_number=&flashblock_index=",
+            "/?block_number&flashblock_index",
+            "/?=12&=3",
+            "/?&&&",
+        ] {
+            assert_eq!(parse_resume_position(query), None, "{query} must not yield a position");
+        }
+    }
+
+    #[test]
+    fn a_repeated_parameter_takes_the_first_occurrence() {
+        let position =
+            parse_resume_position("/?block_number=12&block_number=99&flashblock_index=3");
+
+        assert_eq!(position, Some(FlashblockPosition { block_number: 12, flashblock_index: 3 }));
+    }
+}

--- a/mantle-reth/crates/preconf/src/flashblocks/config.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/config.rs
@@ -1,0 +1,291 @@
+//! Producer-side flashblocks configuration.
+//!
+//! Deliberately separate from [`PreconfConfig`]: the node builds a default
+//! `PreconfConfig` when preconf is off, which would wipe any flashblock
+//! values that had been folded into it.
+//!
+//! "Off" is the absence of a config, not a field inside one — same shape as
+//! preconf at the CLI boundary.
+
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
+
+use crate::PreconfConfig;
+
+/// Default interval between slices — 200ms.
+pub const DEFAULT_FLASHBLOCK_BLOCK_TIME: Duration = Duration::from_millis(200);
+
+/// Default margin by which the budgeted slice grid finishes ahead of the
+/// slot deadline — 50ms.
+///
+/// It shifts the whole tick grid rather than changing how many slices a
+/// block gets: at the default interval the slice count is the same for any
+/// leeway below one interval. Lower values push the last budgeted slice
+/// closer to the deadline, which leaves the tail more gas headroom but
+/// narrows the window between publishing that slice and sealing.
+pub const DEFAULT_FLASHBLOCK_LEEWAY: Duration = Duration::from_millis(50);
+
+/// Default address the publisher binds — loopback.
+pub const DEFAULT_FLASHBLOCK_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// Default port the publisher binds.
+pub const DEFAULT_FLASHBLOCK_PORT: u16 = 1111;
+
+/// Default number of published slices kept for resuming subscribers — 32.
+///
+/// At eleven slices per block that is a little under three blocks, so a
+/// subscriber has roughly six seconds to reconnect before it has to fall
+/// back to canonical sync.
+pub const DEFAULT_RING_CAPACITY: usize = 32;
+
+/// Default capacity of the live broadcast channel — 32.
+pub const DEFAULT_BROADCAST_CAPACITY: usize = 32;
+
+/// Runtime configuration for publishing flashblocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlashblockProducerConfig {
+    /// Interval between slices.
+    pub block_time: Duration,
+    /// How far ahead of the slot deadline building stops.
+    pub leeway_time: Duration,
+    /// Address the publisher binds.
+    pub addr: IpAddr,
+    /// Port the publisher binds.
+    pub port: u16,
+    /// Published slices kept for subscribers that reconnect.
+    pub ring_capacity: usize,
+    /// Capacity of the live broadcast channel.
+    pub broadcast_capacity: usize,
+}
+
+impl Default for FlashblockProducerConfig {
+    fn default() -> Self {
+        Self {
+            block_time: DEFAULT_FLASHBLOCK_BLOCK_TIME,
+            leeway_time: DEFAULT_FLASHBLOCK_LEEWAY,
+            addr: DEFAULT_FLASHBLOCK_ADDR,
+            port: DEFAULT_FLASHBLOCK_PORT,
+            ring_capacity: DEFAULT_RING_CAPACITY,
+            broadcast_capacity: DEFAULT_BROADCAST_CAPACITY,
+        }
+    }
+}
+
+/// Errors surfaced by [`FlashblockProducerConfig::validate`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum FlashblockProducerConfigError {
+    /// `block_time == 0`.
+    #[error("flashblocks block_time must be > 0")]
+    InvalidBlockTime,
+    /// `broadcast_capacity == 0` — tokio broadcast requires capacity > 0.
+    #[error("flashblocks broadcast_capacity must be > 0")]
+    InvalidBroadcastCapacity,
+    /// A single slice would span more than the whole slot, which leaves the
+    /// per-slice budget meaningless.
+    #[error("flashblocks block_time ({block_time:?}) must be <= slot_duration ({slot:?})")]
+    BlockTimeExceedsSlot {
+        /// Configured slice interval.
+        block_time: Duration,
+        /// Slot duration the interval was compared against.
+        slot: Duration,
+    },
+    /// Leeway at or past a whole slot leaves no time to build in.
+    #[error("flashblocks leeway_time ({leeway:?}) must be < slot_duration ({slot:?})")]
+    LeewayReachesSlot {
+        /// Configured leeway.
+        leeway: Duration,
+        /// Slot duration the leeway was compared against.
+        slot: Duration,
+    },
+    /// The archive is smaller than the live channel, so a subscriber could
+    /// lag past what the ring can replay and never be able to resume.
+    #[error("flashblocks ring_capacity ({ring}) must be >= broadcast_capacity ({broadcast})")]
+    RingSmallerThanBroadcast {
+        /// Configured ring capacity.
+        ring: usize,
+        /// Configured broadcast capacity.
+        broadcast: usize,
+    },
+    /// Flashblocks were configured without preconf. Slicing lives in the
+    /// preconf payload builder, and with preconf off the node builds blocks
+    /// with the upstream builder, so the flag would have no effect.
+    #[error("--flashblocks.enable requires --preconf.enable")]
+    RequiresPreconfEnabled,
+}
+
+impl FlashblockProducerConfig {
+    /// Validates config invariants against the preconf config it runs
+    /// alongside. `preconf` is `None` when preconf is disabled.
+    ///
+    /// Returns the original config on success for ergonomic chaining.
+    pub fn validate(
+        self,
+        preconf: Option<&PreconfConfig>,
+    ) -> Result<Self, FlashblockProducerConfigError> {
+        if self.block_time.is_zero() {
+            return Err(FlashblockProducerConfigError::InvalidBlockTime);
+        }
+        if self.broadcast_capacity == 0 {
+            return Err(FlashblockProducerConfigError::InvalidBroadcastCapacity);
+        }
+        if self.ring_capacity < self.broadcast_capacity {
+            return Err(FlashblockProducerConfigError::RingSmallerThanBroadcast {
+                ring: self.ring_capacity,
+                broadcast: self.broadcast_capacity,
+            });
+        }
+
+        let Some(preconf) = preconf else {
+            return Err(FlashblockProducerConfigError::RequiresPreconfEnabled);
+        };
+
+        if self.block_time > preconf.slot_duration {
+            return Err(FlashblockProducerConfigError::BlockTimeExceedsSlot {
+                block_time: self.block_time,
+                slot: preconf.slot_duration,
+            });
+        }
+        if self.leeway_time >= preconf.slot_duration {
+            return Err(FlashblockProducerConfigError::LeewayReachesSlot {
+                leeway: self.leeway_time,
+                slot: preconf.slot_duration,
+            });
+        }
+
+        Ok(self)
+    }
+}
+
+/// Interval the build loop's ticker fires at.
+///
+/// Without flashblocks the cadence stays exactly what preconf used before,
+/// which keeps turning the feature off a true rollback.
+pub fn tick_interval(
+    flashblocks: Option<&FlashblockProducerConfig>,
+    preconf_sweep: Duration,
+) -> Duration {
+    flashblocks.map_or(preconf_sweep, |cfg| cfg.block_time)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        time::Duration,
+    };
+
+    use super::{FlashblockProducerConfig, FlashblockProducerConfigError, tick_interval};
+    use crate::PreconfConfig;
+
+    fn preconf_with_slot(slot: Duration) -> PreconfConfig {
+        PreconfConfig { slot_duration: slot, ..Default::default() }
+    }
+
+    fn cfg() -> FlashblockProducerConfig {
+        FlashblockProducerConfig::default()
+    }
+
+    /// Defaults are an operator-visible contract — `--help` documents them
+    /// and deployments rely on them. Pin the concrete values so a change is
+    /// deliberate rather than incidental.
+    #[test]
+    fn defaults_match_the_documented_values() {
+        let cfg = FlashblockProducerConfig::default();
+
+        assert_eq!(cfg.block_time, Duration::from_millis(200));
+        assert_eq!(cfg.leeway_time, Duration::from_millis(50));
+        assert_eq!(cfg.addr, IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(cfg.port, 1111);
+        assert_eq!(cfg.ring_capacity, 32);
+        assert_eq!(cfg.broadcast_capacity, 32);
+    }
+
+    #[test]
+    fn defaults_validate_clean() {
+        let preconf = preconf_with_slot(Duration::from_secs(2));
+
+        assert!(cfg().validate(Some(&preconf)).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_block_time() {
+        let cfg = FlashblockProducerConfig { block_time: Duration::ZERO, ..cfg() };
+
+        assert!(matches!(
+            cfg.validate(Some(&preconf_with_slot(Duration::from_secs(2)))),
+            Err(FlashblockProducerConfigError::InvalidBlockTime)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_block_time_larger_than_slot() {
+        let cfg = FlashblockProducerConfig { block_time: Duration::from_secs(3), ..cfg() };
+
+        assert!(matches!(
+            cfg.validate(Some(&preconf_with_slot(Duration::from_secs(2)))),
+            Err(FlashblockProducerConfigError::BlockTimeExceedsSlot { .. })
+        ));
+    }
+
+    /// Leeway is subtracted from the slot deadline. At or past a whole slot
+    /// there is never any time left to build in.
+    #[test]
+    fn validate_rejects_leeway_reaching_the_whole_slot() {
+        let cfg = FlashblockProducerConfig { leeway_time: Duration::from_secs(2), ..cfg() };
+
+        assert!(matches!(
+            cfg.validate(Some(&preconf_with_slot(Duration::from_secs(2)))),
+            Err(FlashblockProducerConfigError::LeewayReachesSlot { .. })
+        ));
+    }
+
+    /// A subscriber resuming from the ring must find every slice the channel
+    /// could have dropped, so the archive cannot be the smaller of the two.
+    #[test]
+    fn validate_rejects_ring_smaller_than_broadcast() {
+        let cfg = FlashblockProducerConfig { ring_capacity: 8, broadcast_capacity: 16, ..cfg() };
+
+        assert!(matches!(
+            cfg.validate(Some(&preconf_with_slot(Duration::from_secs(2)))),
+            Err(FlashblockProducerConfigError::RingSmallerThanBroadcast { ring: 8, broadcast: 16 })
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_zero_broadcast_capacity() {
+        let cfg = FlashblockProducerConfig { broadcast_capacity: 0, ..cfg() };
+
+        assert!(matches!(
+            cfg.validate(Some(&preconf_with_slot(Duration::from_secs(2)))),
+            Err(FlashblockProducerConfigError::InvalidBroadcastCapacity)
+        ));
+    }
+
+    /// The slicing logic lives inside the preconf payload builder, and with
+    /// preconf off the node builds blocks with the upstream builder instead.
+    /// Enabling flashblocks alone would silently do nothing.
+    #[test]
+    fn validate_rejects_flashblocks_without_preconf() {
+        assert!(matches!(
+            cfg().validate(None),
+            Err(FlashblockProducerConfigError::RequiresPreconfEnabled)
+        ));
+    }
+
+    #[test]
+    fn tick_interval_prefers_block_time_when_configured() {
+        let cfg = FlashblockProducerConfig { block_time: Duration::from_millis(150), ..cfg() };
+
+        assert_eq!(
+            tick_interval(Some(&cfg), Duration::from_millis(999)),
+            Duration::from_millis(150)
+        );
+    }
+
+    #[test]
+    fn tick_interval_falls_back_to_sweep_when_absent() {
+        assert_eq!(tick_interval(None, Duration::from_millis(999)), Duration::from_millis(999));
+    }
+}

--- a/mantle-reth/crates/preconf/src/flashblocks/mod.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/mod.rs
@@ -1,12 +1,18 @@
 //! Producer side of flashblocks: slicing a block as it is built and
 //! publishing each slice to subscribers.
 
+pub mod broadcast;
 pub mod config;
+pub mod publisher;
+pub mod ring_buffer;
 pub mod slice_pacer;
 
+pub use broadcast::{ReplayOutcome, SubscriptionExit, parse_resume_position};
 pub use config::{
     DEFAULT_BROADCAST_CAPACITY, DEFAULT_FLASHBLOCK_ADDR, DEFAULT_FLASHBLOCK_BLOCK_TIME,
     DEFAULT_FLASHBLOCK_LEEWAY, DEFAULT_FLASHBLOCK_PORT, DEFAULT_RING_CAPACITY,
     FlashblockProducerConfig, FlashblockProducerConfigError,
 };
+pub use publisher::{MantleFlashblocksPublisher, PublisherHandle};
+pub use ring_buffer::{FlashblockPosition, FlashblockRingBuffer};
 pub use slice_pacer::{Reservation, SliceLimits, SlicePacer, SliceSchedule, derive_slice_schedule};

--- a/mantle-reth/crates/preconf/src/flashblocks/mod.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/mod.rs
@@ -1,0 +1,10 @@
+//! Producer side of flashblocks: slicing a block as it is built and
+//! publishing each slice to subscribers.
+
+pub mod config;
+
+pub use config::{
+    DEFAULT_BROADCAST_CAPACITY, DEFAULT_FLASHBLOCK_ADDR, DEFAULT_FLASHBLOCK_BLOCK_TIME,
+    DEFAULT_FLASHBLOCK_LEEWAY, DEFAULT_FLASHBLOCK_PORT, DEFAULT_RING_CAPACITY,
+    FlashblockProducerConfig, FlashblockProducerConfigError,
+};

--- a/mantle-reth/crates/preconf/src/flashblocks/mod.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/mod.rs
@@ -2,9 +2,11 @@
 //! publishing each slice to subscribers.
 
 pub mod config;
+pub mod slice_pacer;
 
 pub use config::{
     DEFAULT_BROADCAST_CAPACITY, DEFAULT_FLASHBLOCK_ADDR, DEFAULT_FLASHBLOCK_BLOCK_TIME,
     DEFAULT_FLASHBLOCK_LEEWAY, DEFAULT_FLASHBLOCK_PORT, DEFAULT_RING_CAPACITY,
     FlashblockProducerConfig, FlashblockProducerConfigError,
 };
+pub use slice_pacer::{Reservation, SliceLimits, SlicePacer, SliceSchedule, derive_slice_schedule};

--- a/mantle-reth/crates/preconf/src/flashblocks/publisher.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/publisher.rs
@@ -1,0 +1,327 @@
+//! The `WebSocket` endpoint slices are published on.
+
+use std::{
+    future::Future,
+    io,
+    net::{SocketAddr, TcpListener as StdTcpListener},
+    num::NonZeroUsize,
+    sync::Arc,
+};
+
+use mantle_reth_flashblocks_types::MantleFlashblockPayload;
+use parking_lot::RwLock;
+use tokio::{net::TcpListener, sync::broadcast};
+use tokio_tungstenite::tungstenite::Utf8Bytes;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::flashblocks::{
+    FlashblockPosition, FlashblockRingBuffer, broadcast::serve_subscriber,
+    config::FlashblockProducerConfig,
+};
+
+/// A slice paired with where it sits in the stream.
+pub type PositionedSlice = (FlashblockPosition, Utf8Bytes);
+
+/// Publishes slices to whoever is connected, and keeps the recent ones so a
+/// subscriber that reconnects can be caught up.
+///
+/// Owns the listener: dropping it closes the endpoint and every open
+/// subscription. Hand [`handle`](Self::handle) to whatever produces slices.
+#[derive(Debug)]
+pub struct MantleFlashblocksPublisher {
+    handle: PublisherHandle,
+    cancel: CancellationToken,
+    local_addr: SocketAddr,
+}
+
+/// Cloneable half of the publisher: enough to publish, nothing that would
+/// keep the endpoint alive.
+#[derive(Debug, Clone)]
+pub struct PublisherHandle {
+    pipe: broadcast::Sender<PositionedSlice>,
+    ring: Arc<RwLock<FlashblockRingBuffer>>,
+}
+
+impl MantleFlashblocksPublisher {
+    /// Bind the endpoint, returning the publisher and the loop that accepts
+    /// subscribers.
+    ///
+    /// The loop is handed back rather than spawned so that how it runs — and
+    /// what happens if it stops — stays a decision for whoever owns the node,
+    /// and so binding does not quietly require a runtime to already exist.
+    /// Nothing is served until the loop is driven.
+    pub fn bind(
+        cfg: &FlashblockProducerConfig,
+    ) -> io::Result<(Self, impl Future<Output = ()> + Send + use<>)> {
+        let ring_capacity = NonZeroUsize::new(cfg.ring_capacity)
+            .ok_or_else(|| io::Error::other("flashblocks ring capacity must be non-zero"))?;
+
+        // Bound the archive below by the live channel: a subscriber may lag by
+        // a whole channel before it is dropped, and it must be able to resume
+        // from wherever it fell behind.
+        debug_assert!(cfg.ring_capacity >= cfg.broadcast_capacity);
+
+        let (pipe, _) = broadcast::channel(cfg.broadcast_capacity.max(1));
+        let ring = Arc::new(RwLock::new(FlashblockRingBuffer::new(ring_capacity)));
+        let cancel = CancellationToken::new();
+
+        // Bind synchronously so a port clash surfaces at startup rather than
+        // inside a task nobody is watching.
+        let std_listener = StdTcpListener::bind(SocketAddr::new(cfg.addr, cfg.port))?;
+        std_listener.set_nonblocking(true)?;
+        let local_addr = std_listener.local_addr()?;
+        let listener = TcpListener::from_std(std_listener)?;
+
+        let accepting =
+            accept_loop(listener, pipe.clone(), Arc::clone(&ring), cancel.child_token());
+
+        info!(target: "mantle::preconf::flashblocks", %local_addr, "flashblocks publisher bound");
+
+        Ok((Self { handle: PublisherHandle { pipe, ring }, cancel, local_addr }, accepting))
+    }
+
+    /// Address actually bound, which differs from the configured one when the
+    /// port was left to the OS.
+    pub const fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// A handle for publishing slices.
+    pub fn handle(&self) -> PublisherHandle {
+        self.handle.clone()
+    }
+}
+
+impl Drop for MantleFlashblocksPublisher {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+impl PublisherHandle {
+    /// Serialize a slice, archive it, and hand it to every live subscriber.
+    ///
+    /// Archiving happens first: a subscriber connecting a moment later must
+    /// find the slice waiting for it rather than fall in the gap between the
+    /// two. Returns the serialized size.
+    pub fn publish(&self, payload: &MantleFlashblockPayload) -> Result<usize, serde_json::Error> {
+        let json = serde_json::to_string(payload)?;
+        let size = json.len();
+        let text = Utf8Bytes::from(json);
+        let position = FlashblockPosition {
+            block_number: payload.metadata.block_number,
+            flashblock_index: payload.index,
+        };
+
+        self.ring.write().push(position, text.clone());
+
+        // No subscribers is the normal case, not a failure: the slice is
+        // archived either way.
+        let _ = self.pipe.send((position, text));
+
+        Ok(size)
+    }
+
+    /// Subscribers currently connected.
+    pub fn subscriber_count(&self) -> usize {
+        self.pipe.receiver_count()
+    }
+}
+
+/// Accept subscribers until cancelled, serving each on its own task.
+async fn accept_loop(
+    listener: TcpListener,
+    pipe: broadcast::Sender<PositionedSlice>,
+    ring: Arc<RwLock<FlashblockRingBuffer>>,
+    cancel: CancellationToken,
+) {
+    loop {
+        let connection = tokio::select! {
+            () = cancel.cancelled() => return,
+            accepted = listener.accept() => match accepted {
+                Ok((connection, _)) => connection,
+                Err(error) => {
+                    warn!(target: "mantle::preconf::flashblocks", %error, "failed to accept subscriber");
+                    continue;
+                }
+            },
+        };
+
+        let pipe = pipe.clone();
+        let ring = Arc::clone(&ring);
+        let cancel = cancel.child_token();
+
+        tokio::spawn(async move {
+            serve_subscriber(connection, &pipe, ring, cancel).await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, time::Duration};
+
+    use futures_util::StreamExt;
+    use mantle_reth_flashblocks_types::MantleFlashblockPayload;
+    use tokio_tungstenite::tungstenite::Message;
+
+    use super::MantleFlashblocksPublisher;
+    use crate::flashblocks::config::FlashblockProducerConfig;
+
+    /// Bind on an OS-assigned port so tests never collide, and drive the
+    /// accept loop the way the node wiring will.
+    fn publisher(ring: usize, channel: usize) -> MantleFlashblocksPublisher {
+        let (publisher, accepting) = MantleFlashblocksPublisher::bind(&FlashblockProducerConfig {
+            addr: Ipv4Addr::LOCALHOST.into(),
+            port: 0,
+            ring_capacity: ring,
+            broadcast_capacity: channel,
+            ..Default::default()
+        })
+        .expect("bind on an ephemeral port");
+        tokio::spawn(accepting);
+        publisher
+    }
+
+    fn slice(block_number: u64, index: u64) -> MantleFlashblockPayload {
+        let mut payload = MantleFlashblockPayload { index, ..Default::default() };
+        payload.metadata.block_number = block_number;
+        payload
+    }
+
+    async fn connect(
+        publisher: &MantleFlashblocksPublisher,
+        query: &str,
+    ) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>
+    {
+        let url = format!("ws://{}{query}", publisher.local_addr());
+        let (stream, _) = tokio_tungstenite::connect_async(url).await.expect("subscriber connects");
+        stream
+    }
+
+    /// Read the slices a subscriber receives, identified by position.
+    async fn received(
+        stream: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        count: usize,
+    ) -> Vec<(u64, u64)> {
+        let mut positions = Vec::with_capacity(count);
+        for _ in 0..count {
+            let message = tokio::time::timeout(Duration::from_secs(5), stream.next())
+                .await
+                .expect("a slice arrives before the timeout")
+                .expect("the stream is still open")
+                .expect("the frame is well formed");
+            let Message::Text(text) = message else { panic!("expected a text frame") };
+            let decoded: MantleFlashblockPayload =
+                serde_json::from_str(&text).expect("slices are published as valid json");
+            positions.push((decoded.metadata.block_number, decoded.index));
+        }
+        positions
+    }
+
+    #[tokio::test]
+    async fn a_published_slice_reaches_a_connected_subscriber() {
+        let publisher = publisher(8, 8);
+        let mut subscriber = connect(&publisher, "").await;
+        // The accept task must have subscribed before publishing, or the
+        // slice would only exist in the archive.
+        while publisher.handle().subscriber_count() == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        publisher.handle().publish(&slice(10, 0)).expect("serializes");
+        publisher.handle().publish(&slice(10, 1)).expect("serializes");
+
+        assert_eq!(received(&mut subscriber, 2).await, [(10, 0), (10, 1)]);
+    }
+
+    /// A subscriber that publishes nothing to us still gets the archive, so a
+    /// connection opened after the fact is not silently empty.
+    #[tokio::test]
+    async fn a_reconnecting_subscriber_is_caught_up_from_the_archive() {
+        let publisher = publisher(8, 8);
+        for index in 0..4 {
+            publisher.handle().publish(&slice(10, index)).expect("serializes");
+        }
+
+        let mut subscriber = connect(&publisher, "/?block_number=10&flashblock_index=1").await;
+
+        assert_eq!(received(&mut subscriber, 2).await, [(10, 2), (10, 3)]);
+    }
+
+    /// End-to-end wiring: a resume request survives the handshake, reaches
+    /// the archive, and the connection then carries live slices. The seam
+    /// between the two phases is covered by the `broadcast` tests, which can
+    /// force the interleaving this one cannot.
+    #[tokio::test]
+    async fn a_resumed_connection_serves_the_archive_and_then_the_live_stream() {
+        let publisher = publisher(8, 8);
+        for index in 0..3 {
+            publisher.handle().publish(&slice(10, index)).expect("serializes");
+        }
+
+        let mut subscriber = connect(&publisher, "/?block_number=10&flashblock_index=0").await;
+        while publisher.handle().subscriber_count() == 0 {
+            tokio::task::yield_now().await;
+        }
+        publisher.handle().publish(&slice(10, 3)).expect("serializes");
+
+        assert_eq!(received(&mut subscriber, 3).await, [(10, 1), (10, 2), (10, 3)]);
+    }
+
+    #[tokio::test]
+    async fn a_first_time_subscriber_gets_only_what_comes_next() {
+        let publisher = publisher(8, 8);
+        publisher.handle().publish(&slice(10, 0)).expect("serializes");
+
+        let mut subscriber = connect(&publisher, "").await;
+        while publisher.handle().subscriber_count() == 0 {
+            tokio::task::yield_now().await;
+        }
+        publisher.handle().publish(&slice(10, 1)).expect("serializes");
+
+        assert_eq!(
+            received(&mut subscriber, 1).await,
+            [(10, 1)],
+            "no replay was asked for, so the earlier slice stays in the archive",
+        );
+    }
+
+    /// Binding reserves the port but serves nobody until the accept loop is
+    /// driven, so wiring that forgets to run it fails loudly rather than
+    /// looking healthy.
+    #[tokio::test]
+    async fn binding_without_driving_the_accept_loop_serves_nobody() {
+        let (publisher, _accepting) = MantleFlashblocksPublisher::bind(&FlashblockProducerConfig {
+            addr: Ipv4Addr::LOCALHOST.into(),
+            port: 0,
+            ..Default::default()
+        })
+        .expect("bind on an ephemeral port");
+
+        let url = format!("ws://{}", publisher.local_addr());
+        let handshake =
+            tokio::time::timeout(Duration::from_millis(300), tokio_tungstenite::connect_async(url))
+                .await;
+
+        assert!(handshake.is_err(), "no handshake can complete while nothing accepts");
+    }
+
+    /// Dropping the publisher must take the endpoint with it, or a restart
+    /// would fail to bind.
+    #[tokio::test]
+    async fn dropping_the_publisher_closes_the_endpoint() {
+        let publisher = publisher(8, 8);
+        let addr = publisher.local_addr();
+        let mut subscriber = connect(&publisher, "").await;
+
+        drop(publisher);
+
+        let closed = tokio::time::timeout(Duration::from_secs(5), subscriber.next()).await;
+        assert!(closed.is_ok(), "the subscription ends rather than hanging");
+        assert!(tokio::net::TcpListener::bind(addr).await.is_ok(), "the port is free again",);
+    }
+}

--- a/mantle-reth/crates/preconf/src/flashblocks/ring_buffer.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/ring_buffer.rs
@@ -1,0 +1,243 @@
+//! Archive of recently published slices, for subscribers that reconnect.
+//!
+//! Live delivery is fire-and-forget: a subscriber that is not connected when
+//! a slice goes out has missed it. This keeps the last few slices around so a
+//! subscriber that names where it left off can be caught up before it joins
+//! the live stream.
+
+use std::{collections::VecDeque, num::NonZeroUsize};
+
+use tokio_tungstenite::tungstenite::Utf8Bytes;
+
+/// Where a slice sits in the stream. Ordered by block first, then by index
+/// within the block, which is the order slices are published in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FlashblockPosition {
+    /// L2 block the slice belongs to.
+    pub block_number: u64,
+    /// Slice index within that block.
+    pub flashblock_index: u64,
+}
+
+/// Bounded archive of published slices, keyed by position.
+///
+/// Entries are held already serialized: publishing pays for the encoding once
+/// and every replay is a refcount bump.
+#[derive(Debug)]
+pub struct FlashblockRingBuffer {
+    entries: VecDeque<(FlashblockPosition, Utf8Bytes)>,
+    capacity: usize,
+}
+
+impl FlashblockRingBuffer {
+    /// Create an archive holding at most `capacity` slices.
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self { entries: VecDeque::with_capacity(capacity.get()), capacity: capacity.get() }
+    }
+
+    /// Archive a slice, evicting the oldest once full.
+    ///
+    /// Rebuilding a block restarts its indices, so an arriving position may
+    /// not follow the last one stored. Everything from that position onward
+    /// is dropped: those slices belong to a payload that was abandoned, and
+    /// replaying them would hand a subscriber transactions that will never
+    /// land. Dropping them also keeps positions ascending, which the lookups
+    /// below rely on.
+    pub fn push(&mut self, position: FlashblockPosition, payload: Utf8Bytes) {
+        while self.entries.back().is_some_and(|(stored, _)| *stored >= position) {
+            self.entries.pop_back();
+        }
+        if self.entries.len() == self.capacity {
+            self.entries.pop_front();
+        }
+        self.entries.push_back((position, payload));
+    }
+
+    /// Slices published strictly after `cutoff`, oldest first.
+    ///
+    /// Strictly after, so a subscriber naming its last received slice is not
+    /// sent that slice again.
+    pub fn entries_after(
+        &self,
+        cutoff: &FlashblockPosition,
+    ) -> Vec<(FlashblockPosition, Utf8Bytes)> {
+        let start = self.entries.partition_point(|(stored, _)| stored <= cutoff);
+        self.entries.iter().skip(start).cloned().collect()
+    }
+
+    /// Whether `cutoff` sits before everything retained, meaning the window
+    /// has moved past it and replay cannot close the gap.
+    pub fn precedes_window(&self, cutoff: &FlashblockPosition) -> bool {
+        self.oldest().is_some_and(|oldest| *cutoff < oldest)
+    }
+
+    /// Position of the oldest slice still held.
+    pub fn oldest(&self) -> Option<FlashblockPosition> {
+        self.entries.front().map(|(position, _)| *position)
+    }
+
+    /// Position of the newest slice held.
+    pub fn latest(&self) -> Option<FlashblockPosition> {
+        self.entries.back().map(|(position, _)| *position)
+    }
+
+    /// Whether `cutoff` sits past everything held. Either the subscriber's
+    /// block was rebuilt out from under it, or it is not talking to this
+    /// producer — nothing published reaches that far either way.
+    pub fn exceeds_window(&self, cutoff: &FlashblockPosition) -> bool {
+        self.latest().is_some_and(|latest| *cutoff > latest)
+    }
+
+    /// Slices currently held.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether nothing has been archived yet.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use tokio_tungstenite::tungstenite::Utf8Bytes;
+
+    use super::{FlashblockPosition, FlashblockRingBuffer};
+
+    fn cap(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).expect("capacity is non-zero")
+    }
+
+    fn pos(block_number: u64, flashblock_index: u64) -> FlashblockPosition {
+        FlashblockPosition { block_number, flashblock_index }
+    }
+
+    /// Payload text carrying its own position, so assertions read as the
+    /// sequence a subscriber would see.
+    fn payload(position: FlashblockPosition) -> Utf8Bytes {
+        Utf8Bytes::from(format!("{}-{}", position.block_number, position.flashblock_index))
+    }
+
+    fn filled(
+        capacity: usize,
+        positions: impl IntoIterator<Item = FlashblockPosition>,
+    ) -> FlashblockRingBuffer {
+        let mut ring = FlashblockRingBuffer::new(cap(capacity));
+        for position in positions {
+            ring.push(position, payload(position));
+        }
+        ring
+    }
+
+    fn texts(entries: Vec<(FlashblockPosition, Utf8Bytes)>) -> Vec<String> {
+        entries.into_iter().map(|(_, text)| text.as_str().to_owned()).collect()
+    }
+
+    /// A subscriber names the last slice it already has, so replay must start
+    /// after it rather than resend it.
+    #[test]
+    fn replay_starts_strictly_after_the_requested_position() {
+        let ring = filled(8, [pos(10, 0), pos(10, 1), pos(10, 2)]);
+
+        assert_eq!(texts(ring.entries_after(&pos(10, 0))), ["10-1", "10-2"]);
+    }
+
+    /// Asking from index 0 of a block skips that block's base slice — the one
+    /// carrying the block-level fields. A subscriber that needs it must ask
+    /// from the previous block instead.
+    #[test]
+    fn replaying_from_index_zero_skips_the_base_slice() {
+        let ring = filled(8, [pos(10, 0), pos(10, 1)]);
+
+        assert_eq!(texts(ring.entries_after(&pos(10, 0))), ["10-1"]);
+    }
+
+    #[test]
+    fn the_oldest_entry_is_evicted_once_capacity_is_reached() {
+        let ring = filled(3, (0..5).map(|index| pos(10, index)));
+
+        assert_eq!(ring.len(), 3);
+        assert_eq!(ring.oldest(), Some(pos(10, 2)));
+        assert_eq!(texts(ring.entries_after(&pos(10, 1))), ["10-2", "10-3", "10-4"]);
+    }
+
+    #[test]
+    fn positions_order_across_a_block_boundary() {
+        let ring = filled(8, [pos(10, 9), pos(10, 10), pos(11, 0)]);
+
+        assert_eq!(texts(ring.entries_after(&pos(10, 9))), ["10-10", "11-0"]);
+    }
+
+    /// A cutoff older than anything retained cannot be honoured: the window
+    /// has moved past it. Everything held is still handed over, but the caller
+    /// has to be able to tell that a gap precedes it.
+    #[test]
+    fn a_cutoff_older_than_the_window_is_reported_as_a_gap() {
+        let ring = filled(3, (5..8).map(|index| pos(10, index)));
+
+        assert!(ring.precedes_window(&pos(10, 1)));
+        assert_eq!(texts(ring.entries_after(&pos(10, 1))), ["10-5", "10-6", "10-7"]);
+    }
+
+    #[test]
+    fn a_cutoff_inside_the_window_is_not_a_gap() {
+        let ring = filled(8, [pos(10, 0), pos(10, 1)]);
+
+        assert!(!ring.precedes_window(&pos(10, 0)));
+        assert!(!ring.precedes_window(&pos(10, 1)));
+    }
+
+    /// The two window checks answer opposite questions and must not be
+    /// confused: one says the archive moved past the subscriber, the other
+    /// says the subscriber is past the archive.
+    #[test]
+    fn a_cutoff_past_the_newest_entry_exceeds_the_window() {
+        let ring = filled(8, [pos(10, 1), pos(10, 2)]);
+
+        assert!(ring.exceeds_window(&pos(10, 3)));
+        assert!(ring.exceeds_window(&pos(11, 0)));
+        assert!(!ring.exceeds_window(&pos(10, 2)), "level with the newest is not past it");
+        assert!(!ring.exceeds_window(&pos(10, 0)));
+        assert!(!ring.precedes_window(&pos(10, 3)), "the two checks never both hold");
+    }
+
+    #[test]
+    fn an_empty_ring_reports_no_gap_and_replays_nothing() {
+        let ring = FlashblockRingBuffer::new(cap(4));
+
+        assert!(!ring.precedes_window(&pos(10, 0)));
+        assert!(
+            !ring.exceeds_window(&pos(10, 0)),
+            "with nothing held there is no window either way"
+        );
+        assert!(ring.entries_after(&pos(10, 0)).is_empty());
+        assert_eq!(ring.oldest(), None);
+        assert_eq!(ring.latest(), None);
+    }
+
+    /// Rebuilding a block restarts its slice indices, so a position can arrive
+    /// that is not after the last one stored. The superseded slices must go:
+    /// replaying them would hand a subscriber transactions from a payload that
+    /// was abandoned.
+    #[test]
+    fn rebuilding_a_block_drops_the_slices_it_supersedes() {
+        let mut ring = filled(8, [pos(10, 0), pos(10, 1), pos(10, 2)]);
+
+        ring.push(pos(10, 1), Utf8Bytes::from("rebuilt-10-1"));
+
+        assert_eq!(ring.len(), 2, "10-1 and 10-2 are superseded by the rebuild");
+        assert_eq!(texts(ring.entries_after(&pos(10, 0))), ["rebuilt-10-1"]);
+    }
+
+    #[test]
+    fn rebuilding_from_the_base_slice_drops_the_whole_block() {
+        let mut ring = filled(8, [pos(9, 4), pos(10, 0), pos(10, 1)]);
+
+        ring.push(pos(10, 0), Utf8Bytes::from("rebuilt-10-0"));
+
+        assert_eq!(texts(ring.entries_after(&pos(9, 3))), ["9-4", "rebuilt-10-0"]);
+    }
+}

--- a/mantle-reth/crates/preconf/src/flashblocks/slice_pacer.rs
+++ b/mantle-reth/crates/preconf/src/flashblocks/slice_pacer.rs
@@ -1,0 +1,607 @@
+//! Per-slice budget: how much of a block one flashblock may carry.
+//!
+//! The block's limits are divided by however many slices are still expected
+//! to fit before the slot deadline, and the resulting allowance accumulates
+//! tick by tick. Deliberately free of wall-clock reads and of any reth type:
+//! the caller measures the time left, everything after that is arithmetic.
+
+use std::time::Duration;
+
+/// The block-level limits a slice budget is carved out of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SliceLimits {
+    /// Gas ceiling for the whole block.
+    pub block_gas_limit: u64,
+    /// Data-availability bytes for the whole block, when configured.
+    pub block_da_limit: Option<u64>,
+    /// Post-Jovian footprint scalar. Footprint is charged in gas — DA bytes
+    /// times this scalar — and shares the block gas ceiling.
+    pub da_footprint_gas_scalar: Option<u16>,
+}
+
+/// How a block's limits are spread across the slices still to come.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SliceSchedule {
+    /// The block-level limits this schedule divides.
+    pub limits: SliceLimits,
+    /// Time left to build in, after leeway and clamping.
+    pub drift: Duration,
+    /// Slices the budget is divided by. Not a cap on how many slices get
+    /// published: if the build started early, more ticks will fire than this,
+    /// and those extra ones carry no per-slice limit.
+    pub tick_count: u64,
+    /// Gas each tick adds to the allowance.
+    pub gas_per_batch: u64,
+    /// DA bytes each tick adds, when a block DA limit is configured.
+    pub da_per_batch: Option<u64>,
+    /// Footprint gas each tick adds, when the scalar is active.
+    pub da_footprint_gas_per_batch: Option<u64>,
+    /// Delay before the first tick. Absorbs the remainder so every later tick
+    /// lands on the interval grid, at the cost of a first window that may be
+    /// shorter than one interval while still carrying a whole batch.
+    pub first_offset: Duration,
+    /// The deadline had already passed, so there was nothing to divide. The
+    /// schedule degrades to a single tick carrying the whole block; callers
+    /// should count this rather than let it pass unnoticed.
+    pub drift_was_exhausted: bool,
+}
+
+/// Derive the slice budget from the time left in the slot.
+///
+/// `time_to_deadline` is the caller's measurement of how long until the
+/// attributes' timestamp; `leeway` is how much of that to hold back so the
+/// budgeted grid finishes before the deadline rather than on it.
+pub fn derive_slice_schedule(
+    time_to_deadline: Duration,
+    leeway: Duration,
+    interval: Duration,
+    slot_duration: Duration,
+    limits: SliceLimits,
+) -> SliceSchedule {
+    // Clamping to one slot keeps a wrong `attrs.timestamp` — clock skew, bad
+    // config — from stretching the budget window without bound.
+    let drift = time_to_deadline.saturating_sub(leeway).min(slot_duration);
+
+    let interval_ms = interval.as_millis().max(1) as u64;
+    let drift_ms = drift.as_millis() as u64;
+
+    // Rounding up gives the sub-interval tail its own tick instead of
+    // dropping it; the floor of one keeps a passed deadline buildable.
+    let tick_count = drift_ms.div_ceil(interval_ms).max(1);
+
+    // The remainder goes to the first tick so every later one lands on the
+    // interval grid. An evenly dividing drift has no remainder to absorb and
+    // takes a whole interval instead — except when the window has no length
+    // at all, where waiting an interval would push the only tick past the
+    // deadline it was created to serve.
+    let remainder_ms = drift_ms % interval_ms;
+    let first_offset = match remainder_ms {
+        0 if drift.is_zero() => Duration::ZERO,
+        0 => interval,
+        remainder => Duration::from_millis(remainder),
+    };
+
+    SliceSchedule {
+        limits,
+        drift,
+        tick_count,
+        gas_per_batch: limits.block_gas_limit / tick_count,
+        da_per_batch: limits.block_da_limit.map(|limit| limit / tick_count),
+        da_footprint_gas_per_batch: limits
+            .da_footprint_gas_scalar
+            .map(|_| limits.block_gas_limit / tick_count),
+        first_offset,
+        drift_was_exhausted: drift.is_zero(),
+    }
+}
+
+/// One dimension's running allowance: what has been spent, what has been
+/// released so far, and the hard block-level stop.
+#[derive(Debug, Clone, Copy)]
+struct Budget {
+    used: u64,
+    ceiling: u64,
+    per_batch: u64,
+    block_limit: u64,
+}
+
+impl Budget {
+    /// Opens holding one batch: the first slice is built before any tick has
+    /// fired, so starting empty would leave it with nothing to spend and push
+    /// every later slice one batch behind.
+    const fn new(per_batch: u64, block_limit: u64) -> Self {
+        let ceiling = if per_batch < block_limit { per_batch } else { block_limit };
+        Self { used: 0, ceiling, per_batch, block_limit }
+    }
+
+    fn tick(&mut self) {
+        self.ceiling = self.ceiling.saturating_add(self.per_batch).min(self.block_limit);
+    }
+
+    fn fits(&self, amount: u64) -> bool {
+        self.used.saturating_add(amount) <= self.ceiling
+    }
+
+    fn record(&mut self, amount: u64) {
+        self.used = self.used.saturating_add(amount);
+    }
+
+    fn refund(&mut self, amount: u64) {
+        self.used = self.used.saturating_sub(amount);
+    }
+}
+
+/// A charge already applied to a [`SlicePacer`], to be resolved once the
+/// transaction it covers has run.
+///
+/// Gas is charged at the declared limit, since what a transaction actually
+/// burns is not known until it has executed. Resolving it with
+/// [`SlicePacer::settle`] hands back the difference;
+/// [`SlicePacer::cancel`] hands back everything.
+///
+/// Losing one without resolving it leaves the budget charged at the declared
+/// amount — under-filling a slice rather than over-filling it — and trips a
+/// debug assertion so it does not go unnoticed in tests.
+#[derive(Debug)]
+#[must_use = "a reservation has already been charged and must be settled or cancelled"]
+pub struct Reservation {
+    declared_gas: u64,
+    da_bytes: u64,
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        // Only complain when this drop is the story. Asserting while the
+        // thread is already unwinding turns any unrelated test failure into
+        // a double panic, which aborts the whole process instead of failing
+        // one case.
+        if std::thread::panicking() {
+            return;
+        }
+        debug_assert!(
+            false,
+            "reservation dropped without settle or cancel; the slice budget stays charged \
+             at the declared {} gas",
+            self.declared_gas
+        );
+    }
+}
+
+/// Gates what a slice may still take on, across gas and the two DA
+/// dimensions.
+///
+/// Allowance accumulates rather than resetting per slice, so whatever one
+/// slice leaves unused is available to the next.
+#[derive(Debug)]
+pub struct SlicePacer {
+    gas: Budget,
+    da: Option<Budget>,
+    footprint: Option<Budget>,
+    footprint_scalar: u64,
+}
+
+impl SlicePacer {
+    /// Opens with one batch of allowance already available, so the slice
+    /// published at the first tick carries a full share rather than nothing.
+    pub fn new(schedule: &SliceSchedule) -> Self {
+        let limits = schedule.limits;
+        Self {
+            gas: Budget::new(schedule.gas_per_batch, limits.block_gas_limit),
+            da: schedule
+                .da_per_batch
+                .zip(limits.block_da_limit)
+                .map(|(per_batch, block_limit)| Budget::new(per_batch, block_limit)),
+            // Footprint is charged in gas and shares the block gas ceiling.
+            footprint: schedule
+                .da_footprint_gas_per_batch
+                .map(|per_batch| Budget::new(per_batch, limits.block_gas_limit)),
+            footprint_scalar: limits.da_footprint_gas_scalar.unwrap_or(0) as u64,
+        }
+    }
+
+    /// Open the next slice's allowance by one more batch, up to the block
+    /// limit.
+    ///
+    /// The tick count a schedule derives is a divisor for the budget, not a
+    /// limit on how many slices a block may publish: a build that started
+    /// early outruns its own schedule. Those extra slices are not starved,
+    /// because by then the accumulated allowance has already reached the
+    /// block limit and there is no per-slice ceiling left to apply.
+    pub fn tick(&mut self) {
+        self.gas.tick();
+        if let Some(da) = self.da.as_mut() {
+            da.tick();
+        }
+        if let Some(footprint) = self.footprint.as_mut() {
+            footprint.tick();
+        }
+    }
+
+    /// Whether any allowance is left at all.
+    ///
+    /// A cheap guard for callers that would otherwise spin: it says the
+    /// budget is worth trying, not that any particular transaction fits.
+    /// [`reserve`](Self::reserve) is the actual gate.
+    pub fn has_headroom(&self) -> bool {
+        self.gas.used < self.gas.ceiling
+    }
+
+    /// Charge a transaction against the allowance, at its declared gas limit.
+    ///
+    /// `None` when it does not fit — nothing is charged in that case.
+    pub fn reserve(&mut self, declared_gas: u64, da_bytes: u64) -> Option<Reservation> {
+        let footprint_gas = da_bytes.saturating_mul(self.footprint_scalar);
+
+        let fits = self.gas.fits(declared_gas) &&
+            self.da.as_ref().is_none_or(|budget| budget.fits(da_bytes)) &&
+            self.footprint.as_ref().is_none_or(|budget| budget.fits(footprint_gas));
+        if !fits {
+            return None;
+        }
+
+        self.gas.record(declared_gas);
+        if let Some(da) = self.da.as_mut() {
+            da.record(da_bytes);
+        }
+        if let Some(footprint) = self.footprint.as_mut() {
+            footprint.record(footprint_gas);
+        }
+
+        Some(Reservation { declared_gas, da_bytes })
+    }
+
+    /// Resolve a reservation for a transaction that made it into the block,
+    /// handing back the gas it declared but did not burn.
+    ///
+    /// The DA charge stands: DA is measured from the encoding, so it was
+    /// already exact when reserved.
+    pub fn settle(&mut self, reservation: Reservation, actual_gas: u64) {
+        let refund = reservation.declared_gas.saturating_sub(actual_gas);
+        std::mem::forget(reservation);
+
+        self.gas.refund(refund);
+    }
+
+    /// Resolve a reservation for a transaction that did not make it into the
+    /// block, handing back everything it was charged.
+    pub fn cancel(&mut self, reservation: Reservation) {
+        let (declared_gas, da_bytes) = (reservation.declared_gas, reservation.da_bytes);
+        std::mem::forget(reservation);
+
+        self.gas.refund(declared_gas);
+        if let Some(da) = self.da.as_mut() {
+            da.refund(da_bytes);
+        }
+        if let Some(footprint) = self.footprint.as_mut() {
+            footprint.refund(da_bytes.saturating_mul(self.footprint_scalar));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{SliceLimits, SlicePacer, derive_slice_schedule};
+
+    const SLOT: Duration = Duration::from_secs(2);
+    const INTERVAL: Duration = Duration::from_millis(200);
+    const BLOCK_GAS: u64 = 30_000_000;
+
+    fn gas_only() -> SliceLimits {
+        SliceLimits {
+            block_gas_limit: BLOCK_GAS,
+            block_da_limit: None,
+            da_footprint_gas_scalar: None,
+        }
+    }
+
+    fn schedule(time_to_deadline: Duration, leeway: Duration) -> super::SliceSchedule {
+        derive_slice_schedule(time_to_deadline, leeway, INTERVAL, SLOT, gas_only())
+    }
+
+    fn pacer() -> SlicePacer {
+        SlicePacer::new(&schedule(SLOT, Duration::from_millis(50)))
+    }
+
+    /// Reserve and settle at the declared cost — the shape most tests want.
+    fn spend(pacer: &mut SlicePacer, gas: u64, da_bytes: u64) -> bool {
+        match pacer.reserve(gas, da_bytes) {
+            Some(reservation) => {
+                pacer.settle(reservation, gas);
+                true
+            }
+            None => false,
+        }
+    }
+
+    // ── schedule derivation ──────────────────────────────────────────────
+
+    #[test]
+    fn normal_start_yields_ten_ticks_of_three_million() {
+        let s = schedule(SLOT, Duration::from_millis(75));
+
+        assert_eq!(s.drift, Duration::from_millis(1925));
+        assert_eq!(s.tick_count, 10);
+        assert_eq!(s.gas_per_batch, 3_000_000);
+        assert_eq!(s.first_offset, Duration::from_millis(125));
+    }
+
+    #[test]
+    fn early_start_clamps_drift_to_slot_duration() {
+        let s = schedule(Duration::from_millis(2400), Duration::from_millis(75));
+
+        assert_eq!(s.drift, SLOT, "2325ms of headroom must clamp to one slot");
+        assert_eq!(s.tick_count, 10);
+        assert_eq!(s.gas_per_batch, 3_000_000);
+        assert_eq!(s.first_offset, INTERVAL, "a zero remainder takes a whole interval");
+    }
+
+    #[test]
+    fn late_start_halves_the_tick_count_and_doubles_the_batch() {
+        let s = schedule(Duration::from_millis(950), Duration::from_millis(75));
+
+        assert_eq!(s.drift, Duration::from_millis(875));
+        assert_eq!(s.tick_count, 5, "the sub-interval tail still gets its own tick");
+        assert_eq!(s.gas_per_batch, 6_000_000);
+        assert_eq!(s.first_offset, Duration::from_millis(75));
+    }
+
+    #[test]
+    fn the_default_leeway_shifts_the_grid_without_changing_the_tick_count() {
+        let s = schedule(SLOT, Duration::from_millis(50));
+
+        assert_eq!(s.tick_count, 10);
+        assert_eq!(s.gas_per_batch, 3_000_000);
+        assert_eq!(s.first_offset, Duration::from_millis(150));
+    }
+
+    #[test]
+    fn a_deadline_already_past_still_yields_one_tick() {
+        let s = schedule(Duration::ZERO, Duration::from_millis(50));
+
+        assert_eq!(s.tick_count, 1);
+        assert_eq!(s.gas_per_batch, BLOCK_GAS, "one tick means the whole block at once");
+        assert!(s.drift_was_exhausted, "the caller needs to be able to count this");
+        assert_eq!(
+            s.first_offset,
+            Duration::ZERO,
+            "a zero-length window must open its one tick immediately, not an interval later"
+        );
+    }
+
+    #[test]
+    fn an_evenly_dividing_drift_still_takes_a_whole_first_interval() {
+        let s = schedule(Duration::from_millis(250), Duration::from_millis(50));
+
+        assert_eq!(s.drift, INTERVAL);
+        assert_eq!(s.tick_count, 1);
+        assert_eq!(s.first_offset, INTERVAL);
+        assert!(!s.drift_was_exhausted);
+    }
+
+    // ── reserve / settle accounting ──────────────────────────────────────
+
+    /// The first slice is built before any tick has fired, so it has to open
+    /// holding a batch already. Starting drained would push every slice one
+    /// batch behind and leave the last one reachable only in the leeway
+    /// window.
+    #[test]
+    fn the_first_slice_opens_with_one_batch_available() {
+        let mut pacer = pacer();
+
+        assert!(pacer.reserve(3_000_001, 0).is_none());
+        let reservation = pacer.reserve(3_000_000, 0).expect("one batch is available up front");
+        pacer.settle(reservation, 3_000_000);
+    }
+
+    #[test]
+    fn a_reservation_charges_the_declared_cost_up_front() {
+        let mut pacer = pacer();
+
+        let reservation = pacer.reserve(3_000_000, 0).expect("the opening batch fits");
+
+        // Charged already: nothing else fits until this one settles.
+        assert!(pacer.reserve(1, 0).is_none());
+        pacer.settle(reservation, 3_000_000);
+    }
+
+    #[test]
+    fn a_reservation_that_does_not_fit_is_refused() {
+        let mut pacer = pacer();
+
+        assert!(pacer.reserve(3_000_001, 0).is_none());
+    }
+
+    /// Gas is reserved at the declared limit and refunded down to what the
+    /// transaction actually burned.
+    #[test]
+    fn settling_refunds_the_unused_gas() {
+        let mut pacer = pacer();
+        let reservation = pacer.reserve(3_000_000, 0).expect("fits");
+
+        pacer.settle(reservation, 1_000_000);
+
+        assert!(spend(&mut pacer, 2_000_000, 0), "the unburned 2M must come back");
+        assert!(!spend(&mut pacer, 1, 0));
+    }
+
+    /// A transaction that never makes it into the block gives everything back.
+    #[test]
+    fn cancelling_refunds_the_whole_reservation() {
+        let mut pacer = pacer();
+        let reservation = pacer.reserve(3_000_000, 0).expect("fits");
+
+        pacer.cancel(reservation);
+
+        assert!(spend(&mut pacer, 3_000_000, 0));
+    }
+
+    /// The failure the ticket exists to prevent: losing a reservation without
+    /// resolving it leaves the budget charged at the declared amount, which is
+    /// the safe direction, and trips loudly where assertions are on.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "reservation dropped")]
+    fn dropping_a_reservation_without_resolving_it_trips() {
+        let mut pacer = pacer();
+        pacer.tick();
+
+        drop(pacer.reserve(3_000_000, 0).expect("fits"));
+    }
+
+    #[test]
+    fn headroom_reports_whether_the_arm_is_worth_polling() {
+        let mut pacer = pacer();
+        assert!(pacer.has_headroom(), "the opening batch is spendable straight away");
+
+        assert!(spend(&mut pacer, 3_000_000, 0));
+        assert!(!pacer.has_headroom(), "batch spent");
+
+        pacer.tick();
+        assert!(pacer.has_headroom(), "the next tick reopens it");
+    }
+
+    // ── ceiling behaviour ────────────────────────────────────────────────
+
+    #[test]
+    fn the_ceiling_accumulates_and_carries_unused_budget() {
+        let mut pacer = pacer();
+
+        for _ in 0..3 {
+            pacer.tick();
+        }
+
+        assert!(
+            spend(&mut pacer, 12_000_000, 0),
+            "the opening batch plus three untouched ticks are all available"
+        );
+        assert!(!spend(&mut pacer, 1, 0));
+    }
+
+    /// Also covers the past-budget branch with realistic limits: twenty ticks
+    /// against a ten-tick schedule, and the block cap still holds.
+    #[test]
+    fn the_ceiling_never_exceeds_the_block_gas_limit() {
+        let mut pacer = pacer();
+
+        for _ in 0..20 {
+            pacer.tick();
+        }
+
+        assert!(spend(&mut pacer, BLOCK_GAS, 0));
+        assert!(!spend(&mut pacer, 1, 0));
+    }
+
+    /// The tick count divides the budget; it does not limit how many slices a
+    /// block may publish. A build that started early keeps ticking past it,
+    /// and those slices carry only the block-level limit.
+    #[test]
+    fn a_build_that_outruns_its_schedule_is_not_capped() {
+        let s = schedule(SLOT, Duration::from_millis(50));
+        let mut pacer = SlicePacer::new(&s);
+
+        for _ in 0..=s.tick_count {
+            pacer.tick();
+        }
+
+        assert!(spend(&mut pacer, BLOCK_GAS, 0), "the whole block is reachable");
+        assert!(!spend(&mut pacer, 1, 0), "and the block limit still holds");
+    }
+
+    // ── the DA dimensions ────────────────────────────────────────────────
+
+    #[test]
+    fn da_bytes_are_paced_alongside_gas() {
+        let limits = SliceLimits {
+            block_gas_limit: BLOCK_GAS,
+            block_da_limit: Some(1_000_000),
+            da_footprint_gas_scalar: None,
+        };
+        let s = derive_slice_schedule(SLOT, Duration::from_millis(50), INTERVAL, SLOT, limits);
+        assert_eq!(s.da_per_batch, Some(100_000));
+
+        let mut pacer = SlicePacer::new(&s);
+        pacer.tick();
+
+        assert!(!spend(&mut pacer, 0, 200_001), "DA has its own ceiling, independent of gas");
+        assert!(spend(&mut pacer, 0, 200_000), "the opening batch plus one tick");
+    }
+
+    /// DA bytes are known before execution, so settling refunds gas only —
+    /// the DA charge stands.
+    #[test]
+    fn settling_does_not_refund_da_bytes() {
+        let limits = SliceLimits {
+            block_gas_limit: BLOCK_GAS,
+            block_da_limit: Some(1_000_000),
+            da_footprint_gas_scalar: None,
+        };
+        let mut pacer = SlicePacer::new(&derive_slice_schedule(
+            SLOT,
+            Duration::from_millis(50),
+            INTERVAL,
+            SLOT,
+            limits,
+        ));
+        let reservation = pacer.reserve(1_000_000, 100_000).expect("fits");
+
+        pacer.settle(reservation, 0);
+
+        assert!(!spend(&mut pacer, 0, 1), "the DA it wrote is still written");
+        assert!(spend(&mut pacer, 3_000_000, 0), "but the gas came back");
+    }
+
+    #[test]
+    fn the_da_footprint_is_paced_in_gas_units() {
+        let limits = SliceLimits {
+            block_gas_limit: BLOCK_GAS,
+            block_da_limit: None,
+            da_footprint_gas_scalar: Some(100),
+        };
+        let s = derive_slice_schedule(SLOT, Duration::from_millis(50), INTERVAL, SLOT, limits);
+        assert_eq!(s.da_footprint_gas_per_batch, Some(3_000_000));
+
+        let mut pacer = SlicePacer::new(&s);
+
+        assert!(!spend(&mut pacer, 0, 30_001));
+        assert!(spend(&mut pacer, 0, 30_000), "30_000 bytes x 100 = 3M footprint gas");
+    }
+
+    #[test]
+    fn an_absent_da_limit_leaves_that_dimension_unpaced() {
+        let mut pacer = pacer();
+        pacer.tick();
+
+        assert!(spend(&mut pacer, 0, u64::MAX), "no DA limit configured means no DA ceiling");
+    }
+
+    #[test]
+    fn total_admission_never_exceeds_the_block_gas_limit() {
+        for deadline_ms in [0, 1, 75, 199, 200, 875, 950, 1925, 2000, 2400, 10_000] {
+            for leeway_ms in [0, 50, 75, 199, 500] {
+                let s =
+                    schedule(Duration::from_millis(deadline_ms), Duration::from_millis(leeway_ms));
+                let mut pacer = SlicePacer::new(&s);
+                let mut spent = 0u64;
+
+                for _ in 0..s.tick_count {
+                    pacer.tick();
+                    let mut step = BLOCK_GAS;
+                    while step > 0 {
+                        if spend(&mut pacer, step, 0) {
+                            spent += step;
+                        } else {
+                            step /= 2;
+                        }
+                    }
+                }
+
+                assert!(
+                    spent <= BLOCK_GAS,
+                    "deadline={deadline_ms}ms leeway={leeway_ms}ms spent {spent}"
+                );
+            }
+        }
+    }
+}

--- a/mantle-reth/crates/preconf/src/lib.rs
+++ b/mantle-reth/crates/preconf/src/lib.rs
@@ -16,6 +16,7 @@ pub mod builder;
 pub mod canon_handler;
 pub mod classifier;
 pub mod config;
+pub mod flashblocks;
 pub mod journal;
 pub mod metrics_seed;
 pub mod payload_service_builder;
@@ -33,6 +34,7 @@ pub use builder::{
 pub use canon_handler::PreconfCanonHandler;
 pub use classifier::{DEFAULT_VERDICT_CACHE_CAP, PreconfClassifier, Verdict, Whitelist};
 pub use config::{DEFAULT_SAFETY_MARGIN, PreconfConfig};
+pub use flashblocks::{FlashblockProducerConfig, FlashblockProducerConfigError};
 pub use journal::{
     CommitmentChainView, JournalEntry, JournalError, OnChain, PreconfJournal, RestorePool,
     RestoreSkip, RestoredEnvelope, RotateStats, restore_preconf_state, run_rejournal_loop,


### PR DESCRIPTION
Producer-side groundwork for flashblocks: the format slices travel in, the flags that turn them on, the budget that decides how much a slice carries, and the endpoint subscribers read them from. Nothing publishes yet — the build loop is the next phase, and every default here is off.

Four commits, each standing on its own:

| | |
|---|---|
| `e1c377a7f` | `mantle-reth-flashblocks-types` — the wire format, shared with the consumer |
| `96f74211f` | `FlashblockProducerConfig` + the `--flashblocks.*` flag group |
| `b5ee01bd2` | `SlicePacer` — per-slice gas and DA budget |
| `03832f289` | `MantleFlashblocksPublisher` — websocket endpoint, archive, catch-up |

## For the consumer side

The wire format and the subscription protocol are settled, so consumer work can start against them.

```
ws://<addr>:<port>/                                    live only
ws://<addr>:<port>/?block_number=X&flashblock_index=Y  resume after (X, Y)
```

- The resume position is **exclusive**: naming `(10,0)` skips `10-0` and delivers everything after it.
- Both parameters are required; anything malformed means "start live" rather than an error.
- The archive holds 32 slices, a little under three blocks. Past that a subscriber has to close the gap from the canonical chain — detectable from its own last position or from `prev_flashblock_id`.
- A subscriber that falls behind the channel is disconnected rather than served a stream with holes; reconnecting replays from the archive.

```rust
use mantle_reth_flashblocks_types::{
    FlashblockId, MantleFlashblockPayload, MantleFlashblockMetadata,
    FlashblockDecodeError, MAX_DECOMPRESSED_FLASHBLOCK_BYTES,
};

let slice = MantleFlashblockPayload::try_decode_message(&bytes)?;
```

`FlashblockDecodeError` mirrors Base's variant, field and constant names, so porting consumer code from there is mechanical. Two of its variants are deliberately absent — `MetadataParse` and `Utf8` exist because Base decodes metadata as a `serde_json::Value` and buffers a `String` first; decoding from the slice into typed metadata makes both unconstructible.

## Where this deviates from Base, and why

**Empty metadata maps are always written.** The upstream metadata fields carry no serde defaults, so omitting them makes upstream decoding fail outright — the opposite of the size optimisation it looks like. A test deletes the keys and asserts upstream then rejects the document.

**A rebuild drops the slices it supersedes.** Rebuilding a block restarts its indices, so an arriving position need not follow the last one archived. Base documents ascending order as a precondition of its binary search and does not maintain it, leaving lookups unspecified once a rebuild happens. Dropping superseded entries keeps the precondition, and is what we want anyway: those slices belong to an abandoned payload.

**An exhausted deadline still builds.** Base treats it as "build no flashblocks", which for it means a deposits-only block. Preconf commitments have already been acknowledged and must land, so that is not available to us. The tick this creates fires immediately rather than an interval later, or it would land after `getPayload` and the loop would run for nothing.

**Past the derived tick count, per-slice ceilings are released** rather than the payload being finalized, so the tail of a block that started early still fills.

**A subscriber ahead of the archive is reported.** In Base that case is indistinguishable from one that is simply up to date. It means a rebuild or a subscriber on the wrong producer, and neither is routine.

## Verification

`just build` clean. 424 unit tests, 62 of them in `flashblocks/`, plus the wire-compat contract in `integration-tests`. Clippy clean at `--all-features --all-targets -D warnings`.

Run against the local devnet on the release binary: blocks every 2s with no errors or panics, the preconf build loop and canonical handler behaving, and a preconf transaction returning a synchronous success receipt and then landing at the promised height. The flashblocks port is deliberately not listening — the publisher is not wired into the node until the assembly phase.

Two behaviours were checked by mutation rather than assumed: removing the second replay phase and removing its deduplication each turn tests red.

## Note on the base branch

This targets `feat/flashblocks` rather than `mantle-stage2`, and both sit on the unmerged `feat/preconf-whitelist`. Two consequences for anyone building on it: the mantle-v2 dependencies float on `mantle-elysium` rather than being pinned to `v1.6.0`, so **do not run `cargo update`** — the lock file trails the branch head by ten unreviewed commits. And `--preconf.from` / `--preconf.to` no longer exist, having moved to an on-chain whitelist contract; devnet configuration carrying them will not start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)